### PR TITLE
chore(workflows): temporarily downgrade docgen-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         run: python3 scripts/upstreaming_dashboard.py
 
       - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@99573be5e68d529995066f7c302b13e802783194 # 2026-02-04
+        uses: leanprover-community/docgen-action@deed0cdc44dd8e5de07a300773eb751d33e32fc8 # 2025-10-26
         with:
           blueprint: true
           homepage: home_page


### PR DESCRIPTION
Temporary workaround until https://github.com/leanprover-community/docgen-action/pull/23 lands.