### PR TITLE
chore(deps): update LeanCert to log/trig revision

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "2d5c725defddde9f355ed49be83227093f77056b",
+   "rev": "7632b3f0c496a3e082862b2b20f76b48d2f1a14d",
    "name": "leancert",
    "manifestFile": "lake-manifest.json",
    "inputRev": "v4.28.0-rc1",


### PR DESCRIPTION
# Description 

- Updates PNT to the latest LeanCert revision used for interval_decide log/trig bounds.
- After clean rebuild, #print axioms on LogTables lemmas now shows only:
      - propext, Classical.choice, Quot.sound, Lean.ofReduceBool, Lean.trustCompiler
- The previously reported LeanCert-specific axioms no longer appear in:
      - LogTables.log_2_gt
      - LogTables.log_3_gt
      - LogTables.log_5_lt