### PR TITLE
Remove extra $$ in blueprint

### DIFF
--- a/PrimeNumberTheoremAnd/HoffsteinLockhart.lean
+++ b/PrimeNumberTheoremAnd/HoffsteinLockhart.lean
@@ -58,7 +58,6 @@ $$
 -\frac{\zeta'}{\zeta}(\sigma+it) \ll (\log t)^2
 $$
 there.
-$$
 \end{theorem}
 \begin{proof}
 \uses{thm:Fsigma'}


### PR DESCRIPTION
Fixed blueprint: there was an extra $$ in Hoffstein-Lockhart