### PR TITLE
feat[LCM]: Lower bound the product ratio p_i/q_i

### DIFF
--- a/PrimeNumberTheoremAnd/Lcm.lean
+++ b/PrimeNumberTheoremAnd/Lcm.lean
@@ -1099,7 +1099,6 @@ theorem pq_ratio_ge {n : ℕ} (hn : n ≥ X₀ ^ 2) :
   · exact fun _ _ => by positivity [hε_pos hn]
   · exact (exists_q_primes hn).choose_spec.2.2.1 _
 
-
 blueprint_comment /--
 \subsection{Reduction to a small epsilon-inequality}
 -/


### PR DESCRIPTION
Three things are done in this PR.
1. I provide a proof of `pq_ratio_ge`.
2. Some trivial lemmas about positivity of a number are proved repeatedly in different theorems, so I pull them out to make the code more compact.
3. I also fixed a typo: I changed `1 + 3.37arepsilon - 0.01arepsilon^2` into `1 + 3.36683arepsilon - 0.01arepsilon^2` in the docstring before `prod_epsilon_le`.

Closes #534