### PR TITLE
fix(Rosser): add parentheses around integrals

### DIFF
--- a/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
+++ b/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
@@ -82,7 +82,7 @@ theorem eq_413 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) {x : 
   (discussion := 600)]
 theorem eq_414 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) {x : ℝ} (hx : 2 ≤ x) :
     ∑ p ∈ filter Prime (Iic ⌊x⌋₊), f p =
-      ∫ y in 2..x, f y / log y + 2 * f 2 / Real.log 2 +
+      (∫ y in 2..x, f y / log y) + 2 * f 2 / Real.log 2 +
       f x * (θ x - x) / log x -
       ∫ y in 2..x, (θ y - y) * deriv (fun s ↦ f s / log s) y := by
   sorry
@@ -108,7 +108,7 @@ noncomputable def L (f : ℝ → ℝ) : ℝ :=
   (discussion := 601)]
 theorem eq_415 {f : ℝ → ℝ} (hf : DifferentiableOn ℝ f (Set.Ici 2)) {x : ℝ} (hx : 2 ≤ x)
    (hbound : ∃ C, ∀ x ∈ Set.Ici 2, |f x| ≤ C / x ∧ |deriv f x| ≤ C / x ^ 2) :
-   ∑ p ∈ filter Prime (Iic ⌊x⌋₊), f p = ∫ y in 2..x, f y / log y + L f +
+   ∑ p ∈ filter Prime (Iic ⌊x⌋₊), f p = (∫ y in 2..x, f y / log y) + L f +
     f x * (θ x - x) / log x + ∫ y in Set.Ioi x, (θ y - y) * deriv (fun s ↦ f s / log s) y := by sorry
 
 @[blueprint


### PR DESCRIPTION
Otherwise lean will interpret `∫ y in 2..x, f y / log y + 2 * f 2 / Real.log 2` as

$$\int_2^x(\frac{f(y)}{\log y}+\frac{2f(2)}{\log 2})dy$$ instead of

$$\int_2^x\frac{f(y)}{\log y}dy + \frac{2f(2)}{\log 2}$$.