### PR TITLE
feat[ROSSER]: medium prime number theorem for the Chebyshev function

### DIFF
--- a/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
+++ b/PrimeNumberTheoremAnd/RosserSchoenfeldPrime.lean
@@ -736,7 +736,7 @@ theorem eq_418 {x : ℝ} (hx : 2 ≤ x) :
   have := deriv_fun_inv'' (y.hasDerivAt_mul_log (by grind)).differentiableAt
     (mul_ne_zero_iff.2 ⟨by grind, by linarith [Real.log_pos (by grind : 1 < y)]⟩)
   simp only [neg_mul_eq_mul_neg, mul_div_assoc, mul_left_cancel_iff_of_pos
-    (Chebyshev.theta_pos hy.1), div_div, fun t : ℝ => one_div (t * log t), this,
+    (theta_pos hy.1), div_div, fun t : ℝ => one_div (t * log t), this,
     deriv_mul_log (by grind : y ≠ 0)]
   ring
 


### PR DESCRIPTION
`Chebyshev.theta_pos` can be deleted because my PR [#34084](https://github.com/leanprover-community/mathlib4/pull/34084) was merged.

Co-authored-by: Aristotle (Harmonic) [aristotle-harmonic@harmonic.fun](mailto:aristotle-harmonic@harmonic.fun).

Closes #597