### PR TITLE
chore: drop ArithmeticFunction.IsMultiplicative.mult_lcm_eq_of_ne_zero

### DIFF
--- a/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/AuxResults.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/AuxResults.lean
@@ -28,12 +28,6 @@ namespace ArithmeticFunction.IsMultiplicative
 
 variable {R : Type*}
 
-theorem mult_lcm_eq_of_ne_zero [CommGroupWithZero R] (f : ArithmeticFunction R) (h_mult : f.IsMultiplicative) (x y : ℕ)
-    (hf : f (x.gcd y) ≠ 0) :
-    f (x.lcm y) = f x * f y / f (x.gcd y) := by
-  rw [←h_mult.lcm_apply_mul_gcd_apply]
-  field_simp
-
 theorem prod_factors_of_mult (f : ArithmeticFunction ℝ) (h_mult : ArithmeticFunction.IsMultiplicative f) {l : ℕ} (hl : Squarefree l) :
     ∏ a ∈ l.primeFactors, f a = f l := by
   rw [←IsMultiplicative.map_prod_of_subset_primeFactors h_mult l _ Finset.Subset.rfl,

--- a/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/Basic.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/Basic.lean
@@ -246,7 +246,7 @@ theorem lambdaSquared_mainSum_eq_quad_form (w : ℕ → ℝ) :
   rw [sum_comm, sum_congr rfl]; intro d2 hd2
   have h : d1.lcm d2 ∣ P := Nat.lcm_dvd_iff.mpr ⟨dvd_of_mem_divisors hd1, dvd_of_mem_divisors hd2⟩
   rw [←sum_intro (divisors P) (d1.lcm d2) (mem_divisors.mpr ⟨h, prodPrimes_ne_zero⟩ )]
-  rw [s.nu_mult.mult_lcm_eq_of_ne_zero]
+  rw [s.nu_mult.map_lcm]
   ring
   refine _root_.ne_of_gt (nu_pos_of_dvd_prodPrimes ?_)
   trans d1


### PR DESCRIPTION
It duplicates ArithmeticFunction.IsMultiplicative.map_lcm.