### PR TITLE
feat(BKLNW): prove `thm_5`

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -723,7 +723,7 @@ noncomputable def a₂ : ℝ → ℝ := Inputs.default.a₂
   (latexEnv := "corollary")
   (discussion := 743)]
 theorem cor_5_1 {b x : ℝ} (hb : b ≥ 7) (hx : x ≥ exp b) :
-    ψ x - θ x < a₁ b * x ^ (1 / 2 : ℝ) + a₂ b * x ^ (1 / 3 : ℝ) :=
+    ψ x - θ x ≤ a₁ b * x ^ (1 / 2 : ℝ) + a₂ b * x ^ (1 / 3 : ℝ) :=
   thm_5 Inputs.default hb hx
 
 def table_cor_5_1 : List (ℝ × ℝ × ℕ) :=


### PR DESCRIPTION
I have changed the strict inequality of the statement to a non strict one since otherwise the statement does not follow from `prop_4_a` and `prop_4_b`. In the original source material both theorem 5 and proposition 4 are stated with strict inequalities, even though their proofs seem to only show the results with non strict ones.

Closes #643