### PR TITLE
Proved lemma 12 ( limiting_fourier_variant ), corollary 4 ( crude_upper_bound ) from the first approach

### DIFF
--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -3210,7 +3210,7 @@ In this section we do *not* assume the bound \eqref{cheby}, but instead derive i
 @[blueprint "limiting-fourier-variant"
   (title := "limiting-fourier-variant")
   (statement := /--
-    If $\psi: \R \to \C$ is $C^2$ and compactly supported with $f$ and $\hat \psi$ non-negative, and $0 \lt x$, then
+    If $\psi: \R \to \C$ is $C^2$ and compactly supported with $f$ and $\hat \psi$ non-negative, and $0 < x$, then
   $$ \sum_{n=1}^\infty \frac{f(n)}{n} \hat \psi( \frac{1}{2\pi} \log \frac{n}{x} ) - A \int_{-\log x}^\infty \hat \psi(\frac{u}{2\pi})\ du =  \int_\R G(1+it) \psi(t) x^{it}\ dt.$$
   -/)
   (proof := /-- Repeat the proof of Lemma \ref{limiting-fourier-variant}, but use monotone convergence instead of dominated convergence.  (The proof should be simpler, as one no longer needs to establish domination for the sum.) -/)


### PR DESCRIPTION
1. This PR fills in the gaps for Lemma 12 (limiting_fourier_variant) and Corollary 4 (crude_upper_bound).

2. It also generalizes the input "hx: 1 ≤ x" of Lemma 12 to "hx: 0 < x". The reason is as follows:
   - The proof for Corollary 4 in the blueprint seems incorrect. It claims that "for x < 1, only a bounded number of summands can contribute," 
     but \hat{\psi} or f is not compactly supported (only \psi is). This issue can be resolved if Lemma 12 is generalized to x < 1 as well.

3. To prove Lemma 12, this PR also generalizes some existing lemmas from the "1 ≤ x" case to the "0 < x" case, along with additional lemmas about montone convergence.