### PR TITLE
feat(Costa): prove `sublemma_1_5`

### DIFF
--- a/PrimeNumberTheoremAnd/CostaPereira.lean
+++ b/PrimeNumberTheoremAnd/CostaPereira.lean
@@ -1,6 +1,6 @@
 import PrimeNumberTheoremAnd.SecondaryDefinitions
 
-open Chebyshev Finset Nat Real
+open Chebyshev Finset Nat Real Filter
 
 blueprint_comment /--
 \section{An inequality of Costa-Pereira}
@@ -19,42 +19,37 @@ namespace CostaPereira
   (proof := /-- This follows directly from the definitions of $\psi$ and $\theta$. -/)
   (latexEnv := "sublemma")
   (discussion := 676)]
-theorem sublemma_1_1 {x : ℝ} (hx : 0 < x) : ψ x = ∑' (k : ℕ), θ (x ^ (1 / (k : ℝ))) := by
-  have theta_zero_large_k : ∀ k, k ∉ Icc 0 ⌊log x / Real.log 2⌋₊ → θ (x ^ (1 / (k : ℝ))) = 0 := by
-    intro k hk
-    simp only [mem_Icc, zero_le, true_and, not_le] at hk
-    apply theta_eq_zero_of_lt_two
-    by_cases hk0 : k = 0
-    · simp [hk0, CharP.cast_eq_zero, div_zero, rpow_zero, one_lt_ofNat]
-    have hk_pos : (k : ℝ) > 0 := cast_pos.mpr <| pos_of_ne_zero hk0
+theorem sublemma_1_1 {x : ℝ} (hx : 0 < x) : ψ x = ∑' (k : ℕ), θ (x ^ (1 / ((k.succ : ℕ) : ℝ))) := by
+  have theta_zero_large_k : ∀ k : ℕ, ⌊log x / Real.log 2⌋₊ ≤ k →
+      θ (x ^ (1 / ((k.succ : ℕ) : ℝ))) = 0 := by
+    refine fun k hk ↦ theta_eq_zero_of_lt_two ?_
     by_cases hx1 : x < 1
-    · linarith [rpow_le_one hx.le hx1.le <| one_div_cast_nonneg k]
-    have h1 : log x / Real.log 2 < k := by
+    · linarith [rpow_le_one hx.le hx1.le <| one_div_cast_nonneg k.succ]
+    have : log x / Real.log 2 < k.succ := by
       calc log x / Real.log 2 < ⌊log x / Real.log 2⌋₊ + 1 := lt_floor_add_one _
-        _ ≤ k := by exact_mod_cast hk
-    have : Real.log x < k * Real.log 2 := by linarith [(div_lt_iff₀ <| log_pos <| one_lt_two).mp h1]
-    have : Real.log x < Real.log (2 ^ (k : ℕ)) := by rw [Real.log_pow]; exact this
-    have : x < 2 ^ (k : ℕ) := (Real.log_lt_log_iff hx (by positivity)).mp this
-    calc x ^ (1 / (k : ℝ)) = x ^ ((k : ℝ)⁻¹) := by rw [one_div]
-      _ < (2 ^ (k : ℕ)) ^ ((k : ℝ)⁻¹) := rpow_lt_rpow hx.le this <| inv_pos.mpr hk_pos
-      _ = 2 ^ ((k : ℕ) * (k : ℝ)⁻¹) := by rw [← rpow_natCast, ← rpow_mul <| zero_le_two]
-      _ = 2 ^ (1 : ℝ) := by congr 1; field_simp
-      _ = 2 := rpow_one 2
-  rw [tsum_eq_sum (s := Icc 0 ⌊log x / Real.log 2⌋₊) theta_zero_large_k]
+        _ ≤ k + 1 := by exact_mod_cast Nat.add_le_add_right hk 1
+        _ = (k.succ : ℝ) := by simp [succ_eq_add_one]
+    have : Real.log x < k.succ * Real.log 2 := by
+      linarith [(div_lt_iff₀ <| log_pos <| one_lt_two).mp this]
+    have : Real.log x < Real.log (2 ^ (k.succ : ℕ)) := by rw [Real.log_pow]; exact this
+    have : x < 2 ^ (k.succ : ℕ) := (log_lt_log_iff hx (by positivity)).mp this
+    calc x ^ (1 / ((k.succ : ℕ) : ℝ)) = x ^ (((k.succ : ℕ) : ℝ)⁻¹) := by rw [one_div]
+      _ < (2 ^ (k.succ : ℕ)) ^ (((k.succ : ℕ) : ℝ)⁻¹) := rpow_lt_rpow hx.le this <| inv_pos.mpr <| cast_pos.mpr k.succ_pos
+      _ = 2 := by rw [← rpow_natCast, ← rpow_mul zero_le_two, mul_inv_cancel₀, rpow_one]; positivity
+  rw [tsum_eq_sum (s := Iio ⌊log x / Real.log 2⌋₊) (fun k hk ↦ theta_zero_large_k k (not_lt.mp (mem_Iio.not.mp hk)))]
   by_cases hx1 : x < 1
-  · have hpsi : ψ x = 0 := psi_eq_zero_of_lt_two (by linarith)
-    refine hpsi ▸ (sum_eq_zero fun k _ ↦ theta_eq_zero_of_lt_two ?_).symm
-    have h_exp_le : x ^ (1 / (k : ℝ)) ≤ 1 := by
-      by_cases hk0 : k = 0
-      · simp [hk0]
-      · exact rpow_le_one hx.le hx1.le <| one_div_cast_nonneg k
-    linarith
-  rw [sum_eq_sum_diff_singleton_add (i := 0) <| insert_eq_self.mp rfl]
-  have : θ (x ^ (1 / (0 : ℕ) : ℝ)) = 0 := by
-    rw [cast_zero, div_zero, rpow_zero]; exact theta_eq_zero_of_lt_two <| by grind
-  simp only [this, add_zero]
-  have h_eq : Icc 0 ⌊log x / Real.log 2⌋₊ \ {0} = Icc 1 ⌊log x / Real.log 2⌋₊ := ((fun {_} ↦ val_inj.mp) rfl).symm
-  simpa [h_eq, theta, psi] using psi_eq_sum_theta hx.le
+  · have : ψ x = 0 := psi_eq_zero_of_lt_two <| by linarith
+    refine this ▸ (sum_eq_zero fun k _ ↦ theta_eq_zero_of_lt_two ?_).symm
+    linarith [rpow_le_one hx.le hx1.le <| one_div_cast_nonneg k.succ]
+  have h_eq : ∑ k ∈ Iio ⌊log x / Real.log 2⌋₊, θ (x ^ (1 / (↑k.succ : ℝ))) =
+      ∑ k ∈ Icc 1 ⌊log x / Real.log 2⌋₊, θ (x ^ (1 / (↑k : ℝ))) := by
+    refine sum_bij' (fun k _ ↦ k.succ) (fun k _ ↦ k.pred)
+        (fun k hk ↦ mem_Icc.mpr ⟨k.succ_pos, mem_Iio.mp hk⟩)
+        (fun k hk ↦ by have ⟨hk1, hk2⟩ := mem_Icc.mp hk; exact mem_Iio.mpr (pred_lt_pred
+          (one_le_iff_ne_zero.mp hk1) (lt_succ_of_le hk2))) (fun k _ ↦ Nat.pred_succ k)
+            (fun k hk ↦ succ_pred_eq_of_pos (mem_Icc.mp hk).1) (fun _ _ ↦ rfl)
+  rw [h_eq]
+  simpa using psi_eq_sum_theta hx.le
 
 @[blueprint
   "costa-pereira-sublemma-1-2"
@@ -63,8 +58,10 @@ theorem sublemma_1_1 {x : ℝ} (hx : 0 < x) : ψ x = ∑' (k : ℕ), θ (x ^ (1 
   (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-1} and substitution.-/)
   (latexEnv := "sublemma")
   (discussion := 677)]
-theorem sublemma_1_2 {x : ℝ} (hx : 0 < x) (n : ℝ) : ψ (x ^ (1 / n:ℝ)) = ∑' (k : ℕ), θ (x ^ (1 / (n * (k:ℝ)))) := by
-  simp_rw [sublemma_1_1 (rpow_pos_of_pos hx _), ← rpow_mul (le_of_lt hx), _root_.div_mul_div_comm, one_mul]
+theorem sublemma_1_2 {x : ℝ} (hx : 0 < x) (n : ℝ) :
+    ψ (x ^ (1 / n : ℝ)) = ∑' (k : ℕ), θ (x ^ (1 / (n * ((k.succ : ℕ) : ℝ)))) := by
+  simp_rw [sublemma_1_1 (rpow_pos_of_pos hx _), ← rpow_mul (le_of_lt hx), _root_.div_mul_div_comm,
+    one_mul]
 
 @[blueprint
   "costa-pereira-sublemma-1-3"
@@ -78,7 +75,7 @@ theorem sublemma_1_2 {x : ℝ} (hx : 0 < x) (n : ℝ) : ψ (x ^ (1 / n:ℝ)) = �
   (latexEnv := "sublemma")
   (discussion := 678)]
 theorem sublemma_1_3 {x : ℝ} (hx : 0 < x) :
-    ψ x = θ x + ψ (x ^ (1 / 2 : ℝ)) + ∑' k, θ (x ^ (1 / (2 * (k : ℝ) + 1))) := by sorry
+    ψ x = θ x + ψ (x ^ (1 / 2 : ℝ)) + ∑' (k : ℕ), θ (x ^ (1 / (2 * (k.succ : ℝ) + 1))) := by sorry
 
 @[blueprint
   "costa-pereira-sublemma-1-4"
@@ -93,9 +90,9 @@ theorem sublemma_1_3 {x : ℝ} (hx : 0 < x) :
   (discussion := 679)]
 theorem sublemma_1_4 {x : ℝ} (hx : 0 < x) :
     ψ x - θ x = ψ (x ^ (1 / 2 : ℝ)) +
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * (k : ℝ) - 3))) +
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * (k : ℝ) - 1))) +
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * (k : ℝ) + 1))) := by sorry
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ : ℕ) : ℝ) - 3))) +
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ : ℕ) : ℝ) - 1))) +
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ : ℕ) : ℝ) + 1))) := by sorry
 
 @[blueprint
   "costa-pereira-sublemma-1-5"
@@ -109,50 +106,60 @@ theorem sublemma_1_4 {x : ℝ} (hx : 0 < x) :
   (latexEnv := "sublemma")
   (discussion := 680)]
 theorem sublemma_1_5 {x : ℝ} (hx : 0 < x) :
-    ψ (x ^ (1 / 3 : ℝ)) =
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((Nat.succ k : ℕ) : ℝ) - 3))) +
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((Nat.succ k : ℕ) : ℝ)))) := by
-      rw [sublemma_1_2 hx (3 : ℝ)]
-      have eventually_theta_eq_zero {x : ℝ} (hx : 0 < x) : ∀ᶠ k : ℕ in Filter.atTop, θ (x ^ (1 / (3 * (2 * k : ℝ)))) = 0 := by
-        have h_lim : Filter.Tendsto (fun k : ℕ => x ^ (1 / (6 * k) : ℝ)) Filter.atTop (nhds 1) := by
-          simpa using tendsto_const_nhds.rpow ( tendsto_inv_atTop_nhds_zero_nat.comp ( Filter.tendsto_id.nsmul_atTop ( by norm_num ) ) ) ( by aesop );
-        filter_upwards [ h_lim.eventually ( gt_mem_nhds one_lt_two ) ] with k hk using theta_eq_zero_of_lt_two <| by ring_nf at *; linarith;
-      have theta_one_equals_zero : θ 1 = 0 := by
-        unfold Chebyshev.theta; norm_num [ Finset.sum_filter, Finset.sum_range_succ ]
-      have summable_of_eventually_zero {f : ℕ → ℝ} (hf : ∀ᶠ n in Filter.atTop, f n = 0) : Summable f := by
-        rw [ Filter.eventually_atTop ] at hf; obtain ⟨ N, hN ⟩ := hf; exact summable_nat_add_iff N |>.1 <| by exact ⟨ _, hasSum_single 0 <| by aesop ⟩ ;
-      have summable_even {x : ℝ} {hx : 0 < x} :
-        Summable (fun k : ℕ ↦ θ (x ^ (1 / (3 * (2 * k : ℝ))))) := by
-        convert summable_of_eventually_zero ( eventually_theta_eq_zero hx ) using 1
-      have summable_test_odd {x : ℝ} (hx : 0 < x) :
-        Summable (fun k : ℕ ↦ θ (x ^ (1 / (3 * (↑(2 * k + 1) : ℝ))))) := by
-          have h_theta_zero : ∀ᶠ k : ℕ in Filter.atTop, θ (x ^ (1 / (3 * (↑(2 * k + 1) : ℝ)))) = 0 := by
-            obtain ⟨N, hN⟩ : ∃ N : ℕ, ∀ k ≥ N, x ^ (1 / (3 * (2 * k + 1) : ℝ)) < 2 := by
-              have h_lim : Filter.Tendsto (fun k : ℕ => x ^ (1 / (3 * (2 * k + 1) : ℝ))) Filter.atTop (nhds 1) := by
-                simpa using tendsto_const_nhds.rpow ( tendsto_inv_atTop_zero.comp <| Filter.Tendsto.const_mul_atTop ( by positivity ) <| Filter.tendsto_atTop_mono ( fun k => by linarith ) tendsto_natCast_atTop_atTop ) ( by aesop );
-              simpa using h_lim.eventually ( gt_mem_nhds <| by norm_num );
-            filter_upwards [ Filter.eventually_ge_atTop N ] with k hk using theta_eq_zero_of_lt_two <| by simpa using hN k hk;
-          apply summable_of_eventually_zero; exact h_theta_zero
-      rw [← tsum_even_add_odd
-        (by simpa using summable_even (x := x) (hx := hx))
-        (by simpa using summable_test_odd (x := x) (hx := hx))]
-      rw [add_comm]
-      congr 1
-      · apply tsum_congr
-        intro k
-        congr 1
-        congr 1
-        push_cast
-        ring
-      · rw [Summable.tsum_eq_zero_add (by simpa using summable_even (x := x) (hx := hx))]
-        simp only [mul_zero, Nat.cast_zero, div_zero, Real.rpow_zero]
-        rw [show θ 1 = 0 from theta_one_equals_zero, zero_add]
-        apply tsum_congr
-        intro k
-        congr 1
-        congr 1
-        push_cast
-        ring
+    ψ (x ^ (1 / 3 : ℝ)) = ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ : ℕ) : ℝ) - 3))) +
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ : ℕ) : ℝ)))) := by
+  rw [sublemma_1_2 hx (3 : ℝ)]
+  have eventually_theta_eq_zero {x : ℝ} (hx : 0 < x) :
+      ∀ᶠ k : ℕ in atTop, θ (x ^ (1 / (3 * (2 * k : ℝ)))) = 0 := by
+    have h_lim : Tendsto (fun k : ℕ ↦ x ^ (1 / (6 * k) : ℝ)) atTop (nhds 1) := by
+      simpa using tendsto_const_nhds.rpow
+        (tendsto_inv_atTop_nhds_zero_nat.comp (tendsto_id.nsmul_atTop (by norm_num)))
+        (by grind)
+    filter_upwards [h_lim.eventually (gt_mem_nhds one_lt_two)] with k hk
+      using theta_eq_zero_of_lt_two <| by ring_nf at *; linarith
+  have theta_one_equals_zero : θ 1 = 0 := by norm_num [theta, sum_filter, sum_range_succ]
+  have summable_of_eventually_zero {f : ℕ → ℝ} (hf : ∀ᶠ n in atTop, f n = 0) : Summable f := by
+    rw [eventually_atTop] at hf
+    obtain ⟨N, hN⟩ := hf
+    exact summable_nat_add_iff N |>.1 <| by exact ⟨_, hasSum_single 0 <| by grind⟩
+  have summable_even {x : ℝ} {hx : 0 < x} : Summable (fun k : ℕ ↦ θ (x ^ (1 / (3 * (2 * k : ℝ))))) := by
+    convert summable_of_eventually_zero (eventually_theta_eq_zero hx) using 1
+  have summable_test_odd {x : ℝ} (hx : 0 < x) : Summable (fun k : ℕ ↦ θ (x ^ (1 / (3 * (↑(2 * k + 1) : ℝ))))) := by
+    apply summable_of_eventually_zero
+    have : Tendsto (fun k : ℕ ↦ (2 * (k : ℝ) + 1)) atTop atTop :=
+      tendsto_atTop_add_const_right _ 1 (tendsto_natCast_atTop_atTop.const_mul_atTop zero_lt_two)
+    have : Tendsto (fun k : ℕ ↦ (3 * (2 * (k : ℝ) + 1))⁻¹) atTop (nhds 0) :=
+      tendsto_inv_atTop_zero.comp <| this.const_mul_atTop (by positivity)
+    have : Tendsto (fun k : ℕ ↦ x ^ (1 / (3 * (↑(2 * k + 1) : ℝ)))) atTop (nhds 1) := by
+      simp only [one_div]
+      rw [show (fun k : ℕ ↦ x ^ (3 * (↑(2 * k + 1) : ℝ))⁻¹) =
+        (fun k : ℕ ↦ x ^ (3 * (2 * (k : ℝ) + 1))⁻¹) from funext fun k ↦ by congr 1; push_cast; ring]
+      convert tendsto_const_nhds.rpow this (Or.inl hx.ne') using 1
+      simp [rpow_zero]
+    filter_upwards [this.eventually (gt_mem_nhds one_lt_two)] with k hk
+    exact theta_eq_zero_of_lt_two hk
+  have : Summable (fun n : ℕ ↦ θ (x ^ (1 / (3 * n) : ℝ))) := by
+    apply summable_of_eventually_zero
+    have h_lim : Tendsto (fun n : ℕ ↦ x ^ (1 / (3 * n) : ℝ)) atTop (nhds 1) := by
+      simpa using tendsto_const_nhds.rpow (tendsto_inv_atTop_nhds_zero_nat.comp
+        (tendsto_id.nsmul_atTop (by positivity))) (by grind)
+    filter_upwards [h_lim.eventually (gt_mem_nhds one_lt_two)] with n hn
+    exact theta_eq_zero_of_lt_two hn
+  have step1 : ∑' k : ℕ, θ (x ^ (1 / (3 * k.succ) : ℝ)) = ∑' n : ℕ, θ (x ^ (1 / (3 * n) : ℝ)) := by
+    rw [Summable.tsum_eq_zero_add this, cast_zero, mul_zero, div_zero, rpow_zero, theta_one_equals_zero, zero_add]
+  rw [step1]
+  set f : ℕ → ℝ := fun n ↦ θ (x ^ ((1 : ℝ) / (3 * n))) with hf
+  have : Summable (f ∘ (2 * ·)) := by
+    convert summable_even (x := x) (hx := hx) using 2 with k
+    simp only [hf, Function.comp_apply]; congr 2; push_cast; ring
+  have split := tsum_even_add_odd this <| hf ▸ summable_test_odd hx
+  simp only [hf, cast_mul, cast_ofNat, cast_add, cast_one] at split
+  rw [← split, add_comm]
+  congr 1
+  · exact tsum_congr fun k ↦ by congr 2; push_cast; ring
+  · rw [Summable.tsum_eq_zero_add (summable_even (x := x) (hx := hx))]
+    simp only [mul_zero, cast_zero, div_zero, rpow_zero, theta_one_equals_zero, zero_add]
+    exact tsum_congr fun k ↦ by congr 2; push_cast; ring
 
 @[blueprint
   "costa-pereira-sublemma-1-6"
@@ -169,9 +176,9 @@ theorem sublemma_1_6 {x : ℝ} (hx : 0 < x) :
     ψ x - θ x =
       ψ (x ^ (1 / 2:ℝ)) +
       ψ (x ^ (1 / 3:ℝ)) +
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * (k:ℝ) - 1))) -
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * (k:ℝ)))) +
-      ∑' (k : ℕ), θ (x ^ (1 / (6 * (k:ℝ) + 1))) := by
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ  : ℕ) : ℝ) - 1))) -
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ  : ℕ) : ℝ)))) +
+      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((k.succ  : ℕ) : ℝ) + 1))) := by
   rw [sublemma_1_4 hx, sublemma_1_5 hx]; ring
 
 @[blueprint
@@ -182,11 +189,12 @@ theorem sublemma_1_6 {x : ℝ} (hx : 0 < x) :
   \psi(x) - \theta(x) \leqslant \psi(x^{1/2}) + \psi(x^{1/3}) + \sum_{k \geqslant 1} \theta(x^{1/5k}
   \]
   -/)
-  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-6} and the fact that $\theta$ is an increasing function. -/)
+  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-6} and the fact that $\theta$
+  is an increasing function. -/)
   (latexEnv := "sublemma")
   (discussion := 682)]
 theorem sublemma_1_7 {x : ℝ} (hx : 0 < x) :
-    ψ x - θ x ≤ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ∑' (k : ℕ), θ (x ^ (1 / (5 * (k : ℝ)))) := by sorry
+    ψ x - θ x ≤ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ∑' (k : ℕ), θ (x ^ (1 / (5 * ((k.succ  : ℕ) : ℝ)))) := by sorry
 
 @[blueprint
   "costa-pereira-sublemma-1-8"
@@ -196,38 +204,37 @@ theorem sublemma_1_7 {x : ℝ} (hx : 0 < x) :
   \psi(x) - \theta(x) \geqslant \psi(x^{1/2}) + \psi(x^{1/3}) + \sum_{k \geqslant 1} \theta(x^{1/7k}
   \]
   -/)
-  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-6} and the fact that $\theta$ is an increasing function. -/)
+  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-6} and the fact that $\theta$
+  is an increasing function. -/)
   (latexEnv := "sublemma")
   (discussion := 683)]
 theorem sublemma_1_8 {x : ℝ} (hx : 0 < x) :
-    ψ x - θ x ≥ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ∑' (k : ℕ), θ (x ^ (1 / (7 * (k : ℝ)))) := by sorry
+    ψ x - θ x ≥ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ∑' (k : ℕ), θ (x ^ (1 / (7 * ((k.succ : ℕ) : ℝ)))) := by sorry
 
 @[blueprint
   "costa-pereira-theorem-1a"
   (title := "Costa-Pereira Theorem 1a")
   (statement := /-- For every $x > 0$ we have
   $\psi(x) - \theta(x) \leqslant \psi(x^{1/2}) + \psi(x^{1/3}) + \psi(x^{1/5})$. -/)
-  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-7} and Sublemma \ref{costa-pereira-sublemma-1-2}. -/)
+  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-7} and
+  Sublemma \ref{costa-pereira-sublemma-1-2}. -/)
   (latexEnv := "theorem")
   (discussion := 684)]
 theorem theorem_1a {x : ℝ} (hx : 0 < x) :
-    ψ x - θ x ≤ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ψ (x ^ (1 / 5 : ℝ)) := by
-  rw [show ψ (x ^ (1 / 5 : ℝ)) = ∑' k : ℕ, θ (x ^ (1 / (5 * (k : ℝ)))) from by
-    simp only [sublemma_1_1 <| rpow_pos_of_pos hx .., ← rpow_mul hx.le]; congr! 2; field_simp]
-  exact sublemma_1_7 hx
+    ψ x - θ x ≤ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ψ (x ^ (1 / 5 : ℝ)) :=
+  sublemma_1_2 hx 5 ▸ sublemma_1_7 hx
 
 @[blueprint
   "costa-pereira-theorem-1b"
   (title := "Costa-Pereira Theorem 1b")
   (statement := /-- For every $x > 0$ we have
   $\psi(x) - \theta(x) \geqslant \psi(x^{1/2}) + \psi(x^{1/3}) + \psi(x^{1/7})$. -/)
-  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-8} and Sublemma \ref{costa-pereira-sublemma-1-2}. -/)
+  (proof := /-- Follows from Sublemma \ref{costa-pereira-sublemma-1-8} and
+  Sublemma \ref{costa-pereira-sublemma-1-2}. -/)
   (latexEnv := "theorem")
   (discussion := 685)]
 theorem theorem_1b {x : ℝ} (hx : 0 < x) :
-    ψ x - θ x ≥ ψ (x ^ (1 / 2:ℝ)) + ψ (x ^ (1 / 3:ℝ)) + ψ (x ^ (1 / 7:ℝ)) := by
-  rw [show ψ (x ^ (1 / 7 : ℝ)) = ∑' k : ℕ, θ (x ^ (1 / (7 * (k : ℝ)))) from by
-    simp only [sublemma_1_1 <| rpow_pos_of_pos hx .., ← rpow_mul hx.le]; congr! 2; field_simp]
-  exact sublemma_1_8 hx
+    ψ x - θ x ≥ ψ (x ^ (1 / 2 : ℝ)) + ψ (x ^ (1 / 3 : ℝ)) + ψ (x ^ (1 / 7 : ℝ)) :=
+  sublemma_1_2 hx 7 ▸ sublemma_1_8 hx
 
 end CostaPereira


### PR DESCRIPTION
Changed the proof to use Nat.succ k, which is what the original paper used:

theorem sublemma_1_5 {x : ℝ} (hx : 0 < x) :
    ψ (x ^ (1 / 3 : ℝ)) =
      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((Nat.succ k : ℕ) : ℝ) - 3))) +
      ∑' (k : ℕ), θ (x ^ (1 / (6 * ((Nat.succ k : ℕ) : ℝ)))) := by

This, however, breaks the current solution for sublemma_1_6, which relies on sublemma_1_5.

Co-authored-by: Aristotle (Harmonic) [aristotle-harmonic@harmonic.fun](mailto:aristotle-harmonic@harmonic.fun).

Closes #680