### PR TITLE
chore: bump LeanArchitect to fix bug

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -25,7 +25,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "ec3dab3002591039b465a2a40aee021dbda8a798",
+   "rev": "a9a1978acc9ee76c84bfd31c403599e6ce0020c8",
    "name": "LeanArchitect",
    "manifestFile": "lake-manifest.json",
    "inputRev": "v4.26.0",


### PR DESCRIPTION
Currently if a single LaTeX label corresponds to multiple Lean declarations in `@[blueprint]` tags, such as for `"fks2-lemma-20"`, two duplicate nodes appear in the blueprint. This PR introduces the bugfix in LeanArchitect that deduplicates nodes in the blueprint appropriately. Additionally, the `title` and `statement` fields are correctly merged between these declarations — the `statement` can now be specified by any declaration with label `"fks2-lemma-20"`, rather than the last.

Bug:
<img width="580" height="246" alt="image" src="https://github.com/user-attachments/assets/f334b0f0-3c25-4d13-b49c-4e16de74a986" />
