### PR TITLE
feat[BKLNW]: Upper bound on theta(x^(1/2)), first case (Proposition 4(a))

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -107,7 +107,7 @@ theorem theorem_2 : ∀ b ≥ 0, ∀ x ≥ exp b,
   (statement := /-- $\theta(x) < x$ for all $1 \leq x \leq 10^{19}$. -/)
   (latexEnv := "sublemma")
   (proof := /-- This follows from Theorem \ref{buthe-theorem-2c}. -/)]
-theorem buthe_eq_1_7 : ∀ x ∈ Set.Icc 1 1e19, θ x < x := by sorry
+theorem buthe_eq_1_7 : ∀ x ∈ Set.Ioc 0 1e19, θ x < x := by sorry
 
 @[blueprint
   "bklnw-inputs"


### PR DESCRIPTION
I changed `hx₁' : ∀ x ∈ Set.Icc 1 x₁, θ x < x` in the definition of Inputs to `hx₁' : ∀ x ∈ Set.Ioc 0 x₁, θ x < x` because it is trivially true that when `0 < x <= 1`, `θ x < x`. I also proved nonstrict inequalities.

Apparently we need to modify the statement a little bit. I didn't even use `(hb : 7 ≤ b) (hi : b ≤ 2 * log I.x₁)` in my proof. I am not sure how to modify it as I don't really have a big picture of the entire article. But I believe even if we change the statement, the proof doesn't need to change much.

Closes #641