### PR TITLE
Smooth1 properties

### DIFF
--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -107,9 +107,28 @@ lemma SmoothedChebyshevDirichlet_aux_contAt {SmoothingF : ℝ → ℝ}
   apply ContinuousAt.congr (f := (fun x ↦ MellinConvolution (DeltaSpike SmoothingF ε) (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) x)) _
   · filter_upwards [lt_mem_nhds ypos] with x hx
     apply MellinConvolutionSymmetric _ _ hx
-  apply continuousAt_of_dominated (bound := (fun x ↦ DeltaSpike SmoothingF ε x))
+  apply continuousAt_of_dominated (bound := (fun x ↦ 2 ^ ε * DeltaSpike SmoothingF ε x))
   · sorry
-  · sorry
+  · filter_upwards [lt_mem_nhds ypos] with x hx
+    filter_upwards [ae_restrict_mem (by measurability)] with t ht
+    simp
+    by_cases h : DeltaSpike SmoothingF ε t = 0
+    · simp [h]
+    push_neg at h
+    have := DeltaSpikeSupport' εpos ht.le suppSmoothingF h
+    have dsnonneg : 0 ≤ DeltaSpike SmoothingF ε t := by apply DeltaSpikeNonNeg_of_NonNeg <;> assumption
+    calc
+      _ ≤ |DeltaSpike SmoothingF ε t| / |t| := by
+        gcongr
+        · split_ifs with h
+          · apply le_refl
+          · exact dsnonneg
+      _ ≤ _ := by
+        rw [_root_.abs_of_nonneg dsnonneg, mul_comm, div_eq_mul_one_div, _root_.abs_of_pos ht]
+        gcongr
+        apply (one_div_le ht (by bound)).mpr
+        · convert this.1 using 1; field_simp
+          rw [← rpow_add (by norm_num), neg_add_cancel, rpow_zero]
   · sorry
   · sorry
 

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -61,63 +61,6 @@ noncomputable def SmoothedChebyshev (SmoothingF : ℝ → ℝ) (ε : ℝ) (X : �
 
 open MeasureTheory
 
-/-%%
-\begin{lemma}[integrable_x_mul_Smooth1]\label{integrable_x_mul_Smooth1}\lean{integrable_x_mul_Smooth1}\leanok
-Fix a nonnegative, continuously differentiable function $F$ on $\mathbb{R}$
-with support in $[1/2,2]$, and total mass one, $\int_{(0,\infty)} F(x)/x dx = 1$. Then for any $\epsilon>0$, the function
-$x \mapsto x \cdot \widetilde{1_{\epsilon}}(x)$ is integrable on $(0,\infty)$.
-\end{lemma}
-%%-/
-open MeasureTheory
-lemma integrable_x_mul_Smooth1 {SmoothingF : ℝ → ℝ} (diffSmoothingF : ContDiff ℝ 1 SmoothingF) (SmoothingFpos : ∀ x > 0, 0 ≤ SmoothingF x)
-    (suppSmoothingF : support SmoothingF ⊆ Icc (1 / 2) 2) (mass_one : ∫ (x : ℝ) in Ioi 0, SmoothingF x / x = 1)
-    (ε : ℝ) (εpos : 0 < ε) (ε_lt_one : ε < 1) :
-    MeasureTheory.IntegrableOn (fun x ↦ x * Smooth1 SmoothingF ε x) (Ioi 0) := by
-  obtain ⟨c, c_pos, hc⟩ := Smooth1Properties_above suppSmoothingF
-  rw [← MeasureTheory.integrable_indicator_iff (by measurability)]
-  apply MeasureTheory.Integrable.mono' (g := Ioc 0 (1 + c * ε) |>.indicator fun x ↦ x)
-  · refine IntegrableOn.integrable_indicator ?hg.h ?hg.hs
-    · apply Continuous.integrableOn_Ioc
-      fun_prop
-    exact measurableSet_Ioc
-  · refine (aestronglyMeasurable_indicator_iff (by measurability)).mpr ?_
-    apply MeasureTheory.AEStronglyMeasurable.mul
-    · exact Measurable.aestronglyMeasurable fun ⦃t⦄ a ↦ a
-    · apply MeasureTheory.AEStronglyMeasurable.mono_measure («μ» := volume)
-      · apply Smooth1_AEStronglyMeasurable diffSmoothingF ε εpos
-      exact Measure.restrict_le_self
-  · filter_upwards []
-    intro x
-    simp
-    rw [_root_.abs_of_nonneg]
-    · simp_rw [indicator_apply, mem_Ioi, mem_Ioc]
-      by_cases hx : x ≤ 0
-      · rw [if_neg (hx.not_lt), if_neg (fun h => h.1.not_le hx)]
-      push_neg at hx
-      rw [if_pos hx, ite_and, if_pos hx]
-      split_ifs with hx'
-      · apply mul_le_of_le_one_right hx.le
-        apply Smooth1LeOne SmoothingFpos mass_one εpos hx
-      push_neg at hx'
-      apply le_of_eq
-      simp only [mul_eq_zero]
-      right
-      exact hc _ _ ⟨εpos, ε_lt_one⟩ hx'.le
-    · apply Set.indicator_nonneg
-      simp only [mem_Ioi]
-      intro x hx
-      have := Smooth1Nonneg SmoothingFpos hx εpos
-      positivity
-
-/-%%
-\begin{proof}\leanok
-\uses{Smooth1Properties_above}
-We have
-from Lemma \ref{Smooth1Properties_above}
- that $\widetilde{1_{\epsilon}}(x) = 0$ for all $x \leq 1+c\epsilon$.
- So the claimed function is integrable on $(0,\infty)$.
-\end{proof}
-%%-/
 
 /-%%
 \begin{lemma}[SmoothedChebyshevDirichlet_aux_integrable]\label{SmoothedChebyshevDirichlet_aux_integrable}\lean{SmoothedChebyshevDirichlet_aux_integrable}\leanok
@@ -273,8 +216,8 @@ theorem SmoothedChebyshevDirichlet {SmoothingF : ℝ → ℝ}
     · beta_reduce at this
       dsimp [MellinInverseTransform, VerticalIntegral] at this
       rw [← MellinTransform_eq, this]
-    · dsimp [MellinConvergent]
-      norm_num; exact_mod_cast (integrable_x_mul_Smooth1 diffSmoothingF SmoothingFpos suppSmoothingF mass_one ε εpos ε_lt_one).ofReal
+    · apply Smooth1MellinConvergent diffSmoothingF suppSmoothingF ⟨εpos, ε_lt_one⟩ SmoothingFpos mass_one
+      simp
     · dsimp [VerticalIntegrable, mellin]
       ring_nf
       apply SmoothedChebyshevDirichlet_aux_integrable diffSmoothingF SmoothingFpos

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -61,27 +61,6 @@ noncomputable def SmoothedChebyshev (SmoothingF : ℝ → ℝ) (ε : ℝ) (X : �
 
 open MeasureTheory
 
-@[fun_prop, measurability]
-lemma Smooth1_AEStronglyMeasurable {SmoothingF : ℝ → ℝ} (diffSmoothingF : ContDiff ℝ 1 SmoothingF) (ε : ℝ) (εpos : 0 < ε) : MeasureTheory.AEStronglyMeasurable (Smooth1 SmoothingF ε) := by
-  unfold Smooth1
-  unfold MellinConvolution
-  convert MeasureTheory.AEStronglyMeasurable.integral_prod_right' (f := uncurry fun x y => (if 0 < y ∧ y ≤ 1 then DeltaSpike SmoothingF ε (x / y) else 0) / y) ?_ with x _ y
-  · unfold uncurry
-    simp only [ite_mul, one_mul, zero_mul, RCLike.ofReal_real_eq_id, id_eq]
-  · exact instSFiniteRestrict (Ioi 0)
-  · refine aestronglyMeasurable_iff_aemeasurable.mpr ?convert_4.a
-    refine Measurable.aemeasurable ?convert_4.a.h
-    apply MeasureTheory.measurable_uncurry_of_continuous_of_measurable
-    · intro x
-      split_ifs with h <;> fun_prop (disch := assumption)
-    intro x
-    convert_to Measurable <| (Ioc 0 1).indicator (fun y ↦ DeltaSpike SmoothingF ε (x/y) / y)
-    · ext x
-      simp [Set.indicator_apply, apply_ite (· / x)]
-    refine Measurable.indicator ?convert_4.a.h.h.hf ?convert_4.a.h.h.hs
-    · fun_prop (disch := assumption)
-    · measurability
-
 /-%%
 \begin{lemma}[integrable_x_mul_Smooth1]\label{integrable_x_mul_Smooth1}\lean{integrable_x_mul_Smooth1}\leanok
 Fix a nonnegative, continuously differentiable function $F$ on $\mathbb{R}$

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -129,7 +129,25 @@ lemma SmoothedChebyshevDirichlet_aux_contAt {SmoothingF : ℝ → ℝ}
         apply (one_div_le ht (by bound)).mpr
         · convert this.1 using 1; field_simp
           rw [← rpow_add (by norm_num), neg_add_cancel, rpow_zero]
-  · sorry
+  · apply Integrable.const_mul
+    apply (integrable_indicator_iff (by measurability)).mp
+    apply (integrableOn_iff_integrable_of_support_subset (s := Icc (2 ^ (-ε)) (2 ^ ε)) _).mp
+    · apply ContinuousOn.integrableOn_compact isCompact_Icc
+      apply ContinuousOn.congr  (f := DeltaSpike SmoothingF ε)
+      · apply Continuous.continuousOn
+        apply DeltaSpikeContinuous<;> assumption
+      · intro x hx
+        have : x ∈ Ioi 0 := by
+          apply mem_Ioi.mpr
+          apply lt_of_lt_of_le (by bound) hx.1
+        rw [indicator, if_pos this]
+    · unfold indicator
+      simp_rw [mem_Ioi]
+      apply support_subset_iff.mpr
+      intro x
+      simp
+      intro hx
+      apply DeltaSpikeSupport' εpos hx.le suppSmoothingF
   · sorry
 
 /-%%

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -148,7 +148,29 @@ lemma SmoothedChebyshevDirichlet_aux_contAt {SmoothingF : ℝ → ℝ}
       simp
       intro hx
       apply DeltaSpikeSupport' εpos hx.le suppSmoothingF
-  · sorry
+  · have : ∀ᵐ (a : ℝ) ∂volume.restrict (Ioi 0), a ≠ y := by
+      apply ae_iff.mpr
+      simp
+    filter_upwards [ae_restrict_mem (by measurability), this] with x hx hx2
+    simp at hx
+    apply ContinuousAt.div_const
+    apply ContinuousAt.mul (by fun_prop)
+    have : (fun x_1 ↦ if 0 < x_1 / x ∧ x_1 / x ≤ 1 then 1 else 0) = (Ioc 0 x).indicator (fun _ ↦ (1 : ℝ)) := by
+      ext t
+      unfold indicator
+      congr 1
+      simp
+      apply and_congr
+      · exact div_pos_iff_of_pos_right hx
+      · exact div_le_one₀ hx
+    rw [this]
+    apply ContinuousOn.continuousAt_indicator (by fun_prop)
+    rw [frontier_Ioc hx]
+    simp
+    constructor <;> push_neg
+    · exact ypos.ne.symm
+    · exact hx2.symm
+
 
 /-%%
 \begin{proof}

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -199,7 +199,7 @@ theorem SmoothedChebyshevDirichlet {SmoothingF : ℝ → ℝ}
         suppSmoothingF mass_one ε εpos
     · refine ContinuousAt.comp (g := ofReal) RCLike.continuous_ofReal.continuousAt ?_
       exact Smooth1ContinuousAt diffSmoothingF SmoothingFpos suppSmoothingF
-        mass_one εpos (by positivity)
+        εpos (by positivity)
 /-%%
 \begin{proof}\leanok
 \uses{SmoothedChebyshev, MellinInversion, LogDerivativeDirichlet, Smooth1LeOne, MellinOfSmooth1b,

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -108,7 +108,24 @@ lemma SmoothedChebyshevDirichlet_aux_contAt {SmoothingF : ℝ → ℝ}
   · filter_upwards [lt_mem_nhds ypos] with x hx
     apply MellinConvolutionSymmetric _ _ hx
   apply continuousAt_of_dominated (bound := (fun x ↦ 2 ^ ε * DeltaSpike SmoothingF ε x))
-  · sorry
+  · filter_upwards [lt_mem_nhds ypos] with x hx
+    apply Measurable.aestronglyMeasurable
+    apply Measurable.mul
+    · apply Measurable.mul
+      · exact Continuous.measurable <| DeltaSpikeContinuous εpos diffSmoothingF
+      · apply Measurable.ite _ (by fun_prop) (by fun_prop)
+        apply MeasurableSet.congr (s := Ici x) (by measurability)
+        ext a
+        constructor
+        · intro ha
+          have apos : 0 < a := lt_of_lt_of_le hx ha
+          constructor
+          · exact div_pos hx apos
+          · exact (div_le_one apos).mpr ha
+        · intro ha
+          have : 0 < a := (div_pos_iff_of_pos_left hx).mp ha.1
+          exact (div_le_one this).mp ha.2
+    · fun_prop
   · filter_upwards [lt_mem_nhds ypos] with x hx
     filter_upwards [ae_restrict_mem (by measurability)] with t ht
     simp

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -102,10 +102,17 @@ lemma SmoothedChebyshevDirichlet_aux_contAt {SmoothingF : ℝ → ℝ}
     (mass_one : ∫ (x : ℝ) in Ioi 0, SmoothingF x / x = 1)
     {ε : ℝ} (εpos : 0 < ε) {y : ℝ} (ypos : 0 < y) :
     ContinuousAt (fun x ↦ Smooth1 SmoothingF ε x) y := by
-  apply Continuous.continuousAt
-  unfold Smooth1 DeltaSpike MellinConvolution
-  simp only [one_div, ite_mul, one_mul, zero_mul, RCLike.ofReal_real_eq_id, id_eq]
-  sorry
+--  apply Continuous.continuousAt
+  unfold Smooth1
+  apply ContinuousAt.congr (f := (fun x ↦ MellinConvolution (DeltaSpike SmoothingF ε) (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) x)) _
+  · filter_upwards [lt_mem_nhds ypos] with x hx
+    apply MellinConvolutionSymmetric _ _ hx
+  apply continuousAt_of_dominated (bound := (fun x ↦ DeltaSpike SmoothingF ε x))
+  · sorry
+  · sorry
+  · sorry
+  · sorry
+
 /-%%
 \begin{proof}
 \uses{Smooth1Properties_above}

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -89,114 +89,6 @@ By Lemma \ref{MellinOfSmooth1b} the integrand is $O(1/t^2)$ as $t\rightarrow \in
 %%-/
 
 /-%%
-\begin{lemma}[SmoothedChebyshevDirichlet_aux_contAt]\label{SmoothedChebyshevDirichlet_aux_contAt}\lean{SmoothedChebyshevDirichlet_aux_contAt}\leanok
-Fix a nonnegative, continuously differentiable function $F$ on $\mathbb{R}$ with support in $[1/2,2]$, and total mass one, $\int_{(0,\infty)} F(x)/x dx = 1$. Then for any $\epsilon>0$, the function
-$x \mapsto \int_{(0,\infty)} x^{1+it} \widetilde{1_{\epsilon}}(x) dx$ is continuous at any $y>0$.
-** Conditions are overkill; can remove some assumptions... **
-\end{lemma}
-%%-/
-lemma SmoothedChebyshevDirichlet_aux_contAt {SmoothingF : ℝ → ℝ}
-    (diffSmoothingF : ContDiff ℝ 1 SmoothingF)
-    (SmoothingFpos : ∀ x > 0, 0 ≤ SmoothingF x)
-    (suppSmoothingF : support SmoothingF ⊆ Icc (1 / 2) 2)
-    (mass_one : ∫ (x : ℝ) in Ioi 0, SmoothingF x / x = 1)
-    {ε : ℝ} (εpos : 0 < ε) {y : ℝ} (ypos : 0 < y) :
-    ContinuousAt (fun x ↦ Smooth1 SmoothingF ε x) y := by
---  apply Continuous.continuousAt
-  unfold Smooth1
-  apply ContinuousAt.congr (f := (fun x ↦ MellinConvolution (DeltaSpike SmoothingF ε) (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) x)) _
-  · filter_upwards [lt_mem_nhds ypos] with x hx
-    apply MellinConvolutionSymmetric _ _ hx
-  apply continuousAt_of_dominated (bound := (fun x ↦ 2 ^ ε * DeltaSpike SmoothingF ε x))
-  · filter_upwards [lt_mem_nhds ypos] with x hx
-    apply Measurable.aestronglyMeasurable
-    apply Measurable.mul
-    · apply Measurable.mul
-      · exact Continuous.measurable <| DeltaSpikeContinuous εpos diffSmoothingF
-      · apply Measurable.ite _ (by fun_prop) (by fun_prop)
-        apply MeasurableSet.congr (s := Ici x) (by measurability)
-        ext a
-        constructor
-        · intro ha
-          have apos : 0 < a := lt_of_lt_of_le hx ha
-          constructor
-          · exact div_pos hx apos
-          · exact (div_le_one apos).mpr ha
-        · intro ha
-          have : 0 < a := (div_pos_iff_of_pos_left hx).mp ha.1
-          exact (div_le_one this).mp ha.2
-    · fun_prop
-  · filter_upwards [lt_mem_nhds ypos] with x hx
-    filter_upwards [ae_restrict_mem (by measurability)] with t ht
-    simp
-    by_cases h : DeltaSpike SmoothingF ε t = 0
-    · simp [h]
-    push_neg at h
-    have := DeltaSpikeSupport' εpos ht.le suppSmoothingF h
-    have dsnonneg : 0 ≤ DeltaSpike SmoothingF ε t := by apply DeltaSpikeNonNeg_of_NonNeg <;> assumption
-    calc
-      _ ≤ |DeltaSpike SmoothingF ε t| / |t| := by
-        gcongr
-        · split_ifs with h
-          · apply le_refl
-          · exact dsnonneg
-      _ ≤ _ := by
-        rw [_root_.abs_of_nonneg dsnonneg, mul_comm, div_eq_mul_one_div, _root_.abs_of_pos ht]
-        gcongr
-        apply (one_div_le ht (by bound)).mpr
-        · convert this.1 using 1; field_simp
-          rw [← rpow_add (by norm_num), neg_add_cancel, rpow_zero]
-  · apply Integrable.const_mul
-    apply (integrable_indicator_iff (by measurability)).mp
-    apply (integrableOn_iff_integrable_of_support_subset (s := Icc (2 ^ (-ε)) (2 ^ ε)) _).mp
-    · apply ContinuousOn.integrableOn_compact isCompact_Icc
-      apply ContinuousOn.congr  (f := DeltaSpike SmoothingF ε)
-      · apply Continuous.continuousOn
-        apply DeltaSpikeContinuous<;> assumption
-      · intro x hx
-        have : x ∈ Ioi 0 := by
-          apply mem_Ioi.mpr
-          apply lt_of_lt_of_le (by bound) hx.1
-        rw [indicator, if_pos this]
-    · unfold indicator
-      simp_rw [mem_Ioi]
-      apply support_subset_iff.mpr
-      intro x
-      simp
-      intro hx
-      apply DeltaSpikeSupport' εpos hx.le suppSmoothingF
-  · have : ∀ᵐ (a : ℝ) ∂volume.restrict (Ioi 0), a ≠ y := by
-      apply ae_iff.mpr
-      simp
-    filter_upwards [ae_restrict_mem (by measurability), this] with x hx hx2
-    simp at hx
-    apply ContinuousAt.div_const
-    apply ContinuousAt.mul (by fun_prop)
-    have : (fun x_1 ↦ if 0 < x_1 / x ∧ x_1 / x ≤ 1 then 1 else 0) = (Ioc 0 x).indicator (fun _ ↦ (1 : ℝ)) := by
-      ext t
-      unfold indicator
-      congr 1
-      simp
-      apply and_congr
-      · exact div_pos_iff_of_pos_right hx
-      · exact div_le_one₀ hx
-    rw [this]
-    apply ContinuousOn.continuousAt_indicator (by fun_prop)
-    rw [frontier_Ioc hx]
-    simp
-    constructor <;> push_neg
-    · exact ypos.ne.symm
-    · exact hx2.symm
-
-
-/-%%
-\begin{proof}
-\uses{Smooth1Properties_above}
-The function is a sum of continuous functions, and hence continuous.
-\end{proof}
-%%-/
-
-/-%%
 \begin{lemma}[SmoothedChebyshevDirichlet_aux_tsum_integral]\label{SmoothedChebyshevDirichlet_aux_tsum_integral}\lean{SmoothedChebyshevDirichlet_aux_tsum_integral}\leanok
 Fix a nonnegative, continuously differentiable function $F$ on $\mathbb{R}$ with support in $[1/2,2]$, and total mass one, $\int_{(0,\infty)} F(x)/x dx = 1$. Then for any $\epsilon>0$, the function
 $x \mapsto \sum_{n=1}^\infty \frac{\Lambda(n)}{n^{2+it}} \mathcal{M}(\widetilde{1_{\epsilon}})(2+it) x^{2+it}$ is equal to
@@ -306,13 +198,13 @@ theorem SmoothedChebyshevDirichlet {SmoothingF : ℝ → ℝ}
       apply SmoothedChebyshevDirichlet_aux_integrable diffSmoothingF SmoothingFpos
         suppSmoothingF mass_one ε εpos
     · refine ContinuousAt.comp (g := ofReal) RCLike.continuous_ofReal.continuousAt ?_
-      exact SmoothedChebyshevDirichlet_aux_contAt diffSmoothingF SmoothingFpos suppSmoothingF
+      exact Smooth1ContinuousAt diffSmoothingF SmoothingFpos suppSmoothingF
         mass_one εpos (by positivity)
 /-%%
 \begin{proof}\leanok
 \uses{SmoothedChebyshev, MellinInversion, LogDerivativeDirichlet, Smooth1LeOne, MellinOfSmooth1b,
 SmoothedChebyshevDirichlet_aux_integrable,
-SmoothedChebyshevDirichlet_aux_contAt, SmoothedChebyshevDirichlet_aux_tsum_integral}
+Smooth1ContinuousAt, SmoothedChebyshevDirichlet_aux_tsum_integral}
 We have that
 $$\psi_{\epsilon}(X) = \frac{1}{2\pi i}\int_{(2)}\sum_{n=1}^\infty \frac{\Lambda(n)}{n^s}
 \mathcal{M}(\widetilde{1_{\epsilon}})(s)

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1759,3 +1759,27 @@ lemma Smooth1Integrable {Ψ : ℝ → ℝ} {ε : ℝ} (suppΨ : Ψ.support ⊆ I
   push_neg at hx'
   rw [hc _ _ hε hx'.le]
   simp
+
+
+lemma Smooth1MellinConvergent {Ψ : ℝ → ℝ} {ε : ℝ} (suppΨ : Ψ.support ⊆ Icc (1 / 2) 2)
+    (hε : ε ∈ Ioo 0 1) (Ψnonneg : ∀ x > 0, 0 ≤ Ψ x)
+    (mass_one : ∫ x in Ioi 0, Ψ x / x = 1)
+    {s : ℂ} (hs: 0 < s.re) :
+    MellinConvergent (fun x ↦ (Smooth1 Ψ ε x : ℂ)) s := by
+  apply mellinConvergent_of_isBigO_rpow_exp zero_lt_one _ _ _ hs
+  · apply IntegrableOn.locallyIntegrableOn
+    exact Smooth1Integrable suppΨ hε Ψnonneg mass_one |>.ofReal
+  · rw [Asymptotics.isBigO_iff]
+    use 1
+    obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ
+    filter_upwards [eventually_ge_atTop (1 + c * ε)] with x hx
+    rw [hc _ _ hε hx]
+    simp; bound
+  · rw [Asymptotics.isBigO_iff]
+    use 1
+    filter_upwards [eventually_mem_nhdsWithin] with x hx
+    simp
+    apply abs_le.mpr
+    constructor
+    · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
+    · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1803,3 +1803,27 @@ lemma Smooth1MellinConvergent {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDiff �
     constructor
     · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
     · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx
+
+lemma Smooth1MellinDifferentiable {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDiff ℝ 1 Ψ) (suppΨ : Ψ.support ⊆ Icc (1 / 2) 2)
+    (hε : ε ∈ Ioo 0 1) (Ψnonneg : ∀ x > 0, 0 ≤ Ψ x)
+    (mass_one : ∫ x in Ioi 0, Ψ x / x = 1)
+    {s : ℂ} (hs: 0 < s.re) :
+    DifferentiableAt ℂ (𝓜 (fun x ↦ (Smooth1 Ψ ε x : ℂ))) s := by
+  rw [MellinTransform_eq]
+  apply mellin_differentiableAt_of_isBigO_rpow_exp zero_lt_one _ _ _ hs
+  · apply IntegrableOn.locallyIntegrableOn
+    exact Smooth1Integrable diffΨ suppΨ hε Ψnonneg mass_one |>.ofReal
+  · rw [Asymptotics.isBigO_iff]
+    use 1
+    obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ
+    filter_upwards [eventually_ge_atTop (1 + c * ε)] with x hx
+    rw [hc _ _ hε hx]
+    simp; bound
+  · rw [Asymptotics.isBigO_iff]
+    use 1
+    filter_upwards [eventually_mem_nhdsWithin] with x hx
+    simp
+    apply abs_le.mpr
+    constructor
+    · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
+    · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1732,7 +1732,7 @@ Follows from Lemmas \ref{MellinOfSmooth1a}, \ref{MellinOfDeltaSpikeAt1} and \ref
 
 /-%%
 \begin{lemma}[Smooth1ContinuousAt]\label{Smooth1ContinuousAt}\lean{Smooth1ContinuousAt}\leanok
-Fix a nonnegative, continuously differentiable function $F$ on $\mathbb{R}$ with support in $[1/2,2]$, and total mass one, $\int_{(0,\infty)} F(x)/x dx = 1$. Then for any $\epsilon>0$, the function
+Fix a nonnegative, continuously differentiable function $F$ on $\mathbb{R}$ with support in $[1/2,2]$. Then for any $\epsilon>0$, the function
 $x \mapsto \int_{(0,\infty)} x^{1+it} \widetilde{1_{\epsilon}}(x) dx$ is continuous at any $y>0$.
 ** Conditions are overkill; can remove some assumptions... **
 \end{lemma}
@@ -1741,11 +1741,8 @@ lemma Smooth1ContinuousAt {SmoothingF : ℝ → ℝ}
     (diffSmoothingF : ContDiff ℝ 1 SmoothingF)
     (SmoothingFpos : ∀ x > 0, 0 ≤ SmoothingF x)
     (suppSmoothingF : SmoothingF.support ⊆ Icc (1 / 2) 2)
-    (mass_one : ∫ (x : ℝ) in Ioi 0, SmoothingF x / x = 1)
     {ε : ℝ} (εpos : 0 < ε) {y : ℝ} (ypos : 0 < y) :
     ContinuousAt (fun x ↦ Smooth1 SmoothingF ε x) y := by
---  apply Continuous.continuousAt
-  unfold Smooth1
   apply ContinuousAt.congr (f := (fun x ↦ MellinConvolution (DeltaSpike SmoothingF ε) (fun x ↦ if 0 < x ∧ x ≤ 1 then 1 else 0) x)) _
   · filter_upwards [lt_mem_nhds ypos] with x hx
     apply MellinConvolutionSymmetric _ _ hx
@@ -1832,9 +1829,9 @@ lemma Smooth1ContinuousAt {SmoothingF : ℝ → ℝ}
 
 
 /-%%
-\begin{proof}
-\uses{Smooth1Properties_above}
-The function is a sum of continuous functions, and hence continuous.
+\begin{proof}leanok
+\uses{MellinConvolutionSymmetric}
+Use Lemma \ref{MellinconvolutionSymmetric} to write $\widetilde{1_{\epsilon}}(x)$ as an integral over an integral near $1$, in particular avoiding the singularity at $0$.  The integrand may be bounded by $2^{\epsilon}\nu_\epsilon(t)$ which is independent of $x$ and we can use dominated convergence to prove continuity. 
 \end{proof}
 %%-/
 
@@ -1846,7 +1843,7 @@ lemma Smooth1MellinConvergent {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDiff �
   apply mellinConvergent_of_isBigO_rpow_exp zero_lt_one _ _ _ hs
   · apply ContinuousOn.locallyIntegrableOn _ (by measurability)
     apply continuousOn_of_forall_continuousAt
-    exact fun x hx ↦ Smooth1ContinuousAt diffΨ Ψnonneg suppΨ mass_one hε.1 hx |>.ofReal
+    exact fun x hx ↦ Smooth1ContinuousAt diffΨ Ψnonneg suppΨ hε.1 hx |>.ofReal
   · rw [Asymptotics.isBigO_iff]
     use 1
     obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ
@@ -1871,7 +1868,7 @@ lemma Smooth1MellinDifferentiable {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDi
   apply mellin_differentiableAt_of_isBigO_rpow_exp zero_lt_one _ _ _ hs
   · apply ContinuousOn.locallyIntegrableOn _ (by measurability)
     apply continuousOn_of_forall_continuousAt
-    exact fun x hx ↦ Smooth1ContinuousAt diffΨ Ψnonneg suppΨ mass_one hε.1 hx |>.ofReal
+    exact fun x hx ↦ Smooth1ContinuousAt diffΨ Ψnonneg suppΨ hε.1 hx |>.ofReal
   · rw [Asymptotics.isBigO_iff]
     use 1
     obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1838,65 +1838,15 @@ The function is a sum of continuous functions, and hence continuous.
 \end{proof}
 %%-/
 
-@[fun_prop, measurability]
-lemma Smooth1_AEStronglyMeasurable {SmoothingF : ℝ → ℝ} (diffSmoothingF : ContDiff ℝ 1 SmoothingF) {ε : ℝ} (εpos : 0 < ε) : MeasureTheory.AEStronglyMeasurable (Smooth1 SmoothingF ε) := by
-  unfold Smooth1 MellinConvolution
-  convert MeasureTheory.AEStronglyMeasurable.integral_prod_right' (f := Function.uncurry fun x y => (if 0 < y ∧ y ≤ 1 then DeltaSpike SmoothingF ε (x / y) else 0) / y) ?_ with x _ y
-  · unfold Function.uncurry
-    simp only [ite_mul, one_mul, zero_mul, RCLike.ofReal_real_eq_id, id_eq]
-  · exact instSFiniteRestrict (Ioi 0)
-  · refine aestronglyMeasurable_iff_aemeasurable.mpr ?convert_4.a
-    refine Measurable.aemeasurable ?convert_4.a.h
-    apply MeasureTheory.measurable_uncurry_of_continuous_of_measurable
-    · intro x
-      split_ifs with h <;> fun_prop (disch := assumption)
-    intro x
-    convert_to Measurable <| (Ioc 0 1).indicator (fun y ↦ DeltaSpike SmoothingF ε (x/y) / y)
-    · ext x
-      simp [Set.indicator_apply, apply_ite (· / x)]
-    refine Measurable.indicator ?convert_4.a.h.h.hf ?convert_4.a.h.h.hs
-    · fun_prop (disch := assumption)
-    · measurability
-
-lemma Smooth1Integrable {Ψ : ℝ → ℝ} (diffΨ : ContDiff ℝ 1 Ψ) {ε : ℝ} (suppΨ : Ψ.support ⊆ Icc (1 / 2) 2)
-    (hε : ε ∈ Ioo 0 1) (Ψnonneg : ∀ x > 0, 0 ≤ Ψ x)
-    (mass_one : ∫ x in Ioi 0, Ψ x / x = 1) :
-    IntegrableOn (Smooth1 Ψ ε ·) (Ioi 0) := by
-  rw [← integrable_indicator_iff (by measurability)]
-  obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ
-  apply Integrable.mono' (g:= (Ioc 0 (1 + c * ε)).indicator 1)
-  · apply IntegrableOn.integrable_indicator _ (by measurability)
-    apply Continuous.integrableOn_Ioc
-    fun_prop
-  · apply (aestronglyMeasurable_indicator_iff (by measurability)).mpr
-    apply MeasureTheory.AEStronglyMeasurable.mono_measure («μ» := volume) _ (Measure.restrict_le_self)
-    exact Smooth1_AEStronglyMeasurable diffΨ hε.1
-  filter_upwards [] with x
-  simp
-  simp_rw [indicator_apply, mem_Ioi, mem_Ioc]
-  by_cases hx : x ≤ 0
-  · rw [if_neg hx.not_lt, if_neg (fun h => h.1.not_le hx)]
-    simp
-  push_neg at hx
-  rw [if_pos hx, ite_and, if_pos hx]
-  split_ifs with hx'
-  · apply abs_le.mpr
-    constructor
-    · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
-    · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx
-  push_neg at hx'
-  rw [hc _ _ hε hx'.le]
-  simp
-
-
 lemma Smooth1MellinConvergent {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDiff ℝ 1 Ψ) (suppΨ : Ψ.support ⊆ Icc (1 / 2) 2)
     (hε : ε ∈ Ioo 0 1) (Ψnonneg : ∀ x > 0, 0 ≤ Ψ x)
     (mass_one : ∫ x in Ioi 0, Ψ x / x = 1)
     {s : ℂ} (hs: 0 < s.re) :
     MellinConvergent (fun x ↦ (Smooth1 Ψ ε x : ℂ)) s := by
   apply mellinConvergent_of_isBigO_rpow_exp zero_lt_one _ _ _ hs
-  · apply IntegrableOn.locallyIntegrableOn
-    exact Smooth1Integrable diffΨ suppΨ hε Ψnonneg mass_one |>.ofReal
+  · apply ContinuousOn.locallyIntegrableOn _ (by measurability)
+    apply continuousOn_of_forall_continuousAt
+    exact fun x hx ↦ Smooth1ContinuousAt diffΨ Ψnonneg suppΨ mass_one hε.1 hx |>.ofReal
   · rw [Asymptotics.isBigO_iff]
     use 1
     obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ
@@ -1919,8 +1869,9 @@ lemma Smooth1MellinDifferentiable {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDi
     DifferentiableAt ℂ (𝓜 (fun x ↦ (Smooth1 Ψ ε x : ℂ))) s := by
   rw [MellinTransform_eq]
   apply mellin_differentiableAt_of_isBigO_rpow_exp zero_lt_one _ _ _ hs
-  · apply IntegrableOn.locallyIntegrableOn
-    exact Smooth1Integrable diffΨ suppΨ hε Ψnonneg mass_one |>.ofReal
+  · apply ContinuousOn.locallyIntegrableOn _ (by measurability)
+    apply continuousOn_of_forall_continuousAt
+    exact fun x hx ↦ Smooth1ContinuousAt diffΨ Ψnonneg suppΨ mass_one hε.1 hx |>.ofReal
   · rw [Asymptotics.isBigO_iff]
     use 1
     obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1729,3 +1729,33 @@ lemma MellinOfSmooth1c {ν : ℝ → ℝ} (diffν : ContDiff ℝ 1 ν)
 Follows from Lemmas \ref{MellinOfSmooth1a}, \ref{MellinOfDeltaSpikeAt1} and \ref{MellinOfDeltaSpikeAt1_asymp}.
 \end{proof}
 %%-/
+
+lemma Smooth1Integrable {Ψ : ℝ → ℝ} {ε : ℝ} (suppΨ : Ψ.support ⊆ Icc (1 / 2) 2)
+    (hε : ε ∈ Ioo 0 1) (Ψnonneg : ∀ x > 0, 0 ≤ Ψ x)
+    (mass_one : ∫ x in Ioi 0, Ψ x / x = 1) :
+    IntegrableOn (Smooth1 Ψ ε ·) (Ioi 0) := by
+  rw [← integrable_indicator_iff (by measurability)]
+  obtain ⟨c, cpos, hc⟩ := Smooth1Properties_above suppΨ
+  apply Integrable.mono' (g:= (Ioc 0 (1 + c * ε)).indicator 1)
+  · apply IntegrableOn.integrable_indicator _ (by measurability)
+    apply Continuous.integrableOn_Ioc
+    fun_prop
+  · apply (aestronglyMeasurable_indicator_iff (by measurability)).mpr
+    apply MeasureTheory.AEStronglyMeasurable.mono_measure («μ» := volume) _ (Measure.restrict_le_self)
+    sorry
+  filter_upwards [] with x
+  simp
+  simp_rw [indicator_apply, mem_Ioi, mem_Ioc]
+  by_cases hx : x ≤ 0
+  · rw [if_neg hx.not_lt, if_neg (fun h => h.1.not_le hx)]
+    simp
+  push_neg at hx
+  rw [if_pos hx, ite_and, if_pos hx]
+  split_ifs with hx'
+  · apply abs_le.mpr
+    constructor
+    · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
+    · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx
+  push_neg at hx'
+  rw [hc _ _ hε hx'.le]
+  simp

--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1831,7 +1831,7 @@ lemma Smooth1ContinuousAt {SmoothingF : ℝ → ℝ}
 /-%%
 \begin{proof}leanok
 \uses{MellinConvolutionSymmetric}
-Use Lemma \ref{MellinconvolutionSymmetric} to write $\widetilde{1_{\epsilon}}(x)$ as an integral over an integral near $1$, in particular avoiding the singularity at $0$.  The integrand may be bounded by $2^{\epsilon}\nu_\epsilon(t)$ which is independent of $x$ and we can use dominated convergence to prove continuity. 
+Use Lemma \ref{MellinconvolutionSymmetric} to write $\widetilde{1_{\epsilon}}(x)$ as an integral over an integral near $1$, in particular avoiding the singularity at $0$.  The integrand may be bounded by $2^{\epsilon}\nu_\epsilon(t)$ which is independent of $x$ and we can use dominated convergence to prove continuity.
 \end{proof}
 %%-/
 
@@ -1854,10 +1854,8 @@ lemma Smooth1MellinConvergent {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDiff �
     use 1
     filter_upwards [eventually_mem_nhdsWithin] with x hx
     simp
-    apply abs_le.mpr
-    constructor
-    · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
-    · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx
+    rw [_root_.abs_of_nonneg <| Smooth1Nonneg Ψnonneg hx hε.1]
+    exact Smooth1LeOne Ψnonneg mass_one hε.1 hx
 
 lemma Smooth1MellinDifferentiable {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDiff ℝ 1 Ψ) (suppΨ : Ψ.support ⊆ Icc (1 / 2) 2)
     (hε : ε ∈ Ioo 0 1) (Ψnonneg : ∀ x > 0, 0 ≤ Ψ x)
@@ -1879,7 +1877,5 @@ lemma Smooth1MellinDifferentiable {Ψ : ℝ → ℝ} {ε : ℝ} (diffΨ : ContDi
     use 1
     filter_upwards [eventually_mem_nhdsWithin] with x hx
     simp
-    apply abs_le.mpr
-    constructor
-    · exact le_trans (by norm_num) <| Smooth1Nonneg Ψnonneg hx hε.1
-    · exact Smooth1LeOne Ψnonneg mass_one hε.1 hx
+    rw [_root_.abs_of_nonneg <| Smooth1Nonneg Ψnonneg hx hε.1]
+    exact Smooth1LeOne Ψnonneg mass_one hε.1 hx


### PR DESCRIPTION
Quite a lot here:
* Proves SmoothedChebyshevDirichlet_aux_contAt which I have renamed to Smooth1ContinuousAt and moved to MellinCalculus.lean.
* Given continuity of Smooth1 and the existing bounds on it we can deduce that it is Mellin convergent and it's Mellin transform is differentiable in $\Re s > 0$, see Smooth1MellinConvergent and Smooth1MellinDifferentiable. The latter currently isn't used but will be needed when we want to pull contours, it also gives us continuity of the Mellin transform which will be useful for (SmoothedChebyshevDirichlet_aux_integrable.
* (integrable_x_mul_Smooth1 is now not needed as it's just Mellin convergence at 2.