### PR TITLE
Prove integrable_x_mul_Smooth1 

### DIFF
--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -543,79 +543,43 @@ lemma MellinConvolutionSymmetric (f g : ℝ → 𝕂) {x : ℝ} (xpos: 0 < x) :
 \end{proof}
 %%-/
 open Pointwise in
-lemma support_MellinConvolution_subsets (f g : ℝ → 𝕂) (A B : Set ℝ) (hA_meas : MeasurableSet A) (hf : f.support ⊆ A) (hg : g.support ⊆ B) : (MellinConvolution f g).support ⊆ A * B := by
-  intro x
-  simp only [Function.mem_support, ne_eq, mem_Ici]
-  contrapose
-  simp only [not_le, Decidable.not_not]
-  intro hx
+lemma support_MellinConvolution_subsets {f g : ℝ → 𝕂} {A B : Set ℝ} (hf : f.support ⊆ A) (hg : g.support ⊆ B) : (MellinConvolution f g).support ⊆ A * B := by
+  rw [Function.support_subset_iff'] at hf hg ⊢
+  intro x hx
   unfold MellinConvolution
-  rw [Function.support_subset_iff'] at hf hg
-  calc
-    _ = ∫ y in A ∩ Ioi 0, f y * g (x / y) / y := by
-      refine setIntegral_eq_of_subset_of_forall_diff_eq_zero (by measurability) Set.inter_subset_right ?h't
-      simp [Set.mem_mul] at hx
-      simp only [mem_diff, mem_Ioi, div_eq_zero_iff, mul_eq_zero, map_eq_zero, and_imp]
-      intro y hy_pos hyA
-      left; left
-      apply hf _
-      simp only [mem_inter_iff, not_and_or] at hyA
-      simpa [hy_pos] using hyA
-    _ = ∫ y in A ∩ Ioi 0, 0 := by
-      apply integral_congr_ae
-      filter_upwards [ae_restrict_mem (by measurability)]
-      intro y hy
-      have div_not_mem : ¬ x / y ∈ B := by
-        intro h
-        apply hx
-        rw [Set.mem_mul]
-        refine ⟨y, mem_of_mem_inter_left hy, _, h, ?_⟩
-        have : 0 < y := by
-          rw [←mem_Ioi]
-          apply (mem_of_mem_inter_right hy)
-        field_simp
-      simp only [div_eq_zero_iff, mul_eq_zero, map_eq_zero]
-      left; right
-      apply hg _ div_not_mem
-    _ = 0 := by
-      simp
+  simp only [Set.mem_mul, not_exists, not_and] at hx
+  apply MeasureTheory.integral_eq_zero_of_ae
+  filter_upwards [ae_restrict_mem (by measurability)]
+  intro y hy
+  simp only [mem_Ioi] at hy
+  simp only [Pi.zero_apply, div_eq_zero_iff, mul_eq_zero, map_eq_zero]
+  left
+  by_cases hyA : y ∈ A
+  · right
+    apply hg
+    intro hxyB
+    apply hx _ hyA _ hxyB
+    field_simp
+  · left
+    apply hf _ hyA
 
 open Pointwise in
-lemma support_MellinConvolution (f g : ℝ → 𝕂) (a b : ℝ) (ha : 0 < a) (hb : 0 < b) (hf : f.support ⊆ Ioi 0) (hg : g.support ⊆ Ioi 0) : (MellinConvolution f g).support ⊆ f.support * g.support := by
-  apply support_M
-  sorry
+lemma support_MellinConvolution (f g : ℝ → 𝕂) : (MellinConvolution f g).support ⊆ f.support * g.support :=
+  support_MellinConvolution_subsets subset_rfl subset_rfl
+
 lemma support_MellinConvolution_Ici (f g : ℝ → 𝕂) (a b : ℝ) (ha : 0 < a) (hb : 0 < b) (hf : f.support ⊆ Set.Ici a) (hg : g.support ⊆ Set.Ici b) : (MellinConvolution f g).support ⊆ Set.Ici (a*b) := by
-  intro x
-  simp only [Function.mem_support, ne_eq, mem_Ici]
-  contrapose
-  simp only [not_le, Decidable.not_not]
-  intro hx
-  unfold MellinConvolution
-  calc
-    _ = ∫ y in Set.Ici a, f y * g (x / y) / y := by
-      refine setIntegral_eq_of_subset_of_forall_diff_eq_zero (by measurability) ?_ ?h't
-      · exact Ici_subset_Ioi.mpr ha
-      simp only [Ioi_diff_Ici, mem_Ioo, div_eq_zero_iff, mul_eq_zero, map_eq_zero, and_imp]
-      intro y hy_pos hya
-      left; left
-      simp only [Function.support_subset_iff'] at hf
-      apply hf
-      simp [hya]
-    _ = ∫ y in Set.Ici a, 0 := by
-      apply integral_congr_ae
-      filter_upwards [ae_restrict_mem (by measurability)]
-      intro y hy
-      simp only [Function.support_subset_iff'] at hg
-      simp only [div_eq_zero_iff, mul_eq_zero, map_eq_zero]
-      left; right
-      apply hg
-      simp only [mem_Ici, not_le]
-      simp only [mem_Ici] at hy
-      rw [div_lt_iff₀' (by linarith)]
-      calc x < a * b := hx
-        _ ≤ y * b := by gcongr
-    _ = 0 := by
-      simp
+  convert support_MellinConvolution_subsets hf hg
+  ext x
+  simp [Set.mem_mul]
+  constructor
+  · intro habx
+    refine ⟨a, le_rfl, x/a, ?_, ?_⟩
+    · rw [le_div_iff₀ ha, mul_comm]
+      exact habx
+    field_simp
+  · rintro ⟨r, hr, s, ⟨_, rfl⟩⟩
+    gcongr
+    linarith
 
 /-%%
 The Mellin transform of a convolution is the product of the Mellin transforms.
@@ -942,6 +906,7 @@ lemma DeltaSpikeSupport {Ψ : ℝ → ℝ} {ε x : ℝ} (εpos : 0 < ε) (xnonne
     x ∉ Icc (2 ^ (-ε)) (2 ^ ε) → DeltaSpike Ψ ε x = 0 := by
   contrapose!; exact DeltaSpikeSupport' εpos xnonneg suppΨ
 
+@[fun_prop]
 lemma DeltaSpikeContinuous {Ψ : ℝ → ℝ} {ε : ℝ} (εpos : 0 < ε) (diffΨ : ContDiff ℝ 1 Ψ) :
     Continuous (fun x ↦ DeltaSpike Ψ ε x) := by
   apply diffΨ.continuous.comp (g := Ψ) _ |>.div_const
@@ -1103,6 +1068,18 @@ $$\widetilde{1_{\epsilon}} = 1_{(0,1]}\ast\psi_\epsilon.$$
 %%-/
 noncomputable def Smooth1 (Ψ : ℝ → ℝ) (ε : ℝ) : ℝ → ℝ :=
   MellinConvolution (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) (DeltaSpike Ψ ε)
+
+lemma Smooth1_def_ite {Ψ : ℝ → ℝ} {ε x : ℝ} (xpos : 0 < x) :
+    Smooth1 Ψ ε x = MellinConvolution (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) (fun x ↦ if x < 0 then 0 else DeltaSpike Ψ ε x) x := by
+  unfold Smooth1
+  rw [MellinConvolutionSymmetric _ _ xpos]
+  conv => lhs; rw [MellinConvolutionSymmetric _ _ xpos]
+  unfold MellinConvolution
+  apply MeasureTheory.integral_congr_ae
+  filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_Ioi]
+  simp +contextual
+  intro y ypos
+  rw [eq_comm, if_neg (by push_neg; positivity)]
 
 /-%%
 \begin{lemma}[Smooth1Properties_estimate]\label{Smooth1Properties_estimate}

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -542,6 +542,80 @@ lemma MellinConvolutionSymmetric (f g : ℝ → 𝕂) {x : ℝ} (xpos: 0 < x) :
   $$
 \end{proof}
 %%-/
+open Pointwise in
+lemma support_MellinConvolution_subsets (f g : ℝ → 𝕂) (A B : Set ℝ) (hA_meas : MeasurableSet A) (hf : f.support ⊆ A) (hg : g.support ⊆ B) : (MellinConvolution f g).support ⊆ A * B := by
+  intro x
+  simp only [Function.mem_support, ne_eq, mem_Ici]
+  contrapose
+  simp only [not_le, Decidable.not_not]
+  intro hx
+  unfold MellinConvolution
+  rw [Function.support_subset_iff'] at hf hg
+  calc
+    _ = ∫ y in A ∩ Ioi 0, f y * g (x / y) / y := by
+      refine setIntegral_eq_of_subset_of_forall_diff_eq_zero (by measurability) Set.inter_subset_right ?h't
+      simp [Set.mem_mul] at hx
+      simp only [mem_diff, mem_Ioi, div_eq_zero_iff, mul_eq_zero, map_eq_zero, and_imp]
+      intro y hy_pos hyA
+      left; left
+      apply hf _
+      simp only [mem_inter_iff, not_and_or] at hyA
+      simpa [hy_pos] using hyA
+    _ = ∫ y in A ∩ Ioi 0, 0 := by
+      apply integral_congr_ae
+      filter_upwards [ae_restrict_mem (by measurability)]
+      intro y hy
+      have div_not_mem : ¬ x / y ∈ B := by
+        intro h
+        apply hx
+        rw [Set.mem_mul]
+        refine ⟨y, mem_of_mem_inter_left hy, _, h, ?_⟩
+        have : 0 < y := by
+          rw [←mem_Ioi]
+          apply (mem_of_mem_inter_right hy)
+        field_simp
+      simp only [div_eq_zero_iff, mul_eq_zero, map_eq_zero]
+      left; right
+      apply hg _ div_not_mem
+    _ = 0 := by
+      simp
+
+open Pointwise in
+lemma support_MellinConvolution (f g : ℝ → 𝕂) (a b : ℝ) (ha : 0 < a) (hb : 0 < b) (hf : f.support ⊆ Ioi 0) (hg : g.support ⊆ Ioi 0) : (MellinConvolution f g).support ⊆ f.support * g.support := by
+  apply support_M
+  sorry
+lemma support_MellinConvolution_Ici (f g : ℝ → 𝕂) (a b : ℝ) (ha : 0 < a) (hb : 0 < b) (hf : f.support ⊆ Set.Ici a) (hg : g.support ⊆ Set.Ici b) : (MellinConvolution f g).support ⊆ Set.Ici (a*b) := by
+  intro x
+  simp only [Function.mem_support, ne_eq, mem_Ici]
+  contrapose
+  simp only [not_le, Decidable.not_not]
+  intro hx
+  unfold MellinConvolution
+  calc
+    _ = ∫ y in Set.Ici a, f y * g (x / y) / y := by
+      refine setIntegral_eq_of_subset_of_forall_diff_eq_zero (by measurability) ?_ ?h't
+      · exact Ici_subset_Ioi.mpr ha
+      simp only [Ioi_diff_Ici, mem_Ioo, div_eq_zero_iff, mul_eq_zero, map_eq_zero, and_imp]
+      intro y hy_pos hya
+      left; left
+      simp only [Function.support_subset_iff'] at hf
+      apply hf
+      simp [hya]
+    _ = ∫ y in Set.Ici a, 0 := by
+      apply integral_congr_ae
+      filter_upwards [ae_restrict_mem (by measurability)]
+      intro y hy
+      simp only [Function.support_subset_iff'] at hg
+      simp only [div_eq_zero_iff, mul_eq_zero, map_eq_zero]
+      left; right
+      apply hg
+      simp only [mem_Ici, not_le]
+      simp only [mem_Ici] at hy
+      rw [div_lt_iff₀' (by linarith)]
+      calc x < a * b := hx
+        _ ≤ y * b := by gcongr
+    _ = 0 := by
+      simp
 
 /-%%
 The Mellin transform of a convolution is the product of the Mellin transforms.

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -567,20 +567,6 @@ open Pointwise in
 lemma support_MellinConvolution (f g : ℝ → 𝕂) : (MellinConvolution f g).support ⊆ f.support * g.support :=
   support_MellinConvolution_subsets subset_rfl subset_rfl
 
-lemma support_MellinConvolution_Ici (f g : ℝ → 𝕂) (a b : ℝ) (ha : 0 < a) (hb : 0 < b) (hf : f.support ⊆ Set.Ici a) (hg : g.support ⊆ Set.Ici b) : (MellinConvolution f g).support ⊆ Set.Ici (a*b) := by
-  convert support_MellinConvolution_subsets hf hg
-  ext x
-  simp [Set.mem_mul]
-  constructor
-  · intro habx
-    refine ⟨a, le_rfl, x/a, ?_, ?_⟩
-    · rw [le_div_iff₀ ha, mul_comm]
-      exact habx
-    field_simp
-  · rintro ⟨r, hr, s, ⟨_, rfl⟩⟩
-    gcongr
-    linarith
-
 /-%%
 The Mellin transform of a convolution is the product of the Mellin transforms.
 \begin{theorem}[MellinConvolutionTransform]\label{MellinConvolutionTransform}

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1069,6 +1069,7 @@ $$\widetilde{1_{\epsilon}} = 1_{(0,1]}\ast\psi_\epsilon.$$
 noncomputable def Smooth1 (Ψ : ℝ → ℝ) (ε : ℝ) : ℝ → ℝ :=
   MellinConvolution (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) (DeltaSpike Ψ ε)
 
+-- This lemma might not be necessary, but the RHS is supported on [0, ∞), which makes results like `support_MellinConvolution_subsets` easier to apply.
 lemma Smooth1_def_ite {Ψ : ℝ → ℝ} {ε x : ℝ} (xpos : 0 < x) :
     Smooth1 Ψ ε x = MellinConvolution (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) (fun x ↦ if x < 0 then 0 else DeltaSpike Ψ ε x) x := by
   unfold Smooth1


### PR DESCRIPTION
Proving measurability was much more painful than expected. I hope that can be golfed down quite a bit. Then again, maybe the right thing to do here is to prove the relevant smoothness properties of the mellin convolution.

I also proved a lemma `support_MellinConvolution_subsets ` that says if $f, g$ are supported on $A, B$ respectively then their mellin convolution is supported on $A*B$. Annoyingly this wasn't actually useful here, since `DeltaSpike` is not generally supported on $[0, \infty)$. Still, I think this is useful API to have.