### PR TITLE
fix(Erdos392): fix misformalisation of `total_imbalance`

### DIFF
--- a/PrimeNumberTheoremAnd/Erdos392.lean
+++ b/PrimeNumberTheoremAnd/Erdos392.lean
@@ -44,7 +44,8 @@ def Factorization.balance {n : ℕ} (f : Factorization n) (p : ℕ) : ℤ := f.s
   (statement := /--
   The total imbalance of a factorization $a_1 \dots a_t$ is the sum of absolute values of the balances at each prime.
   -/)]
-def Factorization.total_imbalance {n : ℕ} (f : Factorization n) : ℕ := (∑ p ∈ (n+1).primesBelow, f.balance p).natAbs
+def Factorization.total_imbalance {n : ℕ} (f : Factorization n) : ℕ :=
+  ∑ p ∈ (n+1).primesBelow, (f.balance p).natAbs
 
 @[blueprint
   "balance-zero"


### PR DESCRIPTION
The definition is now fixed to match the blueprint `∑ p ∈ (n+1).primesBelow, (f.balance p).natAbs` (i.e. sum of absolute values) instead of `(∑ p ∈ (n+1).primesBelow, f.balance p).natAbs` (absolute value of sum).