### PR TITLE
Correct the statement of `prod_epsilon_ge`.

### DIFF
--- a/PrimeNumberTheoremAnd/Lcm.lean
+++ b/PrimeNumberTheoremAnd/Lcm.lean
@@ -1230,7 +1230,7 @@ theorem prod_epsilon_le (ε : ℝ) (hε : 0 ≤ ε ∧ ε ≤ 1 / (89693 ^ 2 : �
     \Bigl(1 + \frac{3}{8}\varepsilon\Bigr)
     \Bigl(1 - \frac{4 \times 1.000675^{12}}{89693}\varepsilon\Bigr)
     \ge
-    1 + 3.36687\varepsilon - 0.01\varepsilon^2.
+    1 + 3.36683\varepsilon - 0.01\varepsilon^2.
   \]
   -/)
   (proof := /--
@@ -1257,18 +1257,18 @@ theorem prod_epsilon_ge (ε : ℝ) (hε : 0 ≤ ε ∧ ε ≤ 1 / (89693 ^ 2 : �
   For \(0 \le \varepsilon \le 1/89693^2\), we have
   \[
     1 + 3.01\varepsilon + 3.01\varepsilon^2 + 1.01\varepsilon^3
-    \le 1 + 3.36687\varepsilon - 0.01\varepsilon^2.
+    \le 1 + 3.36683\varepsilon - 0.01\varepsilon^2.
   \]
   -/)
   (proof := /--
   This is equivalent to
   \[
     3.01\varepsilon + 3.01\varepsilon^2 + 1.01\varepsilon^3
-    \le 3.36687\varepsilon - 0.01\varepsilon^2,
+    \le 3.36683\varepsilon - 0.01\varepsilon^2,
   \]
   or
   \[
-    0 \le (3.36687 - 3.01)\varepsilon - (3.01+0.01)\varepsilon^2 - 1.01\varepsilon^3.
+    0 \le (3.36683 - 3.01)\varepsilon - (3.01+0.01)\varepsilon^2 - 1.01\varepsilon^3.
   \]
   Factor out \(\varepsilon\) and use that \(0<\varepsilon \le 1/89693^2\) to check that the
   resulting quadratic in \(\varepsilon\) is nonnegative on this interval.  Again, this is a


### PR DESCRIPTION
We should divide `1 + 1/89693` instead of multiplying it.

I used `* (1 / (1 + 1/89693))` because this is the formulation used in `inv_n_add_sqrt_ge`, which makes it easy for me to finish #512
