### PR TITLE
feat(TMEEMT,CH2,ZetaSummary): prove 13 sorries

### DIFF
--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -456,7 +456,39 @@ theorem Phi_circ.poles (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
   (latexEnv := "lemma")
   (discussion := 1071)]
 theorem Phi_circ.residue (ν ε : ℝ) (hν : ν > 0) (n : ℤ) :
-    (nhdsWithin (n - I * ν / (2 * π)) {n - I * ν / (2 * π)}ᶜ).Tendsto (fun z ↦ (z - (n - I * ν / (2 * π))) * Phi_circ ν ε z) (nhds (I / (2 * π))) := by sorry
+    (nhdsWithin (n - I * ν / (2 * π)) {n - I * ν / (2 * π)}ᶜ).Tendsto (fun z ↦ (z - (n - I * ν / (2 * π))) * Phi_circ ν ε z) (nhds (I / (2 * π))) := by
+  set w := fun z : ℂ => -2 * Real.pi * I * z + ν
+  set w_div : ℂ → ℂ := fun z => w z / 2
+  have h_tanh : Filter.Tendsto (fun z => (z - (n - I * ν / (2 * Real.pi))) / Complex.tanh (w_div z)) (nhdsWithin (n - I * ν / (2 * Real.pi)) { (n - I * ν / (2 * Real.pi)) }ᶜ) (nhds (1 / (-Real.pi * I))) := by
+    have h_tanh_approx : Filter.Tendsto (fun z => Complex.tanh (w_div z) / (z - (n - I * ν / (2 * Real.pi)))) (nhdsWithin (n - I * ν / (2 * Real.pi)) { (n - I * ν / (2 * Real.pi)) }ᶜ) (nhds (-Real.pi * I)) := by
+      have h_deriv : HasDerivAt (fun z => Complex.tanh (w_div z)) (-Real.pi * I) (n - I * ν / (2 * Real.pi)) := by
+        have h_tanh_deriv : HasDerivAt (fun u => Complex.tanh u) (1 - Complex.tanh (w_div (n - I * ν / (2 * Real.pi))) ^ 2) (w_div (n - I * ν / (2 * Real.pi))) := by
+          convert HasDerivAt.div ( Complex.hasDerivAt_sinh _ ) ( Complex.hasDerivAt_cosh _ ) _ using 1 <;> norm_num [ Complex.tanh_eq_sinh_div_cosh ]
+          · by_cases h : Complex.cosh ( -2 * Real.pi * I * ( n - I * ν / ( 2 * Real.pi ) ) / 2 + ν / 2 ) = 0 <;> simp_all +decide [ sq, mul_div_mul_left ]
+            · rw [ Complex.cosh ] at h ; ring_nf at h ; norm_num [ Complex.ext_iff, Complex.exp_re, Complex.exp_im, neg_div, mul_div_cancel₀, Real.pi_ne_zero ] at h
+              norm_num [ mul_comm Real.pi _, Real.pi_ne_zero ] at h
+              exact absurd ( Real.cos_sq' ( n * Real.pi ) ) ( by norm_num [ h ] )
+            · grind
+          · norm_num +zetaDelta at *
+            ring_nf; norm_num [ Complex.ext_iff, Complex.exp_re, Complex.exp_im, Complex.cosh ]
+            norm_num [ mul_assoc, mul_comm Real.pi _, Real.pi_ne_zero ]
+            exact fun h => absurd ( Real.sin_sq_add_cos_sq ( n * Real.pi ) ) ( by norm_num [ h ] )
+        convert h_tanh_deriv.comp ( ( n : ℂ ) - I * ν / ( 2 * Real.pi ) ) ( HasDerivAt.div_const ( HasDerivAt.add ( HasDerivAt.const_mul ( -2 * Real.pi * I ) ( hasDerivAt_id _ ) ) ( hasDerivAt_const _ _ ) ) _ ) using 1 ; norm_num ; ring
+        norm_num +zetaDelta at *
+        ring_nf; norm_num [ Complex.ext_iff, Real.pi_ne_zero ]
+        norm_num [ Complex.tanh_eq_sinh_div_cosh, Complex.sinh, Complex.cosh, Complex.exp_re, Complex.exp_im, mul_assoc, mul_comm Real.pi _, Real.pi_ne_zero ] ; ring_nf ; norm_num [ Real.pi_ne_zero ]
+        norm_num [ Complex.normSq, Complex.exp_re, Complex.exp_im, mul_assoc, mul_comm Real.pi _, Real.pi_ne_zero ] ; ring_nf ; norm_num [ Real.pi_ne_zero ]
+      rw [ hasDerivAt_iff_tendsto_slope ] at h_deriv
+      convert h_deriv using 2 ; norm_num [ div_eq_mul_inv, slope_def_field ]
+      simp +zetaDelta at *
+      ring_nf; norm_num [ Real.pi_ne_zero ]
+      norm_num [ mul_assoc, mul_comm, mul_left_comm, Real.pi_ne_zero ]
+      norm_num [ Complex.tanh_eq_sinh_div_cosh, Complex.sinh, Complex.cosh ]
+      norm_num [ Complex.ext_iff, Complex.exp_re, Complex.exp_im, mul_comm Real.pi ]
+    simpa using h_tanh_approx.inv₀ ( by norm_num [ Complex.ext_iff, Real.pi_ne_zero ] )
+  have h_rewrite : Filter.Tendsto (fun z => (z - (n - I * ν / (2 * Real.pi))) * (1 / 2 * (1 / Complex.tanh (w_div z) + ε))) (nhdsWithin (n - I * ν / (2 * Real.pi)) { (n - I * ν / (2 * Real.pi)) }ᶜ) (nhds ((1 / 2) * (1 / (-Real.pi * I)) + 0)) := by
+    convert h_tanh.const_mul ( 1 / 2 : ℂ ) |> Filter.Tendsto.add <| Filter.Tendsto.const_mul ( ε / 2 : ℂ ) <| Filter.Tendsto.mono_left ( Continuous.tendsto ( show Continuous fun z : ℂ => ( z - ( n - I * ν / ( 2 * Real.pi ) ) ) from by continuity ) _ ) nhdsWithin_le_nhds using 2 <;> ring!
+  convert h_rewrite using 2 ; norm_num [ Complex.tanh_eq_sinh_div_cosh ] ; ring
 
 @[blueprint
   "Phi-circ-poles-simple"
@@ -468,7 +500,33 @@ theorem Phi_circ.residue (ν ε : ℝ) (hν : ν > 0) (n : ℤ) :
   (latexEnv := "lemma")
   (discussion := 1070)]
 theorem Phi_circ.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
-    meromorphicOrderAt (Phi_circ ν ε) z = -1 ↔ ∃ n : ℤ, z = n - I * ν / (2 * π) := by sorry
+    meromorphicOrderAt (Phi_circ ν ε) z = -1 ↔ ∃ n : ℤ, z = n - I * ν / (2 * π) := by
+  constructor
+  · exact fun h ↦ (Phi_circ.poles ν ε hν z).mp (h ▸ by decide)
+  · rintro ⟨n, rfl⟩
+    set z₀ := (n : ℂ) - I * ν / (2 * π)
+    have hsub : MeromorphicAt (· - z₀ : ℂ → ℂ) z₀ := by fun_prop
+    have hf : MeromorphicAt (Phi_circ ν ε) z₀ := (Phi_circ.meromorphic ν ε).meromorphicAt
+    have heq : (fun z ↦ (z - z₀) * Phi_circ ν ε z) =ᶠ[nhdsWithin z₀ {z₀}ᶜ] ((· - z₀) * Phi_circ ν ε) :=
+      Filter.Eventually.of_forall fun _ ↦ rfl
+    have hL : I / (2 * ↑(π : ℝ)) ≠ (0 : ℂ) := by
+      simp only [ne_eq, div_eq_zero_iff, mul_eq_zero, OfNat.ofNat_ne_zero, ofReal_eq_zero,
+        pi_ne_zero, or_self, or_false]
+      exact I_ne_zero
+    have hord₀ : meromorphicOrderAt ((· - z₀) * Phi_circ ν ε) z₀ = 0 :=
+      (tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (hsub.mul hf)).mp
+        ⟨_, hL, (Phi_circ.residue ν ε hν n).congr' heq⟩
+    have hord₁ : meromorphicOrderAt (· - z₀ : ℂ → ℂ) z₀ = (1 : ℤ) := by
+      rw [meromorphicOrderAt_eq_int_iff hsub]
+      exact ⟨1, analyticAt_const, one_ne_zero, by simp⟩
+    rw [meromorphicOrderAt_mul hsub hf, hord₁] at hord₀
+    obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp
+      (by rintro h; simp [h] at hord₀ : meromorphicOrderAt (Phi_circ ν ε) z₀ ≠ ⊤)
+    rw [← hm] at hord₀ ⊢
+    have h1 : (↑(1 : ℤ) + ↑m : WithTop ℤ) = ↑(1 + m : ℤ) := by push_cast; ring_nf
+    rw [h1] at hord₀
+    have : 1 + m = 0 := by exact_mod_cast hord₀
+    change (↑m : WithTop ℤ) = ↑(-1 : ℤ); congr 1; omega
 
 @[blueprint
   "B-def"
@@ -606,6 +664,7 @@ theorem Phi_star.meromorphic (ν ε : ℝ) : Meromorphic (Phi_star ν ε) := by
 theorem Phi_star.poles (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
     meromorphicOrderAt (Phi_star ν ε) z < 0 ↔ ∃ n : ℤ, n ≠ 0 ∧ z = n - I * ν / (2 * π) := by sorry
 
+set_option maxHeartbeats 400000 in
 @[blueprint
   "Phi-star-residues"
   (title := "Phi-star residues")
@@ -617,7 +676,45 @@ theorem Phi_star.poles (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
   (discussion := 1073)]
 theorem Phi_star.residue (ν ε : ℝ) (hν : ν > 0) (n : ℤ) (hn : n ≠ 0) :
     (nhdsWithin (n - I * ν / (2 * π)) {n - I * ν / (2 * π)}ᶜ).Tendsto
-      (fun z ↦ (z - (n - I * ν / (2 * π))) * Phi_star ν ε z) (nhds (-I * n / (2 * π))) := by sorry
+      (fun z ↦ (z - (n - I * ν / (2 * π))) * Phi_star ν ε z) (nhds (-I * n / (2 * π))) := by
+  unfold Phi_star B coth
+  suffices h_simp : Filter.Tendsto (fun z => (z - (n - I * ν / (2 * Real.pi))) * ((-2 * Real.pi * I * z + ν) * (1 / Complex.tanh ((-2 * Real.pi * I * z + ν) / 2) + ε) / 2 - (ν * (1 / Complex.tanh (ν / 2) + ε) / 2)) / (2 * Real.pi * I)) (nhdsWithin (n - I * ν / (2 * Real.pi)) {n - I * ν / (2 * Real.pi)}ᶜ) (nhds (-I * n / (2 * Real.pi))) by
+    refine' h_simp.congr' _
+    refine' eventuallyEq_nhdsWithin_iff.mpr _
+    rw [ Metric.eventually_nhds_iff ]
+    refine' ⟨ 1 / 2, by norm_num, fun y hy hy' => _ ⟩ ; by_cases hy'' : -2 * Real.pi * I * y + ν = 0 <;> simp_all +decide [ Complex.tanh_eq_sinh_div_cosh ] ; ring
+    · norm_num [ Complex.ext_iff ] at *
+      norm_num [ Complex.dist_eq, Complex.normSq, Complex.norm_def, hy'' ] at hy
+      norm_num [ Complex.normSq, Complex.div_re, Complex.div_im, Real.pi_ne_zero ] at hy
+      rw [ Real.sqrt_lt' ] at hy <;> norm_num at *
+      norm_num [ show y.im = -ν / ( 2 * Real.pi ) by rw [ eq_div_iff ( by positivity ) ] ; linarith ] at *
+      ring_nf at hy ; norm_num [ Real.pi_ne_zero ] at hy
+      nlinarith [ show ( n : ℝ ) ^ 2 ≥ 1 by exact_mod_cast sq_pos_of_ne_zero hn, show 0 < ν ^ 2 * Real.pi * ( Real.pi ^ 3 ) ⁻¹ by positivity, show 0 < ν ^ 2 * Real.pi ^ 2 * ( Real.pi ^ 4 ) ⁻¹ by positivity, show 0 < ν ^ 2 * ( Real.pi ^ 2 ) ⁻¹ by positivity, mul_inv_cancel₀ ( by positivity : ( Real.pi ^ 3 ) ≠ 0 ), mul_inv_cancel₀ ( by positivity : ( Real.pi ^ 4 ) ≠ 0 ), mul_inv_cancel₀ ( by positivity : ( Real.pi ^ 2 ) ≠ 0 ) ]
+    · rw [ if_neg hν.ne' ] ; ring
+  have h_tanh_pole : Filter.Tendsto (fun z => (z - (n - I * ν / (2 * Real.pi))) * (1 / Complex.tanh ((-2 * Real.pi * I * z + ν) / 2))) (nhdsWithin (n - I * ν / (2 * Real.pi)) {n - I * ν / (2 * Real.pi)}ᶜ) (nhds (1 / (-Real.pi * I))) := by
+    have h_tanh_pole : Filter.Tendsto (fun z => (z - (n - I * ν / (2 * Real.pi))) * (Complex.sinh ((-2 * Real.pi * I * z + ν) / 2) / Complex.cosh ((-2 * Real.pi * I * z + ν) / 2))⁻¹) (nhdsWithin (n - I * ν / (2 * Real.pi)) {n - I * ν / (2 * Real.pi)}ᶜ) (nhds (1 / (-Real.pi * I))) := by
+      have h_sinh_zero : HasDerivAt (fun z => Complex.sinh ((-2 * Real.pi * I * z + ν) / 2)) (Complex.cosh ((-2 * Real.pi * I * (n - I * ν / (2 * Real.pi)) + ν) / 2) * (-Real.pi * I)) (n - I * ν / (2 * Real.pi)) := by
+        convert HasDerivAt.comp _ ( Complex.hasDerivAt_sinh _ ) ( HasDerivAt.div_const ( HasDerivAt.add ( HasDerivAt.const_mul _ ( hasDerivAt_id _ ) ) ( hasDerivAt_const _ _ ) ) _ ) using 1 ; norm_num ; ring
+      have h_sinh_zero' : Filter.Tendsto (fun z => (Complex.sinh ((-2 * Real.pi * I * z + ν) / 2)) / (z - (n - I * ν / (2 * Real.pi)))) (nhdsWithin (n - I * ν / (2 * Real.pi)) {n - I * ν / (2 * Real.pi)}ᶜ) (nhds (Complex.cosh ((-2 * Real.pi * I * (n - I * ν / (2 * Real.pi)) + ν) / 2) * (-Real.pi * I))) := by
+        rw [ hasDerivAt_iff_tendsto_slope ] at h_sinh_zero
+        refine' h_sinh_zero.congr' _
+        filter_upwards [ self_mem_nhdsWithin ] with z hz ; simp +decide [ div_eq_inv_mul, slope_def_field, hz ]
+        ring_nf; norm_num [ Complex.ext_iff, Real.pi_ne_zero ]
+        norm_num [ Complex.sinh, Complex.exp_re, Complex.exp_im ]
+        exact Or.inl ( Real.sin_eq_zero_iff.mpr ⟨ n, by ring ⟩ )
+      have h_cosh_nonzero : Complex.cosh ((-2 * Real.pi * I * (n - I * ν / (2 * Real.pi)) + ν) / 2) ≠ 0 := by
+        norm_num [ Complex.ext_iff, Complex.exp_re, Complex.exp_im, Complex.cosh ]
+        norm_num [ Complex.normSq, Complex.div_re, Complex.div_im, mul_div_cancel₀, Real.pi_ne_zero ] ; ring_nf ; norm_num [ Real.pi_pos.ne' ]
+        norm_num [ mul_assoc, mul_comm, mul_left_comm, Real.pi_ne_zero ]
+        exact ne_of_apply_ne ( fun x => x ^ 2 ) ( by norm_num [ mul_comm Real.pi, Real.cos_sq' ] )
+      convert h_sinh_zero'.inv₀ ( mul_ne_zero h_cosh_nonzero <| mul_ne_zero ( neg_ne_zero.mpr <| Complex.ofReal_ne_zero.mpr Real.pi_ne_zero ) I_ne_zero ) |> Filter.Tendsto.mul <| ContinuousAt.continuousWithinAt <| show ContinuousAt ( fun z => Complex.cosh ( ( -2 * Real.pi * I * z + ν ) / 2 ) ) ( n - I * ν / ( 2 * Real.pi ) ) from Complex.continuous_cosh.continuousAt.comp <| Continuous.continuousAt <| by continuity using 2 ; norm_num ; ring
+      grind
+    simpa [ Complex.tanh_eq_sinh_div_cosh ] using h_tanh_pole
+  suffices h_simp' : Filter.Tendsto (fun z => (z - (n - I * ν / (2 * Real.pi))) * ((-2 * Real.pi * I * z + ν) * (1 / Complex.tanh ((-2 * Real.pi * I * z + ν) / 2))) / (2 * Real.pi * I * 2)) (nhdsWithin (n - I * ν / (2 * Real.pi)) {n - I * ν / (2 * Real.pi)}ᶜ) (nhds (-I * n / (2 * Real.pi))) by
+    convert h_simp'.add ( ContinuousAt.continuousWithinAt ( show ContinuousAt ( fun z : ℂ => ( z - ( n - I * ν / ( 2 * Real.pi ) ) ) * ( ( -2 * Real.pi * I * z + ν ) * ε / 2 - ν * ( 1 / Complex.tanh ( ν / 2 ) + ε ) / 2 ) / ( 2 * Real.pi * I ) ) ( n - I * ν / ( 2 * Real.pi ) ) from ContinuousAt.div ( ContinuousAt.mul ( continuousAt_id.sub continuousAt_const ) <| ContinuousAt.sub ( ContinuousAt.div_const ( ContinuousAt.mul ( ContinuousAt.add ( ContinuousAt.mul ( continuousAt_const.mul continuousAt_const ) continuousAt_id ) continuousAt_const ) continuousAt_const ) _ ) <| ContinuousAt.div_const ( ContinuousAt.mul continuousAt_const <| ContinuousAt.add ( continuousAt_const.div_const _ ) continuousAt_const ) _ ) continuousAt_const <| by norm_num [ Complex.ext_iff, Real.pi_ne_zero ] ) ) using 2 <;> ring
+  convert h_tanh_pole.mul ( Continuous.continuousWithinAt ( show Continuous fun z : ℂ => ( -2 * Real.pi * I * z + ν ) / ( 2 * Real.pi * I * 2 ) by continuity ) ) using 2 <;> ring
+  norm_num [ sq, mul_assoc, Real.pi_ne_zero ] ; ring
+  grind
 
 @[blueprint
   "Phi-star-poles-simple"
@@ -1432,7 +1529,15 @@ theorem B_affine_periodic (ν ε : ℝ) (hν : ν > 0) (z : ℂ) (m : ℤ)
     (hw : -2 * π * I * z + ν ≠ 0)
     (hwm : -2 * π * I * (z - m) + ν ≠ 0) :
     B ε (-2 * π * I * (z - m) + ν) = B ε (-2 * π * I * z + ν) + 2 * π * I * m * Phi_circ ν ε z := by
-    sorry
+  unfold B Phi_circ coth
+  have h_tanh_periodic : Complex.tanh ((-2 * Real.pi * I * (z - m) + ν) / 2) = Complex.tanh ((-2 * Real.pi * I * z + ν) / 2) := by
+    rw [Complex.tanh_eq_sinh_div_cosh, Complex.tanh_eq_sinh_div_cosh]
+    ring_nf; norm_num [Complex.sinh, Complex.cosh]; ring
+    norm_num [Complex.exp_add, Complex.exp_sub]; ring
+    norm_num [show Complex.exp (Real.pi * I * m) = (-1) ^ m by rw [← Complex.exp_pi_mul_I]; rw [← Complex.exp_int_mul]; ring]; ring
+    rcases Int.even_or_odd' m with ⟨k, rfl | rfl⟩ <;> norm_num [zpow_add₀, zpow_mul]; ring_nf; norm_num [Complex.exp_ne_zero] at *
+    rw [show (-( Complex.exp (-(Real.pi * I * z)) * Complex.exp (ν * (1 / 2))) - Complex.exp (Real.pi * I * z) * Complex.exp (-(ν * (1 / 2)))) = -(Complex.exp (-(Real.pi * I * z)) * Complex.exp (ν * (1 / 2)) + Complex.exp (Real.pi * I * z) * Complex.exp (-(ν * (1 / 2)))) by ring, inv_neg]; ring
+  grind
 
 @[blueprint
   "phi_star-affine-periodic"
@@ -1447,7 +1552,14 @@ theorem phi_star_affine_periodic (ν ε : ℝ) (hν : ν > 0) (z : ℂ) (m : ℤ
     (hw : -2 * π * I * z + ν ≠ 0)
     (hwm : -2 * π * I * (z - m) + ν ≠ 0) :
     Phi_star ν ε (z - m) = Phi_star ν ε z + m * Phi_circ ν ε z := by
-    sorry
+  have hB := B_affine_periodic ν ε hν z m hw hwm
+  have h_sub : Phi_star ν ε (z - m) = (B ε (-2 * Real.pi * I * z + ν) + 2 * Real.pi * I * m * Phi_circ ν ε z - B ε ν) / (2 * Real.pi * I) := by
+    rw [Phi_star, hB]
+  have h_def : Phi_star ν ε z = (B ε (-2 * Real.pi * I * z + ν) - B ε ν) / (2 * Real.pi * I) := by
+    simp [Phi_star]
+  rw [h_sub, h_def]
+  field_simp
+  ring
 
 @[blueprint
   "shift-upwards-simplified"

--- a/PrimeNumberTheoremAnd/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/TMEEMT.lean
@@ -4,6 +4,8 @@ import PrimeNumberTheoremAnd.SecondaryDefinitions
 import PrimeNumberTheoremAnd.Dusart
 import PrimeNumberTheoremAnd.RSPrimeLower
 import PrimeNumberTheoremAnd.FioriKadiriSwidinsky
+import PrimeNumberTheoremAnd.LogTables
+import PrimeNumberTheoremAnd.PrimeTables
 
 blueprint_comment /--
 \section{Results from the TME-EMT wiki}
@@ -459,7 +461,12 @@ blueprint_comment /-- Some results from \cite{FKS}-/
   (statement := /-- For $x \geq 2$, we have $|\psi(x) - x| \leq x \cdot 9.22022\, (\log x)^{1.5} \exp(-0.8476836\sqrt{\log x})$. -/)
   (latexEnv := "theorem")]
 theorem psi_bound (x : ℝ) (hx : x ≥ 2) :
-    |ψ x - x| ≤ x * 9.22022 * (log x) ^ (1.5 : ℝ) * exp (-0.8476836 * sqrt (log x)) := by sorry
+    |ψ x - x| ≤ x * 9.22022 * (log x) ^ (1.5 : ℝ) * exp (-0.8476836 * sqrt (log x)) := by
+  have h_ineq : |ψ x - x| / x ≤ 9.22022 * (log x) ^ (3 / 2 : ℝ) * exp (-0.8476836 * sqrt (log x)) := by
+    have := FKS.FKS_corollary_1_4
+    convert this x hx using 1; norm_num [exp_neg, sqrt_eq_rpow, rpow_neg, div_eq_mul_inv]; ring_nf
+    norm_num [admissible_bound, exp_neg, sqrt_eq_rpow, rpow_neg, div_eq_mul_inv]; ring_nf
+  rw [div_le_iff₀] at h_ineq <;> ring_nf at * <;> grind
 
 end FKS
 
@@ -740,7 +747,105 @@ blueprint_comment /-- Some results from \cite{rosser1938} -/
   (statement := /-- For $n \geq 2$, we have $p_n > n \log n$. -/)
   (latexEnv := "theorem")]
 theorem p_n_gt_1 (n : ℕ) (hn : n ≥ 2) :
-    nth_prime' n > n * log n := by sorry
+    nth_prime' n > n * log n := by
+  by_cases h : n ≤ 31
+  · -- Small case: use computation via nth_prime_gt_bound technique
+    have key : ∀ (n₀ m : ℕ), Nat.count Nat.Prime m ≤ n₀ - 1 → (n₀ : ℝ) * log n₀ < m →
+        (nth_prime' n₀ : ℝ) > n₀ * log n₀ :=
+      fun n₀ m hc hb => hb.trans_le (by exact_mod_cast RS_prime_helper.count_prime_le_imp_le_nth m (n₀ - 1) hc)
+    interval_cases n
+    · exact key 2 3 count_prime_3_le_1 (by interval_auto)
+    · exact key 3 5 count_prime_5_le_2 (by interval_auto)
+    · exact key 4 7 count_prime_7_le_3 (by interval_auto)
+    · exact key 5 11 count_prime_11_le_4 (by interval_auto)
+    · exact key 6 13 count_prime_13_le_5 (by interval_auto)
+    · exact key 7 17 count_prime_17_le_6 (by interval_auto)
+    · exact key 8 19 count_prime_19_le_7 (by interval_auto)
+    · exact key 9 23 count_prime_23_le_8 (by interval_auto)
+    · exact key 10 29 count_prime_29_le_9 (by interval_auto)
+    · exact key 11 31 count_prime_31_le_10 (by interval_auto)
+    · exact key 12 37 count_prime_37_le_11 (by interval_auto)
+    · exact key 13 41 count_prime_41_le_12 (by interval_auto)
+    · exact key 14 43 count_prime_43_le_13 (by interval_auto)
+    · exact key 15 47 count_prime_47_le_14 (by interval_auto)
+    · exact key 16 53 count_prime_53_le_15 (by interval_auto)
+    · exact key 17 59 count_prime_59_le_16 (by interval_auto)
+    · exact key 18 61 count_prime_61_le_17 (by interval_auto)
+    · exact key 19 67 count_prime_67_le_18 (by interval_auto)
+    · exact key 20 71 count_prime_71_le_19 (by interval_auto)
+    · exact key 21 73 count_prime_73_le_20 (by interval_auto)
+    · exact key 22 79 count_prime_79_le_21 (by interval_auto)
+    · exact key 23 83 count_prime_83_le_22 (by interval_auto)
+    · exact key 24 89 count_prime_89_le_23 (by interval_auto)
+    · exact key 25 97 count_prime_97_le_24 (by interval_auto)
+    · exact key 26 101 count_prime_101_le_25 (by interval_auto)
+    · exact key 27 103 count_prime_103_le_26 (by interval_auto)
+    · exact key 28 107 count_prime_107_le_27 (by interval_auto)
+    · exact key 29 109 count_prime_109_le_28 (by interval_auto)
+    · exact key 30 113 count_prime_113_le_29 (by interval_auto)
+    · exact key 31 127 count_prime_127_le_30 (by interval_auto)
+  · -- Large case (n ≥ 32): use Dusart corollary and bootstrapping
+    push_neg at h
+    have h_pn_ge_succ : nth_prime' n ≥ n + 1 := by
+      have : ∀ n ≥ 1, nth_prime' n ≥ n + 1 := by
+        intro n hn
+        induction n, hn using Nat.le_induction with
+        | base => exact Nat.Prime.two_le (Nat.prime_nth_prime 0) |> Nat.succ_le_of_lt
+        | succ n _ ih => exact Nat.succ_le_of_lt (lt_of_le_of_lt ih (Nat.nth_strictMono Nat.infinite_setOf_prime (Nat.pred_lt (by positivity))))
+      exact this n (by omega)
+    -- Step 1: Dusart bound: nth_prime' n ≥ n * (log(nth_prime' n) - 1.112)
+    have h_dusart : (nth_prime' n : ℝ) ≥ n * (log (nth_prime' n) - 1.112) := by
+      have h_pi_le : (n : ℝ) ≤ (nth_prime' n : ℝ) / (log (nth_prime' n) - 1.112) := by
+        have h_pi_le' : pi (nth_prime' n) ≤ (nth_prime' n : ℝ) / (log (nth_prime' n) - 1.112) := by
+          convert Dusart.corollary_5_3_b _ using 1
+          linarith [show (n : ℝ) ≥ 32 by norm_cast, show exp 1.112 < 3.041 from LogTables.exp_1_112_lt,
+            show (nth_prime' n : ℝ) ≥ n + 1 by norm_cast]
+        convert h_pi_le' using 1
+        exact_mod_cast Eq.symm (RS_prime_helper.pi_nth_prime' n (by omega))
+      rwa [le_div_iff₀ (sub_pos.mpr <| by
+        contrapose! h_pi_le
+        exact lt_of_le_of_lt
+          (div_nonpos_of_nonneg_of_nonpos (Nat.cast_nonneg _) (sub_nonpos.mpr h_pi_le))
+          (by positivity))] at h_pi_le
+    -- Step 2: log(nth_prime' n) ≥ log n (since nth_prime' n ≥ n)
+    have h_pn_ge_n : (nth_prime' n : ℝ) ≥ n := by linarith [show (nth_prime' n : ℝ) ≥ n + 1 by norm_cast]
+    have h_log_pn_ge : log (nth_prime' n) ≥ log n :=
+      log_le_log (by positivity) h_pn_ge_n
+    -- Step 3: nth_prime' n ≥ n * (log n - 1.112)
+    have h_pn_ge1 : (nth_prime' n : ℝ) ≥ n * (log n - 1.112) :=
+      le_trans (mul_le_mul_of_nonneg_left (by linarith) (Nat.cast_nonneg _)) h_dusart
+    -- Step 4: log(log n - 1.112) > 0.855 (since log n > 3.465, so log n - 1.112 > 2.353)
+    have h_log_diff : log (log n - 1.112) > 0.855 := by
+      have : log n ≥ log 32 := log_le_log (by norm_num) (by norm_cast)
+      have : log n > 3.465 := by linarith [LogTables.log_32_gt]
+      exact lt_of_lt_of_le LogTables.log_2_353_gt (log_le_log (by norm_num) (by linarith))
+    -- Step 5: log(nth_prime' n) ≥ log n + log(log n - 1.112) > log n + 0.855
+    have h_log_n_minus_pos : log n - 1.112 > 0 := by
+      have : log n ≥ log 32 := log_le_log (by norm_num) (by norm_cast)
+      linarith [LogTables.log_32_gt]
+    have h_log_pn2 : log (nth_prime' n) ≥ log n + log (log n - 1.112) := by
+      rw [← log_mul (ne_of_gt (by positivity : (0 : ℝ) < n)) (ne_of_gt h_log_n_minus_pos)]
+      exact log_le_log (by positivity) h_pn_ge1
+    -- Step 6: nth_prime' n ≥ n * (log n - 0.262)
+    have h_pn_ge2 : (nth_prime' n : ℝ) ≥ n * (log n - 0.262) := by
+      have : (nth_prime' n : ℝ) ≥ n * (log n + 0.855 - 1.112) :=
+        le_trans (mul_le_mul_of_nonneg_left (by linarith) (Nat.cast_nonneg _)) h_dusart
+      linarith
+    -- Step 7: nth_prime' n ≥ n * 3.2 (since log n ≥ 3.465)
+    have h_pn_ge3 : (nth_prime' n : ℝ) ≥ n * 3.2 := by
+      have : log n ≥ log 32 := log_le_log (by norm_num) (by norm_cast)
+      nlinarith [LogTables.log_32_gt]
+    -- Step 8: log(nth_prime' n) ≥ log(n * 3.2) > log n + 1.16
+    have h_log_pn3 : log (nth_prime' n) > log n + 1.16 := by
+      have : log (nth_prime' n) ≥ log (n * 3.2) :=
+        log_le_log (by positivity) h_pn_ge3
+      have : log (n * 3.2) = log n + log 3.2 :=
+        log_mul (ne_of_gt (by positivity)) (by norm_num)
+      linarith [LogTables.log_3_2_gt]
+    -- Step 9: nth_prime' n ≥ n * (log n + 0.048) > n * log n
+    have : (nth_prime' n : ℝ) ≥ n * (log n + 1.16 - 1.112) :=
+      le_trans (mul_le_mul_of_nonneg_left (by linarith) (Nat.cast_nonneg _)) h_dusart
+    nlinarith [show (n : ℝ) > 0 from by positivity]
 
 @[blueprint
   "thm:rosser1938-pn-lower"
@@ -748,7 +853,12 @@ theorem p_n_gt_1 (n : ℕ) (hn : n ≥ 2) :
   (statement := /-- For $n > 1$, we have $p_n > n(\log n + \log\log n - 10)$. -/)
   (latexEnv := "theorem")]
 theorem p_n_gt_2 (n : ℕ) (hn : n > 1) :
-    nth_prime' n > n * (log n + log (log n) - 10) := by sorry
+    nth_prime' n > n * (log n + log (log n) - 10) := by
+  have h_rs : (nth_prime' n : ℝ) > n * (log n + log (log n) - 3 / 2) := by
+    by_cases h : n ≤ 31
+    · exact RS_prime_helper.p_n_lower_small n hn h
+    · exact RS_prime_helper.p_n_lower_large n (by omega)
+  nlinarith [show (n : ℝ) > 0 from by positivity]
 
 @[blueprint
   "thm:rosser1938-pn-upper"
@@ -793,7 +903,12 @@ blueprint_comment /-- Some results from \cite{rosser1941} -/
   (statement := /-- For $n \geq 55$, we have $p_n > n(\log n + \log\log n - 4)$. -/)
   (latexEnv := "theorem")]
 theorem p_n_lower (n : ℕ) (hn : n ≥ 55) :
-    nth_prime' n > n * (log n + log (log n) - 4) := by sorry
+    nth_prime' n > n * (log n + log (log n) - 4) := by
+  have h_rs : (nth_prime' n : ℝ) > n * (log n + log (log n) - 3 / 2) := by
+    by_cases h : n ≤ 31
+    · exact RS_prime_helper.p_n_lower_small n (by omega) h
+    · exact RS_prime_helper.p_n_lower_large n (by omega)
+  nlinarith [show (n : ℝ) > 0 from by positivity]
 
 @[blueprint
   "thm:rosser1941-pn-upper"

--- a/PrimeNumberTheoremAnd/ZetaSummary.lean
+++ b/PrimeNumberTheoremAnd/ZetaSummary.lean
@@ -3,6 +3,7 @@ import PrimeNumberTheoremAnd.ZetaDefinitions
 import PrimeNumberTheoremAnd.KLN
 import PrimeNumberTheoremAnd.RosserSchoenfeldZeta
 import PrimeNumberTheoremAnd.ZetaAppendix
+import PrimeNumberTheoremAnd.ZetaSummaryProofs
 
 blueprint_comment /--
 \section{Summary of results}
@@ -35,19 +36,6 @@ zeta-function, arXiv:2212.06867.
 theorem HSW.main_theorem : riemannZeta.Riemann_vonMangoldt_bound 0.1038 0.2573 9.3675 := sorry
 
 @[blueprint
-  "mt_theorem_1"
-  (title := "MT Theorem 1")
-  (statement := /--
-    One has a classical zero-free region with $R = 5.5666305$.
-    (A more conservative value of $R = 5.573412$ was announced in
-    the paper using weaker numerical verification of the Riemann
-    hypothesis.)
-  -/)
-  (uses := ["classical-zero-free-region"])
-  (latexEnv := "theorem")]
-theorem MT_theorem_1 : riemannZeta.classicalZeroFree 5.5666305 := sorry
-
-@[blueprint
   "mty_theorem"
   (title := "MTY")
   (statement := /--
@@ -58,24 +46,18 @@ theorem MT_theorem_1 : riemannZeta.classicalZeroFree 5.5666305 := sorry
 theorem MTY_theorem : riemannZeta.classicalZeroFree 5.558691 := sorry
 
 @[blueprint
-  "platt_RH"
-  (title := "Platt's numerical verification of RH")
+  "mt_theorem_1"
+  (title := "MT Theorem 1")
   (statement := /--
-    The Riemann hypothesis is verified up to
-    $H_0 = 3.061 \times 10^{10}$.
+    One has a classical zero-free region with $R = 5.5666305$.
+    (A more conservative value of $R = 5.573412$ was announced in
+    the paper using weaker numerical verification of the Riemann
+    hypothesis.)
   -/)
+  (uses := ["classical-zero-free-region"])
   (latexEnv := "theorem")]
-theorem Platt_theorem : riemannZeta.RH_up_to 30610000000 := sorry
-
-@[blueprint
-  "gourdon_wedeniwski"
-  (title := "Gourdon-Wedeniwski")
-  (statement := /--
-    The Riemann hypothesis is verified up to
-    $H_0 = 2445999556030$.
-  -/)
-  (latexEnv := "theorem")]
-theorem GW_theorem : riemannZeta.RH_up_to 2445999556030 := sorry
+theorem MT_theorem_1 : riemannZeta.classicalZeroFree 5.5666305 :=
+  classicalZeroFree_mono (by positivity) (by norm_num) MTY_theorem
 
 @[blueprint
   "pt_theorem_1"
@@ -86,3 +68,25 @@ theorem GW_theorem : riemannZeta.RH_up_to 2445999556030 := sorry
   -/)
   (latexEnv := "theorem")]
 theorem PT_theorem_1 : riemannZeta.RH_up_to 3e12 := sorry
+
+@[blueprint
+  "gourdon_wedeniwski"
+  (title := "Gourdon-Wedeniwski")
+  (statement := /--
+    The Riemann hypothesis is verified up to
+    $H_0 = 2445999556030$.
+  -/)
+  (latexEnv := "theorem")]
+theorem GW_theorem : riemannZeta.RH_up_to 2445999556030 :=
+  RH_up_to_mono (by norm_num) PT_theorem_1
+
+@[blueprint
+  "platt_RH"
+  (title := "Platt's numerical verification of RH")
+  (statement := /--
+    The Riemann hypothesis is verified up to
+    $H_0 = 3.061 \times 10^{10}$.
+  -/)
+  (latexEnv := "theorem")]
+theorem Platt_theorem : riemannZeta.RH_up_to 30610000000 :=
+  RH_up_to_mono (by norm_num) GW_theorem

--- a/PrimeNumberTheoremAnd/ZetaSummaryProofs.lean
+++ b/PrimeNumberTheoremAnd/ZetaSummaryProofs.lean
@@ -1,0 +1,24 @@
+import Mathlib
+import PrimeNumberTheoremAnd.ZetaDefinitions
+
+open Real
+
+/-- RH_up_to is antitone: verifying RH to a greater height implies it for smaller heights. -/
+lemma RH_up_to_mono {T₁ T₂ : ℝ} (h : T₁ ≤ T₂) (hRH : riemannZeta.RH_up_to T₂) :
+    riemannZeta.RH_up_to T₁ := by
+  apply Classical.byContradiction
+  intro h_nonempty_T₁
+  obtain ⟨ρ, hρ⟩ := not_isEmpty_iff.mp h_nonempty_T₁
+  exact hRH.elim ⟨ρ, hρ.1, ⟨hρ.2.1.1, hρ.2.1.2.trans h⟩, hρ.2.2⟩
+
+/-- classicalZeroFree is monotone in R (for positive R₁): a zero-free region with smaller R
+    implies one with larger R, since larger R means a narrower zero-free region. -/
+lemma classicalZeroFree_mono {R₁ R₂ : ℝ} (hR₁ : 0 < R₁) (h : R₁ ≤ R₂)
+    (hR : riemannZeta.classicalZeroFree R₁) :
+    riemannZeta.classicalZeroFree R₂ := by
+  intro σ t ht hσ
+  apply hR σ t ht
+  linarith [one_div_le_one_div_of_le
+    (by exact mul_pos hR₁ (Real.log_pos (by linarith)))
+    (by exact mul_le_mul_of_nonneg_right h (Real.log_nonneg (by linarith)) :
+      R₂ * Real.log t ≥ R₁ * Real.log t)]


### PR DESCRIPTION
This PR adds proofs autoformalised by @Aristotle-Harmonic.

**TMEEMT** (4 fills): `Rosser1938.p_n_gt_1`, `p_n_gt_2`, `Rosser1941.p_n_lower`, JY psi bound
**CH2** (5 fills): `Phi_circ.residue`, `Phi_star.residue`, `Phi_circ.poles_simple`, `B_affine_periodic`, `phi_star_affine_periodic`
**ZetaSummary** (3 fills): `MT_theorem_1`, `GW_theorem`, `Platt_theorem`
**New file**: `ZetaSummaryProofs.lean` (monotonicity helpers for `RH_up_to` and `classicalZeroFree`)

Total sorry reduction: 221 → 208

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>