### PR TITLE
chore: drop Aux.sum_intro

### DIFF
--- a/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/AuxResults.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/AuxResults.lean
@@ -47,16 +47,6 @@ theorem sum_over_dvd_ite {α : Type _} [Ring α] {P : ℕ} (hP : P ≠ 0) {n : �
   by
   rw [←Finset.sum_filter, Nat.divisors_filter_dvd_of_dvd hP hn]
 
-theorem sum_intro {α M: Type _} [AddCommMonoid M] [DecidableEq α] (s : Finset α) {f : α → M} (d : α)
-     (hd : d ∈ s) :
-    f d = ∑ k ∈ s, if k = d then f k else 0 := by
-  trans (∑ k ∈ s, if k = d then f d else 0)
-  · rw [sum_eq_single_of_mem d hd]
-    rw [if_pos rfl]
-    intro _ _ h; rw [if_neg h]
-  apply sum_congr rfl; intro k _; apply if_ctx_congr Iff.rfl _ (fun _ => rfl)
-  intro h; rw [h]
-
 theorem ite_sum_zero {p : Prop} [Decidable p] (s : Finset ℕ) (f : ℕ → ℝ) :
     (if p then (∑ x ∈ s, f x) else 0) = ∑ x ∈ s, if p then f x else 0 := by
   split_ifs <;> simp

--- a/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/Basic.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/Basic.lean
@@ -208,7 +208,7 @@ theorem upperMoebius_of_lambda_sq (weights : ℕ → ℝ) (hw : weights 1 = 1) :
     apply sum_congr rfl; intro d1 hd1
     rw [sum_mul, sum_comm]
     apply sum_congr rfl; intro d2 hd2
-    rw [←Aux.sum_intro]
+    rw [sum_ite_eq_of_mem']
     ring
     rw [mem_divisors, Nat.lcm_dvd_iff]
     exact ⟨⟨dvd_of_mem_divisors hd1, dvd_of_mem_divisors hd2⟩, (mem_divisors.mp hd1).2⟩
@@ -245,7 +245,7 @@ theorem lambdaSquared_mainSum_eq_quad_form (w : ℕ → ℝ) :
   rw [sum_comm, sum_congr rfl]; intro d1 hd1
   rw [sum_comm, sum_congr rfl]; intro d2 hd2
   have h : d1.lcm d2 ∣ P := Nat.lcm_dvd_iff.mpr ⟨dvd_of_mem_divisors hd1, dvd_of_mem_divisors hd2⟩
-  rw [←sum_intro (divisors P) (d1.lcm d2) (mem_divisors.mpr ⟨h, prodPrimes_ne_zero⟩ )]
+  rw [sum_ite_eq_of_mem' (divisors P) (d1.lcm d2) _ (mem_divisors.mpr ⟨h, prodPrimes_ne_zero⟩ )]
   rw [s.nu_mult.mult_lcm_eq_of_ne_zero]
   ring
   refine _root_.ne_of_gt (nu_pos_of_dvd_prodPrimes ?_)

--- a/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/Selberg.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/NumberTheory/Sieve/Selberg.lean
@@ -145,7 +145,7 @@ lemma sum_mul_subst (k n: ℕ) {f : ℕ → ℝ} (h : ∀ l, l ∣ n → ¬ k �
       exact ⟨Trans.trans (Nat.div_dvd_of_dvd hkl) (dvd_of_mem_divisors hl), hn⟩
   · rw [sum_comm, sum_congr rfl]; intro m _
     split_ifs with hdvd
-    · rw [←Aux.sum_intro]
+    · rw [sum_ite_eq_of_mem']
       simp only [mem_divisors, hdvd, ne_eq, hn, not_false_eq_true, and_self]
     · apply sum_eq_zero; intro l hl
       apply if_neg;
@@ -218,7 +218,7 @@ theorem selbergWeights_diagonalisation (l : ℕ) (hl : l ∈ divisors P) :
       · tauto
       intro _; ring
     _ = if l ^ 2 ≤ y then g l * μ l * S⁻¹ else 0 := by
-      rw [Aux.sum_intro (f:=fun _ => if l^2 ≤ y then g l * μ l * S⁻¹ else 0) (divisors P) l hl]
+      rw [← sum_ite_eq_of_mem' (divisors P) l (fun _ => if l^2 ≤ y then g l * μ l * S⁻¹ else 0) hl]
       apply sum_congr rfl; intro k hk
       rw [Aux.moebius_inv_dvd_lower_bound_real s.prodPrimes_squarefree l _ (dvd_of_mem_divisors hk),
         ←ite_and, ite_zero_mul, ite_zero_mul, ← ite_and]
@@ -313,7 +313,7 @@ theorem selbergBoundingSum_ge {d : ℕ} (hdP : d ∣ P) :
     dsimp only [selbergBoundingSum]
     rw [sum_comm, sum_congr rfl]; intro l _
     simp_rw [ite_and]
-    rw [←Aux.sum_intro]
+    rw [sum_ite_eq_of_mem']
     · rw [mem_divisors]
       exact ⟨(Nat.gcd_dvd_left d l).trans (hdP), prodPrimes_ne_zero⟩
   _ = (∑ k ∈ divisors P,


### PR DESCRIPTION
It's a duplicate of Finset.sum_ite_eq_of_mem'.