### PR TITLE
feat(Rosser): Second identity for sum over primes (4.14)

### DIFF
--- a/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
+++ b/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
@@ -111,16 +111,14 @@ theorem eq_414 {f : ℝ → ℝ} {x : ℝ} (hx : 2 ≤ x) (hf : DifferentiableOn
         (IntervalIntegrable.continuousOn_mul hd (by fun_prop))]
       · ring_nf
       · refine (intervalIntegrable_iff_integrableOn_Ioc_of_le hx).2 ?_
-        have hsm : AEStronglyMeasurable (fun t => θ t - t) (volume.restrict (Set.Ioc 2 x)) := by
-          refine AEStronglyMeasurable.sub ?_ (by fun_prop)
-          sorry
         have hb : ∀ᵐ y ∂volume.restrict (Set.Ioc 2 x), ‖θ y - y‖ ≤ θ x + x := by
           refine ae_restrict_of_forall_mem measurableSet_Ioc (fun y hy => ?_)
           calc
           _ ≤ ‖θ y‖ + ‖y‖ := by bound
           _ = θ y + y := by rw [norm_of_nonneg (theta_nonneg y), norm_of_nonneg (by grind : 0 ≤ y)]
           _ ≤ θ x + x := add_le_add (theta_mono hy.2) hy.2
-        exact ((intervalIntegrable_iff_integrableOn_Ioc_of_le hx).1 hd).bdd_mul hsm hb
+        exact ((intervalIntegrable_iff_integrableOn_Ioc_of_le hx).1 hd).bdd_mul
+          (AEStronglyMeasurable.sub theta_mono.measurable.aestronglyMeasurable (by fun_prop)) hb
     _ = f x * (θ x - x) / log x +
       ((∫ y in 2..x, 1 * (f y / log y)+ y * derivWithin (fun t ↦ f t / log t) (Set.uIcc 2 x) y) +
       2 * f 2 / log (2 : ℝ)) -


### PR DESCRIPTION
I changed the assumption from `DifferentiableOn ℝ f (Set.Ici 2)` to `DifferentiableOn ℝ f (Set.Icc 2 x)`. In order to integrate by parts, we also need the derivative of `fun t => f t / log t` to be integrable, so I also include this assumption in the theorem.
