### PR TITLE
change name of blueprint-cache (seems to be a bug?)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -46,10 +46,11 @@ jobs:
           mkdir -p docs
           mv blueprint/web docs/
 
+      ## something seems to be going wrong with 'Blueprint-cache' (it looks like a github bug) - use Blueprint-cache2 instead
       - name: Clear previously saved cache
         uses: DareFox/delete-cache-by-key@v1.0.1
         with:
-          key: Blueprint-cache
+          key: Blueprint-cache2
           mode: exact
         continue-on-error: true
 
@@ -58,7 +59,7 @@ jobs:
         with:
           path: |
             docs/web
-          key: Blueprint-cache
+          key: Blueprint-cache2
 
 
       - name: Restore previous documentation, while we wait for the next one to be generated
@@ -149,7 +150,7 @@ jobs:
         with:
           path: |
             docs/web
-          key: Blueprint-cache
+          key: Blueprint-cache2
         continue-on-error: true
 
       ## cannot use upload-pages-artifact@v3 twice (it is used for the blueprint above)


### PR DESCRIPTION
I am not sure this will fix our problem. It runs fine on my fork (but the actions ran fine there before this fix as well). It seems to me that there is a bug with our github repo, that the cache named 'Blueprint-cache' seems to exist, but not be accessible neither does it seem to be possible to delete it. So I changed the name of the cache, and hope for the best!