### PR TITLE
feat(BKLNW_app): prove A.13

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW_app.lean
+++ b/PrimeNumberTheoremAnd/BKLNW_app.lean
@@ -186,9 +186,11 @@ theorem bklnw_eq_A_12 (I : Inputs)
   \sum_{k=0}^{K-1} \lambda^k
   x^{-\frac{1}{R \log(T/\lambda^k)}}
   \left(c_1 \left(\frac{T}{\lambda^k}
-  \right)^{\frac{8\delta}{3}}
-  (\log(T/\lambda^k))^{3+2\delta}
-  + c_2 (\log(T/\lambda^k))^2\right). $$ -/)
+  \right)^{p(1-\delta)}
+  (\log(T/\lambda^k))^{q(1-\delta)}
+  + c_2 (\log(T/\lambda^k))^2\right) $$
+  where $p$, $q$, $c_1$, $c_2$ are the
+  parameters of the zero density bound. -/)
   (proof := /-- Inserting (A.6) into the result
   of (A.12). -/)
   (latexEnv := "sublemma")
@@ -228,11 +230,13 @@ theorem bklnw_eq_A_13 (I : Inputs)
   - k \log \lambda)}\right) \\
   &\quad \times \left(c_1
   \left(\frac{T}{\lambda^k}
-  \right)^{\frac{8\delta}{3}}
-  (\log(T/\lambda^k))^{3+2\delta}
+  \right)^{p(1-\delta)}
+  (\log(T/\lambda^k))^{q(1-\delta)}
   + c_2
-  (\log(T/\lambda^k))^2\right). \notag
-  \end{align} -/)]
+  (\log(T/\lambda^k))^2\right) \notag
+  \end{align}
+  where $p$, $q$, $c_1$, $c_2$ are the
+  parameters of the zero density bound. -/)]
 noncomputable def Inputs.s₂ (I : Inputs)
     (δ b : ℝ) (K : ℕ) (lambda T : ℝ) : ℝ :=
   (2 * lambda / T) *


### PR DESCRIPTION
This PR attempts to finish issue #751. In particular, we:
1. Prove `bklnw_eq_A_13`: complete the proof of equation (A.13) from Appendix A of BKLNW, which bounds |Σ₂| by inserting the zero density estimate into (A.12).
2. Generalize exponents in A.13/A.14: replace concrete exponents `8δ/3` and `3+2δ` with abstract `I.ZDB.p(1−δ)` and `I.ZDB.q(1−δ)` from `zero_density_bound`.
3. Add missing hypotheses to A.12/A.13: add `hx`, `hT`, `hTH`, `hσ`, `hT₀` — these are conditions implicit in the paper's setup (§A.2.1) and needed to apply the zero density bound.
4. Fix parenthesization in A.12: correct `-(1 / I.R * log ...)` to `-(1 / (I.R * log ...))`.

This commit is written with the help of model `Doubao-Seed-2.0-code`.

Closes #751