### PR TITLE
Fix/Align statements in the ramanujan_final proof chain

### DIFF
--- a/PrimeNumberTheoremAnd/Ramanujan.lean
+++ b/PrimeNumberTheoremAnd/Ramanujan.lean
@@ -19,15 +19,17 @@ noncomputable def ε (M x : ℝ) : ℝ := 72 + 2 * M + (2 * M + 132) / log x + (
 
 noncomputable def ε' (m x : ℝ) : ℝ := 206 + m + 364 / log x + 381 / (log x)^2 + 238 / (log x)^3 + 97 / (log x)^4 + 30 / (log x)^5 + 8 / (log x)^6
 
+noncomputable def εneg (m xₐ x : ℝ) : ℝ :=
+  206 + (1 + 1 / log xₐ)^6 * m
+    + 364 / log x
+    + 381 / (log x)^2
+    + 238 / (log x)^3
+    + 97 / (log x)^4
+    + 30 / (log x)^5
+    + 8 / (log x)^6
+
 noncomputable def εlower (m xₐ x : ℝ) : ℝ :=
-  if 0 ≤ m then ε' m x else
-    206 + (1 + 1 / log xₐ)^6 * m
-      + 364 / log x
-      + 381 / (log x)^2
-      + 238 / (log x)^3
-      + 97 / (log x)^4
-      + 30 / (log x)^5
-      + 8 / (log x)^6
+  if 0 ≤ m then ε' m x else εneg m xₐ x
 
 -- noncomputable def x' (m M x : ℝ) : ℝ := exp (ε M x - ε' m x)
 


### PR DESCRIPTION
- Align ex_pi_gt, criterion, and epsilon_bound statements in Ramanujan.lean.
  1. update `ex_pi_gt` signature to use `hx_a : 1 < x_a` and `εlower`
  2. update `criterion` assumptions (`hxₐ` and generalized `hcrit`)
  3. update `epsilon_bound` to the quantified form over `x > exₐ`
  4. update `ramanujan_final` proof body to pass the new `hxₐ` argument to criterion
- Keep existing sorry placeholders unchanged. 
- Add εneg and εlower to use it.
- No extra lemmas/theorems imported from Ramanujan_final.lean.

Rmk) All newly proved statements were already claimed, none of existing sorries are filled.