### PR TITLE
feat(CH2): prove `Phi_cancel`

### DIFF
--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -948,7 +948,7 @@ theorem Phi_star.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
   (proof := /-- The residues cancel out. -/)
   (latexEnv := "lemma")
   (discussion := 1074)]
-theorem Phi_cancel (ν ε σ : ℝ) (hν : ν > 0) (_hε : |ε| = 1) (hσ : |σ| = 1) :
+theorem Phi_cancel (ν ε σ : ℝ) (hν : ν > 0) (hσ : |σ| = 1) :
     meromorphicOrderAt (fun z ↦ Phi_circ ν ε z + σ * Phi_star ν ε z) ((σ : ℂ) - I * ν / (2 * π)) ≥ 0 := by
   obtain ⟨n, rfl, hn_cases⟩ : ∃ n : ℤ, σ = n ∧ n ≠ 0 := by
     rcases (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hσ with h | h


### PR DESCRIPTION
Co-authored with Gemini 3 and Claude

Closes #1074

Note: I modified the theorem statement from `meromorphicOrderAt (fun z ↦ Phi_circ ν ε z + σ * Phi_star ν ε z) ≥ 0` to `meromorphicOrderAt (fun z ↦ Phi_circ ν ε z + σ * Phi_star ν ε z) ((σ : ℂ) - I * ν / (2 * π)) ≥ 0` to reflect the fact that
- we fix $z$ to $\pm 1 - i \nu / 2 \pi$

I also added the hypothesis `(hσ : |σ| = 1)` to reflect the fact that $\sigma \in \{\pm 1\}$. Let me know if I am mistaken.

In my proof `(hε : |ε| = 1)` was not used.