### PR TITLE
fix(BKLNW_app_tables): fix def `table_8_ε'`

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW_app_tables.lean
+++ b/PrimeNumberTheoremAnd/BKLNW_app_tables.lean
@@ -303,7 +303,7 @@ noncomputable def table_8_ε (b : ℝ) : ℝ := sInf { ε | ∃ p ∈ table_8, p
 /-- Simplified form of table -/
 noncomputable def table_8_ε' (b : ℝ) : ℝ :=
   if b < 20 then 1   -- junk value
-  else if b < 21 then 4.2670e-5
+  else if b < 21 then 4.26760e-5
   else if b < 22 then 2.58843e-5
   else if b < 23 then 1.56996e-5
   else if b < 24 then 9.52229e-6


### PR DESCRIPTION
This PR fixes a misformalised definition thanks to @Aristotle-Harmonic.

In particular, @Aristotle-Harmonic negated `table_8_ε.le_simp` as follows:

```lean
/-
Check if the inequality fails at b=20.
-/
lemma check_disproof : BKLNW_app.table_8_ε 20 > BKLNW_app.table_8_ε' 20 := by
  norm_num [ BKLNW_app.table_8_ε, BKLNW_app.table_8_ε' ] at *;
  refine' lt_of_lt_of_le _ ( le_csInf _ _ );
  rotate_left;
  exact 4267 / 100000000 + 1 / 1000000000000;
  · exact ⟨ _, ⟨ 20, List.mem_cons.mpr ( Or.inl rfl ), by norm_num ⟩ ⟩;
  · norm_num +zetaDelta at *;
    intro b x hx hx'; fin_cases hx <;> norm_num at * ;
  · grind

end AristotleLemmas

/-
**BKLNW Table 8 vs expanded Table 8**

The value of $\eps(b)$ arising from Table 8 of [reference] is weaker than that from the expanded version of Table 8 available in the arXiv.
-/
theorem table_8_ε.le_simp (b : ℝ) (hb : b ≥ 20) : table_8_ε b ≤ table_8_ε' b := by
  -- Wait, there's a mistake. We can actually prove the opposite.
  negate_state;
  -- Proof starts here:
  -- By definition of $table_8_ε'$, we know that for $b = 20$, $table_8_ε' 20 = 4.2670e-5$.
  use 20
  simp [check_disproof]
```

Then I fixed the typo in the definition of `table_8_ε'` as suggested by @teorth in this [Zulip post](https://leanprover.zulipchat.com/#narrow/channel/423402-PrimeNumberTheorem.2B/topic/Starting.20on.20BKLNW/near/570364489).

Co-authored-by: Aristotle (Harmonic) [aristotle-harmonic@harmonic.fun](mailto:aristotle-harmonic@harmonic.fun).