### PR TITLE
Ch2 fix statement of `prop_2_3`

### DIFF
--- a/PrimeNumberTheoremAnd/ZetaAppendix.lean
+++ b/PrimeNumberTheoremAnd/ZetaAppendix.lean
@@ -1229,13 +1229,6 @@ lemma deriv_e {φ : ℝ → ℝ} {t : ℝ} (hφ : DifferentiableAt ℝ φ t) :
   convert (Complex.hasDerivAt_exp _).comp t (hφ.hasDerivAt.ofReal_comp.const_mul (2 * π * I)) using 1
   ring
 
-lemma deriv_e {φ : ℝ → ℝ} {t : ℝ} (hφ : DifferentiableAt ℝ φ t) :
-    deriv (fun t ↦ e (φ t)) t = 2 * π * I * deriv φ t * e (φ t) := by
-  simp only [e]
-  apply HasDerivAt.deriv
-  convert (Complex.hasDerivAt_exp _).comp t (hφ.hasDerivAt.ofReal_comp.const_mul (2 * π * I)) using 1
-  ring
-
 theorem lemma_aachfour (s : ℂ) (hsigma : 0 ≤ s.re) (ν : ℝ) (hν : ν ≠ 0) (a b : ℝ)
     (ha : a > |s.im| / (2 * π * |ν|)) (hb : b > a) :
     let φ : ℝ → ℝ := fun t ↦ ν * t - (s.im / (2 * π)) * Real.log t


### PR DESCRIPTION
add potential missing hypotheses (hφ_cont : ContinuousAt φ 0) in #880
Without this hypothesis I don't think we can apply Fourier inversion formula e.g. [MeasureTheory.Integrable.fourier_fourierInv_eq](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/Fourier/Inversion.html#MeasureTheory.Integrable.fourier_fourierInv_eq)
 
Also add parentheses to goal. Currently the goal in lean states
$$\frac{1}{2 \pi T} \cdot \int_{-T}^T\left[\varphi(t / T) G(1+i t) x^{1+i t}+\left(\varphi(0)-\int_{-\infty}^{-T \log x / 2 \pi} \mathcal{F} \varphi(y) d y\right) \frac{x}{T}\right] d t$$

My proposed edit modifies the lean goal to $$\frac{1}{2 \pi T} \cdot\left(\int_{-T}^T \varphi(t / T) G(1+i t) x^{1+i t} d t\right)+\left(\varphi(0)-\int_{-\infty}^{-T \log x / 2 \pi} \mathcal{F} \varphi(y) d y\right) \frac{x}{T}$$

