### PR TITLE
fix(ZetaAppendix): fix `lemma_abadsumas`

### DIFF
--- a/PrimeNumberTheoremAnd/ZetaAppendix.lean
+++ b/PrimeNumberTheoremAnd/ZetaAppendix.lean
@@ -1764,7 +1764,7 @@ theorem lemma_abadsumas {s : ℂ} (hs1 : s ≠ 1) (hsigma : 0 ≤ s.re) {a b : �
           |ϑ| / (2 * π ^ 2) * ((1 / ((1 - |ϑ|) ^ 3 : ℝ)) + 2 * (riemannZeta 3).re - 1)
       else
         s.re / 6
-    ∃ E : ℂ, ∑' n : ℤ, (FourierTransform.fourier f n + FourierTransform.fourier f (-n)) =
+    ∃ E : ℂ, ∑' n : ℕ, (FourierTransform.fourier f (n + 1) + FourierTransform.fourier f (-(n + 1 : ℤ))) =
       ((a ^ (-s) : ℂ) * g ϑ) / (2 * I) - ((b ^ (-s) : ℂ) * g ϑ_minus) / (2 * I) + E ∧
       ‖E‖ ≤ C / a ^ (s.re + 1) := by
   sorry


### PR DESCRIPTION
This PR fixes a misformalised statement automatically negated by @Aristotle-Harmonic.

In particular, @Aristotle-Harmonic disproved `lemma_abadsumas` finding the counterexample (`s=0`, `a=1/2`, `b=3/2`).

```lean4
theorem lemma_abadsumas {s : ℂ} (hs1 : s ≠ 1) (hsigma : 0 ≤ s.re) {a b : ℝ} (ha : 0 < a)
    (hab : a < b) (ha' : a.IsHalfInteger) (hb' : b.IsHalfInteger) (haτ : a > |s.im| / (2 * π)) :
    let ϑ : ℝ := s.im / (2 * π * a)
    let ϑ_minus : ℝ := s.im / (2 * π * b)
    let f : ℝ → ℂ := fun y ↦
      if a ≤ y ∧ y ≤ b then (y ^ (-s.re) : ℝ) * e (-(s.im / (2 * π)) * Real.log y) else 0
    let g : ℝ → ℂ := fun t ↦
      if t ≠ 0 then (1 / Complex.sin (π * t) : ℂ) - (1 / (π * t : ℂ)) else 0
    let C : ℝ :=
      if ϑ ≠ 0 then
        s.re / 2 * ((1 / (Complex.sin (π * ϑ) ^ 2 : ℂ)).re - (1 / ((π * ϑ) ^ 2 : ℂ)).re) +
          |ϑ| / (2 * π ^ 2) * ((1 / ((1 - |ϑ|) ^ 3 : ℝ)) + 2 * (riemannZeta 3).re - 1)
      else
        s.re / 6
    ∃ E : ℂ, ∑' n : ℤ, (Real.fourierIntegral f n + Real.fourierIntegral f (-n)) =
      ((a ^ (-s) : ℂ) * g ϑ) / (2 * I) - ((b ^ (-s) : ℂ) * g ϑ_minus) / (2 * I) + E ∧
      ‖E‖ ≤ C := by
  -- Wait, there's a mistake. We can actually prove the opposite.
  negate_state;
  -- Proof starts here:
  refine' ⟨ 0, _, _, 1 / 2, 3 / 2, _, _, _, _ ⟩ <;> norm_num [ Real.pi_pos.le ];
  · exact ⟨ 0, by norm_num ⟩;
  · refine' ⟨ ⟨ 1, _ ⟩, _ ⟩ <;> norm_num [ ZetaAppendix.e ];
    ...
```

So I have fixed: 
- the error bound so that it corresponds to the informal `statement` in LaTeX
- the double counting and more importantly the $n = 0$ in `∑' n : ℤ, (Real.fourierIntegral f n + Real.fourierIntegral f (-n))` substituting it with `∑' n : ℕ, (FourierTransform.fourier f (n + 1) + FourierTransform.fourier f (-(n + 1 : ℤ)))`.

Co-authored-by: Aristotle (Harmonic) [aristotle-harmonic@harmonic.fun](mailto:aristotle-harmonic@harmonic.fun).