### PR TITLE
chore: vanishesOnRectangle -> integral_boundary_rect_eq_zero_of_differentiableOn

### DIFF
--- a/PrimeNumberTheoremAnd/PerronFormula.lean
+++ b/PrimeNumberTheoremAnd/PerronFormula.lean
@@ -528,7 +528,8 @@ tendsto_zero_Lower, tendsto_zero_Upper, isIntegrable}
 --%% The rectangle integral of $f$ with corners $\sigma-iT$ and $\sigma+iT$ is zero.
   have rectInt (σ' σ'' : ℝ) (σ'pos : 0 < σ') (σ''pos : 0 < σ'') (T : ℝ) :
       RectangleIntegral f (σ' - I * T) (σ'' + I * T) = 0
-  · refine fHolo.vanishesOnRectangle fun z h_rect ↦ not_or.mpr (?_ : ¬z = 0 ∧ ¬z = -1)
+  · refine integral_boundary_rect_eq_zero_of_differentiableOn f _ _
+      (fHolo.mono fun z h_rect ↦ not_or.mpr (?_ : ¬z = 0 ∧ ¬z = -1))
     simp_rw [Complex.ext_iff, ← not_or, Complex.zero_re, show (-1 : ℂ).re = -1 from rfl]
     have : σ' ≤ z.re ∨ σ'' ≤ z.re := by simpa using h_rect.1.1
     intro hc; cases hc <;> cases this <;> linarith [σ'pos, σ''pos]

--- a/PrimeNumberTheoremAnd/ResidueCalcOnRectangles.lean
+++ b/PrimeNumberTheoremAnd/ResidueCalcOnRectangles.lean
@@ -161,7 +161,8 @@ If $f$ is holomorphic on a rectangle $z$ and $w$, then the integral of $f$ over 
 %%-/
 theorem HolomorphicOn.vanishesOnRectangle {f : ℂ → ℂ} {U : Set ℂ} {z w : ℂ}
     (f_holo : HolomorphicOn f U) (hU : Rectangle z w ⊆ U) :
-    RectangleIntegral f z w = 0 := by sorry -- mathlib4\#9598
+    RectangleIntegral f z w = 0 :=
+  integral_boundary_rect_eq_zero_of_differentiableOn f z w (f_holo.mono hU)
 /-%%
 \begin{proof}\leanok
 This is in a Mathlib PR.
@@ -302,7 +303,7 @@ theorem ResidueTheoremAtOrigin_aux1b (x : ℝ)
   have : (x + I) * (x + -I) = 1 + x^2 := by
     ring_nf
     simp only [I_sq, sub_neg_eq_add]
-    rw [add_comm]                                    
+    rw [add_comm]
   rw [this]
   simp only [one_div, mul_one, one_mul, add_sub_add_left_eq_sub, sub_neg_eq_add]
   rw [← mul_assoc, mul_comm, ← mul_assoc]
@@ -455,7 +456,7 @@ theorem ResidueTheoremAtOrigin_aux2c (a b : ℝ) :
       simp only [add_re, one_re, mul_re, ofReal_re, I_re, mul_zero, ofReal_im, I_im, mul_one,
         sub_self, add_zero]
     rw [h] at this
-    simp only [zero_re, zero_ne_one] at this 
+    simp only [zero_re, zero_ne_one] at this
   exact integrable_of_continuous a b ℂ f this
 
 theorem ResidueTheoremAtOrigin_aux2c' (a b : ℝ) :


### PR DESCRIPTION
Somehow I completely missed the recommendation on Zulip the first time around.