### PR TITLE
fix(build): add path to references.bib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,4 @@ jobs:
         with:
           blueprint: true
           homepage: home_page
+          references: 'blueprint/src/references.bib'


### PR DESCRIPTION
Now that we bumped docgen-action in #885, we can add the path to references back in.