### PR TITLE
fix(Rosser): fix misformalised statements

### DIFF
--- a/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
+++ b/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
@@ -88,11 +88,13 @@ theorem eq_413 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) {x : 
   $$ + \frac{f(x) (\vartheta(x) - x)}{\log x} - \int_2^x (\vartheta(y) - y) \frac{d}{dy} \frac{d}{dy}( \frac{f(y)}{\log y} )\ dy.$$ -/)
   (proof := /-- Follows from Sublemma \ref{rs-413} and integration by parts. -/)
   (latexEnv := "sublemma")]
-theorem eq_414 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) (x : ℝ) :
-    ∑ p ∈ filter Prime (range ⌊x⌋₊), f p =
+theorem eq_414 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) {x : ℝ} (hx : 2 ≤ x) :
+    ∑ p ∈ filter Prime (Iic ⌊x⌋₊), f p =
       ∫ y in 2..x, f y / log y + 2 * f 2 / Real.log 2 +
       f x * (θ x - x) / log x -
-      ∫ y in 2..x, (θ y - y) * deriv (fun t ↦ deriv (fun s ↦ f s / log s) t) y := by sorry
+      ∫ y in 2..x, (θ y - y) * deriv (fun t ↦ deriv (fun s ↦ f s / log s) t) y := by
+  sorry
+
 
 @[blueprint
   "rs-416"
@@ -111,9 +113,9 @@ noncomputable def L (f : ℝ → ℝ) : ℝ :=
   $$ + \frac{f(x) (\vartheta(x) - x)}{\log x} + \int_x^\infty (\vartheta(y) - y) \frac{d}{dy} \frac{d}{dy}( \frac{f(y)}{\log y} )\ dy.$$ -/)
   (proof := /-- Follows from Sublemma \ref{rs-414} and Definition \ref{rs-416}. -/)
   (latexEnv := "sublemma")]
-theorem eq_415 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) (x : ℝ)
+theorem eq_415 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) {x : ℝ} (hx : 2 ≤ x)
    (hbound : ∃ C, ∀ x ∈ Set.Ici 2, |f x| ≤ C / x ∧ |deriv f x| ≤ C / x ^ 2) :
-   ∑ p ∈ filter Prime (range ⌊x⌋₊), f p = ∫ y in 2..x, f y / log y + L f +
+   ∑ p ∈ filter Prime (Iic ⌊x⌋₊), f p = ∫ y in 2..x, f y / log y + L f +
     f x * (θ x - x) / log x + ∫ y in Set.Ioi x, (θ y - y) * deriv (fun t ↦ deriv (fun s ↦ f s / log s) t) y := by sorry
 
 @[blueprint
@@ -154,8 +156,8 @@ theorem mertens_second_theorem : Filter.atTop.Tendsto (fun x : ℝ ↦
 -/)
   (proof := /-- Follows from Sublemma \ref{rs-413} applied to $f(t) = 1/t$. One can also use this identity to demonstrate convergence of the limit defining $B$.-/)
   (latexEnv := "sublemma")]
-theorem eq_419 (x : ℝ) :
-    ∑ p ∈ filter Prime (range ⌊x⌋₊), 1 / p =
+theorem eq_419 {x : ℝ} (hx : 2 ≤ x) :
+    ∑ p ∈ filter Prime (Iic ⌊x⌋₊), 1 / p =
       log (log x) + B + (θ x - x) / (x * log x) - ∫ y in 2..x, (θ y - y) * (1 + log y) / (y ^ 2 * log y ^ 2) := by sorry
 
 @[blueprint
@@ -177,8 +179,8 @@ theorem mertens_first_theorem : Filter.atTop.Tendsto (fun x : ℝ ↦
 -/)
   (proof := /-- Follows from Sublemma \ref{rs-413} applied to $f(t) = \log t / t$.  Convergence will need Theorem \ref{rs-pnt}. -/)
   (latexEnv := "sublemma")]
-theorem eq_420 (x : ℝ) :
-    ∑ p ∈ filter Prime (range ⌊x⌋₊), Real.log p / p =
+theorem eq_420 {x : ℝ} (hx : 2 ≤ x) :
+    ∑ p ∈ filter Prime (Iic ⌊x⌋₊), Real.log p / p =
       log x + E + (θ x - x) / x - ∫ y in 2..x, (θ y - y) / (y ^ 2) := by sorry
 
 @[blueprint


### PR DESCRIPTION
This PR fixes misformalised statements disproved by @Aristotle-Harmonic: 
- `pre_413`
- `eq_413`
- `eq_414`
- `eq_415`
- `eq_418`
- `eq_419`
- `eq_420`

Co-authored-by: Aristotle (Harmonic) [aristotle-harmonic@harmonic.fun](mailto:aristotle-harmonic@harmonic.fun).