### PR TITLE
Fix in blueprint proof: \int |fg| \le \int (\sup |f|) |g| only if |g| is integrable

### DIFF
--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -949,7 +949,8 @@ and since $1_{(0,1]}(y)\le 1$, and all the factors in the integrand are nonnegat
 $$
   \widetilde{1_\epsilon}(x)\le\int_0^\infty \frac1\epsilon\psi((x/y)^{\frac1\epsilon}) \frac{dy}y
 $$
-in which we change variables to $z=(x/y)^{\frac1\epsilon}$:
+(because in mathlib the integral of a non-integrable function is $0$, for the inequality above to be true, we must prove that $\psi((x/y)^{\frac1\epsilon})/y$ is integrable; this follows from the computation below).
+We then change variables to $z=(x/y)^{\frac1\epsilon}$:
 $$
   \widetilde{1_\epsilon}(x)\le\int_0^\infty \psi(z) \frac{dz}z
 $$


### PR DESCRIPTION
I noticed an issue with one of the proofs I wrote: I used the fact that the integrands in an integral are non-negative and bounded to bound an integral. However, because the integral of non_integrable functions is 0, this is only true under an integrability condition. I added this to the proof.