### PR TITLE
fix: stale docs for PrimeNumberTheoremAnd.*

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -92,6 +92,7 @@ jobs:
             .lake/build/doc/Std
             .lake/build/doc/Mathlib
             .lake/build/doc/declarations
+            !.lake/build/doc/declarations/declaration-data-PrimeNumberTheoremAnd*
           key: MathlibDoc-${{ hashFiles('lake-manifest.json') }}
           restore-keys: |
             MathlibDoc-


### PR DESCRIPTION
Currently the docs don't reflect lemmas being moved from `AuxiliaryLemmata` to `MellinCalculus`. This is because `.lake/build/doc/declarations/declaration-data-PrimeNumberTheoremAnd*` are being cached.

This is the same fix as https://github.com/teorth/pfr/pull/173.