### PR TITLE
fix: remove unneeded lean_exe target to improve build time

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -1,1 +1,0 @@
-import «PrimeNumberTheoremAnd»

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,6 +4,7 @@ open Lake DSL
 package «PrimeNumberTheoremAnd» where
   -- add package configuration options here
 
+@[default_target]
 lean_lib «PrimeNumberTheoremAnd» where
   -- add library configuration options here
 
@@ -11,7 +12,3 @@ require mathlib from git
   "https://github.com/leanprover-community/mathlib4.git"@"e659b1b"
 
 meta if get_config? env = some "dev" then require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "29f7f43"
-
-@[default_target]
-lean_exe «primenumbertheoremand» where
-  root := `Main


### PR DESCRIPTION
Removes the `lean_exe` build target, which was making `lake build` take a long time because it was unable to use the mathlib cache. Makes `lean_lib PrimeNumberTheoremAnd` the default build target. After this change, the mathlib cache does get used and things should go much faster.

