### PR TITLE
slight speedup of Consequences, removing unused imports

### DIFF
--- a/PrimeNumberTheoremAnd/Consequences.lean
+++ b/PrimeNumberTheoremAnd/Consequences.lean
@@ -1,11 +1,4 @@
 import Architect
-import Mathlib.Algebra.Order.Floor.Semifield
-import Mathlib.Analysis.Asymptotics.Lemmas
-import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
-import Mathlib.NumberTheory.Chebyshev
-import Mathlib.NumberTheory.PrimeCounting
 import Mathlib.NumberTheory.Harmonic.Bounds
 import PrimeNumberTheoremAnd.Mathlib.Analysis.SpecialFunctions.Log.Basic
 import PrimeNumberTheoremAnd.Wiener


### PR DESCRIPTION
Imports removed:
(Mathlib.Analysis.Polynomial.Basic
Mathlib.Analysis.Asymptotics.SpecificAsymptotics
Mathlib.NumberTheory.AbelSummation
Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts)

Saves ~4s