### PR TITLE
Move limit out of consequences.lean

### DIFF
--- a/PrimeNumberTheoremAnd/Consequences.lean
+++ b/PrimeNumberTheoremAnd/Consequences.lean
@@ -1,4 +1,5 @@
 import PrimeNumberTheoremAnd.Wiener
+import PrimeNumberTheoremAnd.Mathlib.Analysis.SpecialFunctions.Log.Basic
 import PrimeNumberTheoremAnd.Mathlib.NumberTheory.ArithmeticFunction
 import Mathlib.Analysis.Asymptotics.Asymptotics
 import Mathlib.NumberTheory.AbelSummation
@@ -452,41 +453,6 @@ theorem Asymptotics.IsEquivalent.add_isLittleO'' {α : Type*} {β : Type*} [Norm
 Asymptotics.IsEquivalent l w v := by
   rw [<- sub_sub_self u w]
   exact sub_isLittleO huv hwu
-
-/-- log^b x / x^a goes to zero at infinity if a is positive. -/
-theorem Real.tendsto_pow_log_div_pow_atTop (a : ℝ) (b : ℝ) (ha : a > 0) :
-Filter.Tendsto (fun x ↦ log x ^ b / x^a) Filter.atTop (nhds 0) := by
-  convert squeeze_zero' (f := fun x ↦ log x ^ b / x^a) (g := fun x ↦ (log x ^ ⌈ b/a ⌉₊ / x)^a ) (t₀ := atTop) ?_ ?_ ?_
-  . simp
-    use 1
-    intro x hx
-    apply div_nonneg
-    . apply rpow_nonneg
-      exact log_nonneg hx
-    apply rpow_nonneg
-    apply zero_le_one.trans hx
-  . simp
-    use exp 1
-    intro x hx
-    have h0 : 0 < x := by
-      apply lt_of_lt_of_le _ hx
-      exact exp_pos 1
-    have h1 : 1 ≤ log x := by
-      rwa [le_log_iff_exp_le h0]
-    rw [div_rpow _ (le_of_lt h0)]
-    . rw [div_le_div_iff_of_pos_right (rpow_pos_of_pos h0 _), <-rpow_natCast, <-rpow_mul (zero_le_one.trans h1)]
-      apply rpow_le_rpow_of_exponent_le h1
-      rw [<-div_le_iff₀ ha]
-      exact le_ceil _
-    apply pow_nonneg
-    apply zero_le_one.trans h1
-  rw [(zero_rpow (_root_.ne_of_lt ha).symm).symm]
-  apply Tendsto.rpow_const
-  . have := tendsto_pow_log_div_mul_add_atTop 1 0 ⌈b/a⌉₊ zero_ne_one.symm
-    simp at this
-    exact this
-  right
-  exact le_of_lt ha
 
 theorem WeakPNT' : Tendsto (fun N ↦ (∑ n in Iic N, Λ n) / N) atTop (nhds 1) := by
   have : (fun N ↦ (∑ n in Iic N, Λ n) / N) = (fun N ↦ (∑ n in range N, Λ n)/N + Λ N / N) := by

--- a/PrimeNumberTheoremAnd/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -5,23 +5,20 @@ import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
 open Filter Real
 
 /-- log^b x / x^a goes to zero at infinity if a is positive. -/
-theorem Real.tendsto_pow_log_div_pow_atTop (a : ℝ) (b : ℝ) (ha : a > 0) :
+theorem Real.tendsto_pow_log_div_pow_atTop (a : ℝ) (b : ℝ) (ha : 0 < a) :
 Filter.Tendsto (fun x ↦ log x ^ b / x^a) Filter.atTop (nhds 0) := by
   convert squeeze_zero' (f := fun x ↦ log x ^ b / x^a) (g := fun x ↦ (log x ^ ⌈ b/a ⌉₊ / x)^a ) (t₀ := atTop) ?_ ?_ ?_
   . simp
     use 1
     intro x hx
-    apply div_nonneg
-    . apply rpow_nonneg
-      exact log_nonneg hx
-    apply rpow_nonneg
-    apply zero_le_one.trans hx
+    apply div_nonneg <;> apply Real.rpow_nonneg
+    . exact log_nonneg hx
+    linarith
   . simp
     use exp 1
     intro x hx
     have h0 : 0 < x := by
-      apply lt_of_lt_of_le _ hx
-      exact exp_pos 1
+      apply lt_of_lt_of_le (exp_pos 1) hx
     have h1 : 1 ≤ log x := by
       rwa [le_log_iff_exp_le h0]
     rw [div_rpow _ (le_of_lt h0)]
@@ -29,8 +26,7 @@ Filter.Tendsto (fun x ↦ log x ^ b / x^a) Filter.atTop (nhds 0) := by
       apply rpow_le_rpow_of_exponent_le h1
       rw [<-div_le_iff₀ ha]
       exact Nat.le_ceil _
-    apply pow_nonneg
-    apply zero_le_one.trans h1
+    apply pow_nonneg (by linarith)
   rw [(zero_rpow (_root_.ne_of_lt ha).symm).symm]
   apply Tendsto.rpow_const
   . have := tendsto_pow_log_div_mul_add_atTop 1 0 ⌈b/a⌉₊ zero_ne_one.symm

--- a/PrimeNumberTheoremAnd/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/Analysis/SpecialFunctions/Log/Basic.lean
@@ -1,0 +1,40 @@
+import Mathlib.Algebra.Order.Floor
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Continuity
+
+open Filter Real
+
+/-- log^b x / x^a goes to zero at infinity if a is positive. -/
+theorem Real.tendsto_pow_log_div_pow_atTop (a : ℝ) (b : ℝ) (ha : a > 0) :
+Filter.Tendsto (fun x ↦ log x ^ b / x^a) Filter.atTop (nhds 0) := by
+  convert squeeze_zero' (f := fun x ↦ log x ^ b / x^a) (g := fun x ↦ (log x ^ ⌈ b/a ⌉₊ / x)^a ) (t₀ := atTop) ?_ ?_ ?_
+  . simp
+    use 1
+    intro x hx
+    apply div_nonneg
+    . apply rpow_nonneg
+      exact log_nonneg hx
+    apply rpow_nonneg
+    apply zero_le_one.trans hx
+  . simp
+    use exp 1
+    intro x hx
+    have h0 : 0 < x := by
+      apply lt_of_lt_of_le _ hx
+      exact exp_pos 1
+    have h1 : 1 ≤ log x := by
+      rwa [le_log_iff_exp_le h0]
+    rw [div_rpow _ (le_of_lt h0)]
+    . rw [div_le_div_iff_of_pos_right (rpow_pos_of_pos h0 _), <-rpow_natCast, <-rpow_mul (zero_le_one.trans h1)]
+      apply rpow_le_rpow_of_exponent_le h1
+      rw [<-div_le_iff₀ ha]
+      exact Nat.le_ceil _
+    apply pow_nonneg
+    apply zero_le_one.trans h1
+  rw [(zero_rpow (_root_.ne_of_lt ha).symm).symm]
+  apply Tendsto.rpow_const
+  . have := tendsto_pow_log_div_mul_add_atTop 1 0 ⌈b/a⌉₊ zero_ne_one.symm
+    simp at this
+    exact this
+  right
+  exact le_of_lt ha


### PR DESCRIPTION
Moves Real.tendsto_pow_log_div_pow_atTop out of Consequences.lean into a file under the Mathlib directory.  The main reason is that I need this limit for estimating the derivative in ZetaBounds.lean.  It also seems like a good candidate for an easy PR to Mathlib.  I chose the location to match that of tendsto_pow_log_div_mul_add_atTop, which this theorem depends on.