### PR TITLE
Work on holomorphy results

### DIFF
--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -6410,17 +6410,22 @@ theorem MediumPNT : ∃ c > 0,
 
   let T : ℝ := sorry
   have T_gt_3 : 3 < T := sorry
-
-  let A : ℝ := sorry
-  have A_in_Ioo : A ∈ Ioo 0 (1 / 2) := sorry
-
+  obtain ⟨A, A_in_Ioc, holo1⟩ := LogDerivZetaHolcLargeT
+  specialize holo1 T T_gt_3.le
   let σ₁ : ℝ := 1 - A / (Real.log T) ^ 9
-
+  have σ₁pos : 0 < σ₁ := by sorry
+  have σ₁_lt_one : σ₁ < 1 := by
+    apply sub_lt_self
+    apply div_pos A_in_Ioc.1
+    bound
   let σ₂ : ℝ := sorry
 
   have ψ_ε_diff : ‖ψ_ε_of_X - 𝓜 ((Smooth1 ν ε) ·) 1 * X‖ ≤ ‖I₁ ν ε T X‖ + ‖I₂ ν ε X T σ₁‖
     + ‖I₃ ν ε X T σ₁‖ + ‖I₄ ν ε X σ₁ σ₂‖ + ‖I₅ ν ε X σ₂‖ + ‖I₆ ν ε X σ₁ σ₂‖ + ‖I₇ ν ε T X σ₁‖
-    + ‖I₈ ν ε X T σ₁‖ + ‖I₉ ν ε X T‖ := by sorry
+    + ‖I₈ ν ε X T σ₁‖ + ‖I₉ ν ε X T‖ := by
+    unfold ψ_ε_of_X
+    rw [SmoothedChebyshevPull1 ε_pos ε_lt_one X X_gt_3 (T := T) (by linarith) σ₁pos σ₁_lt_one holo1 ν_supp ν_nonneg ν_massOne ContDiff1ν]
+    sorry
 
   have : ∃ C_main > 0, ‖𝓜 ((Smooth1 ν ε) ·) 1 * X - X‖ ≤ C_main * ε * X := by sorry
 

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -1989,30 +1989,6 @@ theorem dlog_riemannZeta_bdd_on_vertical_lines {σ₀ : ℝ} (σ₀_gt : 1 < σ�
 
     exact C
 
-theorem analyticAt_riemannZeta {s : ℂ} (s_ne_one : s ≠ 1) :
-  AnalyticAt ℂ riemannZeta s := by
-  have : DifferentiableAt ℂ riemannZeta s := differentiableAt_riemannZeta s_ne_one
-  have exclude := eventually_ne_nhds s_ne_one
-  unfold Filter.Eventually at exclude
-  have : AnalyticAt ℂ riemannZeta s := by
-      refine Complex.analyticAt_iff_eventually_differentiableAt.mpr ?_
-      unfold Filter.Eventually
-      have T : {x | (fun x ↦ x ≠ 1) x} ⊆ {x | (fun z ↦ DifferentiableAt ℂ ζ z) x} := by
-        intro x
-        simp [*]
-        push_neg
-        intro hyp_x
-        exact differentiableAt_riemannZeta hyp_x
-      apply mem_nhds_iff.mpr
-      use {x | (fun x ↦ x ≠ 1) x}
-      constructor
-      · exact T
-      · constructor
-        · exact isOpen_ne
-        · exact s_ne_one
-
-  exact this
-
 /-%%
 \begin{lemma}[dlog_riemannZeta_bdd_on_vertical_lines']\label{dlog_riemannZeta_bdd_on_vertical_lines'}\lean{dlog_riemannZeta_bdd_on_vertical_lines'}\leanok
 For $\sigma_0 > 1$, there exists a constant $C > 0$ such that
@@ -2030,12 +2006,6 @@ theorem dlog_riemannZeta_bdd_on_vertical_lines' {σ₀ : ℝ} (σ₀_gt : 1 < σ
 Write as Dirichlet series and estimate trivially using Theorem \ref{LogDerivativeDirichlet}.
 \end{proof}
 %%-/
-
-
-theorem differentiableAt_deriv_riemannZeta {s : ℂ} (s_ne_one : s ≠ 1) :
-    DifferentiableAt ℂ ζ' s := by
-      have U := (analyticAt_riemannZeta s_ne_one).deriv.differentiableAt
-      exact U
 
 /-%%
 \begin{lemma}[SmoothedChebyshevPull1_aux_integrable]\label{SmoothedChebyshevPull1_aux_integrable}\lean{SmoothedChebyshevPull1_aux_integrable}\leanok

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -6438,14 +6438,19 @@ theorem MediumPNT : ∃ c > 0,
       left
       norm_cast
       linarith
-  have ψ_ε_diff : ‖ψ_ε_of_X - 𝓜 ((Smooth1 ν ε) ·) 1 * X‖ ≤ ‖I₁ ν ε T X‖ + ‖I₂ ν ε X T σ₁‖
-    + ‖I₃ ν ε X T σ₁‖ + ‖I₄ ν ε X σ₁ σ₂‖ + ‖I₅ ν ε X σ₂‖ + ‖I₆ ν ε X σ₁ σ₂‖ + ‖I₇ ν ε T X σ₁‖
-    + ‖I₈ ν ε X T σ₁‖ + ‖I₉ ν ε X T‖ := by
+  have ψ_ε_diff : ‖ψ_ε_of_X - 𝓜 ((Smooth1 ν ε) ·) 1 * X‖ ≤ ‖I₁ ν ε X T‖ + ‖I₂ ν ε T X σ₁‖
+    + ‖I₃ ν ε T X σ₁‖ + ‖I₄ ν ε X σ₁ σ₂‖ + ‖I₅ ν ε X σ₂‖ + ‖I₆ ν ε X σ₁ σ₂‖ + ‖I₇ ν ε T X σ₁‖
+    + ‖I₈ ν ε T X σ₁‖ + ‖I₉ ν ε X T‖ := by
     unfold ψ_ε_of_X
     rw [SmoothedChebyshevPull1 ε_pos ε_lt_one X X_gt_3 (T := T) (by linarith) σ₁pos σ₁_lt_one holo1 ν_supp ν_nonneg ν_massOne ContDiff1ν]
     rw [SmoothedChebyshevPull2 ε_pos ε_lt_one X X_gt_3 (T := T) (by linarith) σ₂_pos σ₁_lt_one σ₂_lt_σ₁ holo1 holo2a ν_supp ν_nonneg ν_massOne ContDiff1ν]
-    sorry
-
+    ring_nf
+    iterate 5
+      apply le_trans (by apply norm_add_le)
+      gcongr
+    apply le_trans (by apply norm_add_le)
+    rw [(by ring : ‖I₁ ν ε X T‖ + ‖I₂ ν ε T X σ₁‖ + ‖I₃ ν ε T X σ₁‖ + ‖I₄ ν ε X σ₁ σ₂‖ = (‖I₁ ν ε X T‖ + ‖I₂ ν ε T X σ₁‖) + (‖I₃ ν ε T X σ₁‖ + ‖I₄ ν ε X σ₁ σ₂‖))]
+    gcongr <;> apply le_trans (by apply norm_sub_le) <;> rfl
   have : ∃ C_main > 0, ‖𝓜 ((Smooth1 ν ε) ·) 1 * X - X‖ ≤ C_main * ε * X := by sorry
 
   obtain ⟨C_main, C_main_pos, main_diff⟩ := this

--- a/PrimeNumberTheoremAnd/MediumPNT.lean
+++ b/PrimeNumberTheoremAnd/MediumPNT.lean
@@ -6418,13 +6418,32 @@ theorem MediumPNT : ∃ c > 0,
     apply sub_lt_self
     apply div_pos A_in_Ioc.1
     bound
-  let σ₂ : ℝ := sorry
+  obtain ⟨σ₂, σ₂_lt_one, holo2⟩ := LogDerivZetaHolcSmallT
+  have σ₂_pos : 0 < σ₂ := by sorry
+  have σ₂_lt_σ₁ : σ₂ < σ₁ := by sorry
+  rw [uIcc_of_le (by linarith), uIcc_of_le (by linarith)] at holo2
 
+  have holo2a : HolomorphicOn (SmoothedChebyshevIntegrand ν ε X) (Icc σ₂ 2 ×ℂ Icc (-3) 3 \ {1}) := by
+    apply DifferentiableOn.mul
+    · apply DifferentiableOn.mul
+      · rw [(by ext; ring : (fun s ↦ -ζ' s / ζ s) = (fun s ↦ -(ζ' s / ζ s)))]
+        apply DifferentiableOn.neg holo2
+      · intro s hs
+        apply DifferentiableAt.differentiableWithinAt
+        apply Smooth1MellinDifferentiable ContDiff1ν ν_supp ⟨ε_pos, ε_lt_one⟩ ν_nonneg ν_massOne
+        linarith[mem_reProdIm.mp hs.1 |>.1.1]
+    · intro s hs
+      apply DifferentiableAt.differentiableWithinAt
+      apply DifferentiableAt.const_cpow (by fun_prop)
+      left
+      norm_cast
+      linarith
   have ψ_ε_diff : ‖ψ_ε_of_X - 𝓜 ((Smooth1 ν ε) ·) 1 * X‖ ≤ ‖I₁ ν ε T X‖ + ‖I₂ ν ε X T σ₁‖
     + ‖I₃ ν ε X T σ₁‖ + ‖I₄ ν ε X σ₁ σ₂‖ + ‖I₅ ν ε X σ₂‖ + ‖I₆ ν ε X σ₁ σ₂‖ + ‖I₇ ν ε T X σ₁‖
     + ‖I₈ ν ε X T σ₁‖ + ‖I₉ ν ε X T‖ := by
     unfold ψ_ε_of_X
     rw [SmoothedChebyshevPull1 ε_pos ε_lt_one X X_gt_3 (T := T) (by linarith) σ₁pos σ₁_lt_one holo1 ν_supp ν_nonneg ν_massOne ContDiff1ν]
+    rw [SmoothedChebyshevPull2 ε_pos ε_lt_one X X_gt_3 (T := T) (by linarith) σ₂_pos σ₁_lt_one σ₂_lt_σ₁ holo1 holo2a ν_supp ν_nonneg ν_massOne ContDiff1ν]
     sorry
 
   have : ∃ C_main > 0, ‖𝓜 ((Smooth1 ν ε) ·) 1 * X - X‖ ≤ C_main * ε * X := by sorry

--- a/PrimeNumberTheoremAnd/ZetaBounds.lean
+++ b/PrimeNumberTheoremAnd/ZetaBounds.lean
@@ -4026,12 +4026,12 @@ For any $T>0$, there is a constant $\sigma<1$ so that
 $$
 \zeta(\sigma'+it) \ne 0
 $$
-for all $|t| < T$ and $\sigma' \ge \sigma$.
+for all $|t| \leq T$ and $\sigma' \ge \sigma$.
 \end{lemma}
 %%-/
 
 lemma ZetaNoZerosInBox (T : ℝ) :
-    ∃ (σ : ℝ) (_ : σ < 1), ∀ (t : ℝ) (_ : |t| < T)
+    ∃ (σ : ℝ) (_ : σ < 1), ∀ (t : ℝ) (_ : |t| ≤ T)
     (σ' : ℝ) (_ : σ' ≥ σ), ζ (σ' + t * I) ≠ 0 := by
   by_contra h
   push_neg at h
@@ -4039,7 +4039,7 @@ lemma ZetaNoZerosInBox (T : ℝ) :
   have hn (n : ℕ) := h (σ := 1 - 1 / (n + 1)) (sub_lt_self _ (by positivity))
 
   have : ∃ (tn : ℕ → ℝ) (σn : ℕ → ℝ), (∀ n, σn n ≤ 1) ∧
-    (∀ n, (1 : ℝ) - 1 / (n + 1) ≤ σn n) ∧ (∀ n, |tn n| < T) ∧
+    (∀ n, (1 : ℝ) - 1 / (n + 1) ≤ σn n) ∧ (∀ n, |tn n| ≤ T) ∧
     (∀ n, ζ (σn n + tn n * I) = 0) := by
     choose t ht σ' hσ' hζ using hn
     refine ⟨t, σ', ?_, hσ', ht, hζ⟩
@@ -4061,7 +4061,7 @@ lemma ZetaNoZerosInBox (T : ℝ) :
   have : ∃ (t₀ : ℝ) (subseq : ℕ → ℕ),
       Filter.Tendsto (t ∘ subseq) Filter.atTop (𝓝 t₀) ∧
       Filter.Tendsto subseq Filter.atTop Filter.atTop := by
-    refine (isCompact_Icc.isSeqCompact fun and => abs_le.1 (ht and).le).imp fun and ⟨x, A, B, _⟩ => ?_
+    refine (isCompact_Icc.isSeqCompact fun and => abs_le.1 (ht and)).imp fun and ⟨x, A, B, _⟩ => ?_
     use A, by valid, B.tendsto_atTop
 
   obtain ⟨t₀, subseq, tTendsto, subseqTendsto⟩ := this
@@ -4157,7 +4157,7 @@ is holomorphic on $\{ \sigma_2 \le \Re s \le 2, |\Im s| \le 3 \} \setminus \{1\}
 theorem LogDerivZetaHolcSmallT :
     ∃ (σ₂ : ℝ) (_ : σ₂ < 1), HolomorphicOn (fun (s : ℂ) ↦ ζ' s / (ζ s))
       (( [[ σ₂, 2 ]] ×ℂ [[ -3, 3 ]]) \ {1}) := by
-  obtain ⟨σ₂, hσ₂_lt_one, hζ_ne_zero⟩ := ZetaNoZerosInBox 4
+  obtain ⟨σ₂, hσ₂_lt_one, hζ_ne_zero⟩ := ZetaNoZerosInBox 3
   refine ⟨σ₂, hσ₂_lt_one, ?_⟩
   let U := ([[σ₂, 2]] ×ℂ [[-3, 3]]) \ {1}
   have s_in_U_im_le3 : ∀ s ∈ U, |s.im| ≤ 3 := by
@@ -4173,18 +4173,6 @@ theorem LogDerivZetaHolcSmallT :
     constructor
     · exact him_lower
     · exact him_upper
-  have s_in_U_re_le2 : ∀ s ∈ U, s.re ≤ 2 := by
-    intro s hs
-    rw [mem_diff_singleton] at hs
-    rcases hs with ⟨hbox, _hne⟩
-    rcases hbox with ⟨hre, _him⟩
-    simp only [Set.mem_preimage, mem_Icc] at hre
-    obtain ⟨hre_lower, hre_upper⟩ := hre
-    have : max σ₂ 2 = 2 := by
-      apply max_eq_right
-      linarith [hσ₂_lt_one]
-    rw[this] at hre_upper
-    exact hre_upper
 
   have s_in_U_re_ges2 : ∀ s ∈ U, σ₂ ≤ s.re := by
     intro s hs
@@ -4199,21 +4187,13 @@ theorem LogDerivZetaHolcSmallT :
     rw[this] at hre_lower
     exact hre_lower
 
-  have hζ_ne_zero' : ∀ s ∈ U, ζ s ≠ 0 := by
-    intro s hs
-    have : |s.im| ≤ 3 := s_in_U_im_le3 s hs
-    have h1 : |s.im| < 4 := by
-      linarith [this]
-    have h2 : σ₂ ≤ s.re := by
-      exact s_in_U_re_ges2 s hs
-    have : s = s.re + s.im * I := by
-      exact Eq.symm (re_add_im s)
-    rw[this]
-    apply hζ_ne_zero s.im h1 s.re
-    exact s_in_U_re_ges2 s hs
-
-  apply LogDerivZetaHoloOn _ hζ_ne_zero'
-  exact notMem_diff_of_mem rfl
+  apply LogDerivZetaHoloOn
+  · exact notMem_diff_of_mem rfl
+  · intro s hs
+    rw[← re_add_im s]
+    apply hζ_ne_zero
+    apply s_in_U_im_le3 _ hs
+    apply s_in_U_re_ges2 _ hs
 /-%%
 \begin{proof}\uses{ZetaNoZerosInBox}\leanok
 The derivative of $\zeta$ is holomorphic away from $s=1$; the denominator $\zeta(s)$ is nonzero
@@ -4367,9 +4347,9 @@ theorem LogDerivZetaHolcLargeT :
         exact Ne.symm (Nat.zero_ne_add_one 8)
       (expose_names; exact gt_trans temp this)
     exact ⟨this, σ_inter.2⟩
-    have : ∀ (t : ℝ), |t| < 4 → ∀ σ' ≥ σ₁, riemannZeta (↑σ' + ↑t * Complex.I) ≠ 0 := by exact fun t a σ' a_1 ↦ noZerosInBox t a σ' a_1
+    have : ∀ (t : ℝ), |t| ≤ 4 → ∀ σ' ≥ σ₁, riemannZeta (↑σ' + ↑t * Complex.I) ≠ 0 := by exact fun t a σ' a_1 ↦ noZerosInBox t a σ' a_1
     apply this
-    (expose_names; exact h)
+    (expose_names; exact h.le)
     have temp : σ₀ < 1 - A / Real.log T ^ 9 ∧ σ₁ < 1 - A / Real.log T ^ 9 := by exact TlbConsequences T Tlb_lt_T
     have : 1 - A / Real.log T ^ 9 < σ := by
       have : 1 - A / Real.log |T| ^ 9 < σ := by exact σ_inter.1

--- a/PrimeNumberTheoremAnd/ZetaBounds.lean
+++ b/PrimeNumberTheoremAnd/ZetaBounds.lean
@@ -4214,7 +4214,7 @@ is holomorphic on $\{1-A/\log^9 T \le \Re s \le 2, |\Im s|\le T \}\setminus\{1\}
 theorem LogDerivZetaHolcLargeT :
     ∃ (A : ℝ) (_ : A ∈ Ioc 0 (1 / 2)), ∀ (T : ℝ) (_ : 3 ≤ T),
     HolomorphicOn (fun (s : ℂ) ↦ ζ' s / (ζ s))
-      (( (Ioo ((1 : ℝ) - A / Real.log T ^ 9) 2)  ×ℂ (Ioo (-T) T) ) \ {1}) := by
+      (( (Icc ((1 : ℝ) - A / Real.log T ^ 9) 2)  ×ℂ (Icc (-T) T) ) \ {1}) := by
   obtain ⟨A, A_inter, restOfZetaZeroFree⟩ := ZetaZeroFree
   obtain ⟨σ₁, σ₁_lt_one, noZerosInBox⟩ := ZetaNoZerosInBox 3
   let A₀ := min A ((1 - σ₁) * Real.log 3 ^ 9)
@@ -4241,12 +4241,12 @@ theorem LogDerivZetaHolcLargeT :
         · bound
         · bound
         · bound
-        · exact abs_le.mpr ⟨this.2.1.le, this.2.2.le⟩
-      _ ≤ _:= by exact this.1.1.le
+        · exact abs_le.mpr ⟨this.2.1, this.2.2⟩
+      _ ≤ _:= by exact this.1.1
 
   · apply noZerosInBox _ le3
     calc
-      _ ≥ 1 - A₀ / Real.log T ^ 9 := by exact this.1.1.le
+      _ ≥ 1 - A₀ / Real.log T ^ 9 := by exact this.1.1
       _ ≥ 1 - A₀ / Real.log 3 ^ 9 := by
         gcongr
         apply le_min A_inter.1.le

--- a/PrimeNumberTheoremAnd/ZetaBounds.lean
+++ b/PrimeNumberTheoremAnd/ZetaBounds.lean
@@ -4212,177 +4212,49 @@ is holomorphic on $\{1-A/\log^9 T \le \Re s \le 2, |\Im s|\le T \}\setminus\{1\}
 %%-/
 
 theorem LogDerivZetaHolcLargeT :
-    ∃ (A : ℝ) (_ : A ∈ Ioc 0 (1 / 2)), ∃ (Tlb : ℝ) (_ : 3 < Tlb), ∀ (T : ℝ) (_ : Tlb < T),
+    ∃ (A : ℝ) (_ : A ∈ Ioc 0 (1 / 2)), ∀ (T : ℝ) (_ : 3 ≤ T),
     HolomorphicOn (fun (s : ℂ) ↦ ζ' s / (ζ s))
       (( (Ioo ((1 : ℝ) - A / Real.log T ^ 9) 2)  ×ℂ (Ioo (-T) T) ) \ {1}) := by
   obtain ⟨A, A_inter, restOfZetaZeroFree⟩ := ZetaZeroFree
-  use A
-  use A_inter
-  obtain ⟨σ₀, σ₀_lt_one, trash⟩ := LogDerivZetaHolcSmallT
-  obtain ⟨σ₁, σ₁_lt_one, noZerosInBox⟩ := ZetaNoZerosInBox 4
-  have : ∃ (Tlb : ℝ) (_ : 3 < Tlb), ∀ (T : ℝ), Tlb < T → σ₀ < (1 : ℝ) - A / Real.log T ^ 9 ∧ σ₁ < (1 : ℝ) - A / Real.log T ^ 9 := by
-    let Tlb : ℝ := max 5 (max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9))))
-    use Tlb
-    have three_lt_Tlb : 3 < Tlb := by
-      rw[lt_max_iff]
-      exact Or.inl (by norm_num)
-    use three_lt_Tlb
-    intro T Tlb_lt_T
-    have temp : σ₀ < 1 - A / Real.log T ^ 9 := by
-      have : Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9)) ≤ Tlb := by
-        dsimp[Tlb]
-        have temp : Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9)) ≤
-          max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9))) := by apply le_max_left
-        have : max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9))) ≤
-          max 5 (max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9)))) := by apply le_max_right
-        (expose_names; exact le_sup_of_le_right temp)
-      have keep : Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9)) < T := by exact lt_of_le_of_lt this Tlb_lt_T
-      rw[← Real.lt_log_iff_exp_lt] at keep
-      have : A / (1 - σ₀) < Real.log T ^ 9 := by
-        have temp : 0 ≤ A / (1 - σ₀) := by
-          apply div_nonneg
-          apply le_of_lt A_inter.1
-          linarith
-        have : 9 ≠ 0 := by exact Ne.symm (Nat.zero_ne_add_one 8)
-        rw[← Real.rpow_inv_natCast_pow temp this]
-        have : Odd 9 := by exact Nat.odd_iff.mpr rfl
-        rw[Odd.pow_lt_pow this]
-        have : (↑(9 : ℕ))⁻¹ = 1 / (9 : ℝ) := by exact inv_eq_one_div (9 : ℝ)
-        rw[this]
-        exact keep
-      have : A / Real.log T ^ 9 < 1 - σ₀ := by
-        rw[div_lt_iff₀] at this ⊢
-        rw[mul_comm]
-        exact this
-        refine pow_pos ?_ 9
-        apply Real.log_pos
-        repeat linarith
-      repeat linarith
-    have : σ₁ < 1 - A / Real.log T ^ 9 := by
-      have : Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9)) ≤ Tlb := by
-        dsimp[Tlb]
-        have temp : Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9)) ≤
-          max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9))) := by apply le_max_right
-        have : max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9))) ≤
-          max 5 (max (Real.exp ((A / (1 - σ₀)) ^ ((1 : ℝ) / 9))) (Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9)))) := by apply le_max_right
-        (expose_names; exact le_sup_of_le_right temp)
-      have keep : Real.exp ((A / (1 - σ₁)) ^ ((1 : ℝ) / 9)) < T := by exact lt_of_le_of_lt this Tlb_lt_T
-      rw[← Real.lt_log_iff_exp_lt] at keep
-      have : A / (1 - σ₁) < Real.log T ^ 9 := by
-        have temp : 0 ≤ A / (1 - σ₁) := by
-          apply div_nonneg
-          apply le_of_lt A_inter.1
-          linarith
-        have : 9 ≠ 0 := by exact Ne.symm (Nat.zero_ne_add_one 8)
-        rw[← Real.rpow_inv_natCast_pow temp this]
-        have : Odd 9 := by exact Nat.odd_iff.mpr rfl
-        rw[Odd.pow_lt_pow this]
-        have : (↑(9 : ℕ))⁻¹ = 1 / (9 : ℝ) := by exact inv_eq_one_div (9 : ℝ)
-        rw[this]
-        exact keep
-      have : A / Real.log T ^ 9 < 1 - σ₁ := by
-        rw[div_lt_iff₀] at this ⊢
-        rw[mul_comm]
-        exact this
-        refine pow_pos ?_ 9
-        apply Real.log_pos
-        repeat linarith
-      repeat linarith
-    exact ⟨temp, this⟩
-  obtain ⟨Tlb, three_lt_Tlb, TlbConsequences⟩ := this
-  use Tlb
-  use three_lt_Tlb
-  intro T Tlb_lt_T
-  have three_lt_T : 3 < T := by exact gt_trans Tlb_lt_T three_lt_Tlb
-  have Tlb_lt_abs_T : Tlb < |T| := by
-    rw[abs_of_nonneg]
-    exact Tlb_lt_T
-    positivity
-  have temp : 1 - A / Real.log T ^ 9 < 1 := by
-    apply sub_lt_self
-    apply div_pos
-    have : 0 < A := by
-      rw[Set.mem_Ioc] at A_inter
-      exact A_inter.1
-    exact this
-    apply pow_pos
-    rw[← Real.log_one]
-    apply Real.log_lt_log
-    norm_num
-    linarith
-  have temp' : 1 - A / Real.log |T| ^ 9 < 1 := by
-    rw[abs_of_nonneg]
-    exact temp
-    positivity
-  have zetaZeroFreeCrit : ∀ (σ t : ℝ), σ ∈ Ioo (1 - A / Real.log |T| ^ 9) 1 → t ∈ Ioo (-T) T → ζ (↑σ + ↑t * I) ≠ 0 := by
-    intro σ t σ_inter t_inter
-    have : 4 ≤ |t| ∨ 4 > |t| := by exact le_or_gt 4 |t|
-    rcases this
-    apply restOfZetaZeroFree σ t
-    linarith
-    apply Ioo_subset_Ico_self
-    refine mem_Ioo.mpr ?_
-    have : 1 - A / Real.log |t| ^ 9 < σ := by
-      have temp: 1 - A / Real.log |T| ^ 9 < σ := by exact σ_inter.1
-      have : 1 - A / Real.log |t| ^ 9 < 1 - A / Real.log |T| ^ 9 := by
-        refine (sub_lt_sub_iff_left 1).mpr ?_
-        refine div_lt_div_of_pos_left ?_ ?_ ?_
-        exact A_inter.1
-        refine pow_pos ?_ 9
-        rw[← Real.log_one]
-        apply Real.log_lt_log
-        norm_num
-        linarith
-        refine pow_lt_pow_left₀ ?_ ?_ ?_
-        apply Real.log_lt_log
-        positivity
-        nth_rewrite 2 [abs_of_nonneg]
-        rw[abs_lt]
-        exact t_inter
-        positivity
-        rw[← Real.log_one]
-        apply Real.log_le_log
-        positivity
-        linarith
-        exact Ne.symm (Nat.zero_ne_add_one 8)
-      (expose_names; exact gt_trans temp this)
-    exact ⟨this, σ_inter.2⟩
-    have : ∀ (t : ℝ), |t| ≤ 4 → ∀ σ' ≥ σ₁, riemannZeta (↑σ' + ↑t * Complex.I) ≠ 0 := by exact fun t a σ' a_1 ↦ noZerosInBox t a σ' a_1
-    apply this
-    (expose_names; exact h.le)
-    have temp : σ₀ < 1 - A / Real.log T ^ 9 ∧ σ₁ < 1 - A / Real.log T ^ 9 := by exact TlbConsequences T Tlb_lt_T
-    have : 1 - A / Real.log T ^ 9 < σ := by
-      have : 1 - A / Real.log |T| ^ 9 < σ := by exact σ_inter.1
-      rw[abs_of_nonneg] at this
-      exact this
-      positivity
-    apply le_of_lt
-    exact lt_trans temp.2 this
-  have zetaZeroFreeTriv : ∀ (σ t : ℝ), σ ∈ Ico 1 2 → t ∈ Ioo (-T) T → ζ (↑σ + ↑t * I) ≠ 0 := by
-    intro σ t σ_inter t_inter
-    obtain ⟨lb, ub⟩ := σ_inter
-    have : 1 ≤ (↑σ + ↑t * I).re := by
-      rw[add_re, mul_re, I_re, I_im, ofReal_re, ofReal_im]
-      linarith
-    exact riemannZeta_ne_zero_of_one_le_re this
-  have zetaZeroFreeCombo : ∀ (σ t : ℝ), σ ∈ Ioo (1 - A / Real.log |T| ^ 9) 2 → t ∈ Ioo (-T) T → ζ (↑σ + ↑t * I) ≠ 0 := by
-    intro σ t σ_inter
-    rw[← Set.Ioo_union_Ico_eq_Ioo temp' one_le_two, Set.mem_union] at σ_inter
-    exact Or.elim σ_inter (zetaZeroFreeCrit σ t) (zetaZeroFreeTriv σ t)
-  clear zetaZeroFreeCrit zetaZeroFreeTriv
+  obtain ⟨σ₁, σ₁_lt_one, noZerosInBox⟩ := ZetaNoZerosInBox 3
+  let A₀ := min A ((1 - σ₁) * Real.log 3 ^ 9)
+  refine ⟨A₀, ?_, ?_⟩
+  · constructor
+    · apply lt_min A_inter.1
+      bound
+    · exact le_trans (min_le_left _ _) A_inter.2
+  intro T hT
   apply LogDerivZetaHoloOn
   · exact notMem_diff_of_mem rfl
-  intro x
-  rw[Set.mem_diff, Complex.mem_reProdIm]
-  intro xHypo
-  obtain ⟨⟨xReIn, xImIn⟩, xOut⟩ := xHypo
-  have : x = x.re + x.im * I := by exact Eq.symm (re_add_im x)
-  rw[this]
-  apply zetaZeroFreeCombo x.re x.im
-  rw[abs_of_nonneg]
-  exact xReIn
-  positivity
-  exact xImIn
+  intro s hs
+  rcases le_or_gt 1 s.re with one_le|lt_one
+  · exact riemannZeta_ne_zero_of_one_le_re one_le
+  rw [← re_add_im s]
+  have := Complex.mem_reProdIm.mp hs.1
+  rcases lt_or_ge 3 |s.im| with gt3|le3
+  · apply restOfZetaZeroFree _ _ gt3
+    refine ⟨?_, lt_one⟩
+    calc
+      _ ≤ 1 - A₀ / Real.log T ^ 9 := by
+        gcongr
+        · exact A_inter.1.le
+        · bound
+        · bound
+        · bound
+        · exact abs_le.mpr ⟨this.2.1.le, this.2.2.le⟩
+      _ ≤ _:= by exact this.1.1.le
+
+  · apply noZerosInBox _ le3
+    calc
+      _ ≥ 1 - A₀ / Real.log T ^ 9 := by exact this.1.1.le
+      _ ≥ 1 - A₀ / Real.log 3 ^ 9 := by
+        gcongr
+        apply le_min A_inter.1.le
+        bound
+      _ ≥ 1 - (((1 - σ₁) * Real.log 3 ^ 9)) / Real.log 3 ^ 9:= by
+        gcongr
+        apply min_le_right
+      _ = _ := by field_simp
 
 /-%%
 \begin{proof}\uses{ZetaZeroFree}\leanok

--- a/PrimeNumberTheoremAnd/ZetaBounds.lean
+++ b/PrimeNumberTheoremAnd/ZetaBounds.lean
@@ -190,6 +190,15 @@ $f(s) = A/(s-p) + O(1)$.
 \end{proof}
 %%-/
 
+theorem analyticAt_riemannZeta {s : ℂ} (s_ne_one : s ≠ 1) :
+  AnalyticAt ℂ riemannZeta s := by
+  apply Complex.analyticAt_iff_eventually_differentiableAt.mpr
+  filter_upwards [eventually_ne_nhds s_ne_one] with z hz
+  exact differentiableAt_riemannZeta hz
+
+theorem differentiableAt_deriv_riemannZeta {s : ℂ} (s_ne_one : s ≠ 1) :
+    DifferentiableAt ℂ ζ' s := by
+  exact (analyticAt_riemannZeta s_ne_one).deriv.differentiableAt
 
 /-%%
 \begin{theorem}[riemannZetaResidue]\label{riemannZetaResidue}\lean{riemannZetaResidue}\leanok


### PR DESCRIPTION
Various small improvements to the LogDerivZetaHolc results so that MediumPNT can now easily call pull1:
* Moved a couple of results about zeta from MediumPNT.lean to ZetaBounds.lean (and shortened the proofs).
* a general lemma that to get holomorphy of zeta'/zeta on a set we just need to avoid 1 and be zero free.  This significantly shortens the following results.
* Make the bound in NoZerosInBox be inclusive.  This further simplifies the holomorphy results because we can just use T = 3 rather than needing the result at 4 too.
* Rework LogDerivZetaHolcLargeT to hold for all T >= 3 rather than just sufficiently large (by reducing the constant A). Also changed this to use closed intervals to match the MediumPNT requirement.
* The new HolcLargeT can now be used in MediumPNT to implement pull1.