### PR TITLE
Golf RamanujanCalculations.lean

### DIFF
--- a/PrimeNumberTheoremAnd/RamanujanCalculations.lean
+++ b/PrimeNumberTheoremAnd/RamanujanCalculations.lean
@@ -28,50 +28,22 @@ theorem style_eq (y : ℝ) (hy : 0 < y) :
       exp (-(1.89 : ℝ) * (sqrt y / sqrt (5.573412 : ℝ))))
     =
     styleVal y := by
-  have hpow5 : y ^ 5 = y * (y * (y * (y * y))) := by ring
-  rw [hpow5]
-  have hconst1 : (379.7 : ℝ) = (3797 / 10 : ℝ) := by norm_num
-  rw [hconst1]
-  have hconst2 : (5.573412 : ℝ) = (1393353 / 250000 : ℝ) := by norm_num
-  rw [hconst2]
-  have hdiv : y / (1393353 / 250000 : ℝ) = y * (250000 / 1393353 : ℝ) := by
-    field_simp
-  rw [hdiv]
+  have hdiv : y / (1393353 / 250000 : ℝ) = y * (250000 / 1393353 : ℝ) := by field_simp
   have hposbase : 0 < y * (250000 / 1393353 : ℝ) := by positivity
-  have hrpow : (y * (250000 / 1393353 : ℝ)) ^ (1.52 : ℝ) =
-      exp (log (y * (250000 / 1393353 : ℝ)) * (38 / 25 : ℝ)) := by
-    rw [rpow_def_of_pos hposbase]
-    congr 1
-    norm_num
-  rw [hrpow]
-  have hsqrt :
-      sqrt y / sqrt (1393353 / 250000 : ℝ) =
-        sqrt (y * (250000 / 1393353 : ℝ)) := by
-    have hs :
-        sqrt (y / (1393353 / 250000 : ℝ)) =
-          sqrt y / sqrt (1393353 / 250000 : ℝ) := by
-      rw [sqrt_div (le_of_lt hy)]
-    rw [← hs, hdiv]
-  rw [hsqrt]
-  have hconst3 : (1.89 : ℝ) = (189 / 100 : ℝ) := by norm_num
-  rw [hconst3]
-  have hneg :
-      (-(189 / 100 : ℝ)) * sqrt (y * (250000 / 1393353 : ℝ))
-        = (-189 / 100 : ℝ) * sqrt (y * (250000 / 1393353 : ℝ)) := by
-    ring
-  rw [hneg]
-  simp only [styleVal]
+  unfold styleVal
+  rw [show y ^ 5 = y * (y * (y * (y * y))) by ring,
+    show (379.7 : ℝ) = (3797 / 10 : ℝ) by norm_num,
+    show (5.573412 : ℝ) = (1393353 / 250000 : ℝ) by norm_num, hdiv,
+    rpow_def_of_pos hposbase, show (1.52 : ℝ) = (38 / 25 : ℝ) by norm_num,
+    show sqrt y / sqrt (1393353 / 250000 : ℝ) = sqrt (y * (250000 / 1393353 : ℝ)) by
+      rw [← sqrt_div (le_of_lt hy), hdiv],
+    show (1.89 : ℝ) = (189 / 100 : ℝ) by norm_num,
+    show (-(189 / 100 : ℝ)) * sqrt (y * (250000 / 1393353 : ℝ)) =
+      (-189 / 100 : ℝ) * sqrt (y * (250000 / 1393353 : ℝ)) by ring]
 
 lemma rpow_652_split {y : ℝ} (hy : 0 < y) :
     y ^ (6.52 : ℝ) = y ^ (5 : ℕ) * y ^ (1.52 : ℝ) := by
-  have hdecomp : (6.52 : ℝ) = (5 : ℝ) + (1.52 : ℝ) := by
-    norm_num
-  rw [hdecomp]
-  calc
-    y ^ ((5 : ℝ) + (1.52 : ℝ)) = y ^ (5 : ℝ) * y ^ (1.52 : ℝ) := by
-      simpa using (rpow_add hy (5 : ℝ) (1.52 : ℝ))
-    _ = y ^ (5 : ℕ) * y ^ (1.52 : ℝ) := by
-      simp
+  rw [show (6.52 : ℝ) = 5 + 1.52 by norm_num, rpow_add hy]; simp
 
 lemma sqrt_ratio_5573412 {y : ℝ} (hy : 0 ≤ y) :
     (y / 5.573412) ^ ((1 : ℝ) / 2) = sqrt y / sqrt (5.573412 : ℝ) := by
@@ -79,12 +51,9 @@ lemma sqrt_ratio_5573412 {y : ℝ} (hy : 0 ≤ y) :
   rw [sqrt_div hy]
 
 theorem not_mem_Ico_of_ge_exp3000
-    {z lo hi : ℝ}
-    (hz : z ≥ exp 3000)
-    (hhi : hi ≤ exp 3000) :
-    ¬ z ∈ Set.Ico lo hi := by
-  intro hzmem
-  exact (not_lt_of_ge (le_trans hhi hz)) hzmem.2
+    {z lo hi : ℝ} (hz : z ≥ exp 3000) (hhi : hi ≤ exp 3000) :
+    ¬ z ∈ Set.Ico lo hi :=
+  fun hzmem => (not_lt_of_ge (le_trans hhi hz)) hzmem.2
 
 theorem styleVal_bound_3914_1311 :
     ∀ y ∈ Set.Icc (3914 : ℝ) 3914, styleVal y ≤ (1311 : ℝ) := by
@@ -101,26 +70,21 @@ theorem styleVal_bound_3915_13042_div_10 :
 
 theorem tail_small :
     7 * (3914 : ℝ) ^ 6 * exp (-(1957 : ℝ)) / (log 2) ^ 8 ≤ (1 : ℝ) / 1000000 := by
-  have haux : ∀ y ∈ Set.Icc (3914 : ℝ) 3914,
-      7 * y ^ 6 * exp (-y / 2) / (log 2) ^ 8 ≤ (1 : ℝ) / 1000000 := by
-    interval_bound 20
-  have h := haux 3914 (by constructor <;> norm_num)
-  have hy : (-(3914 : ℝ) / 2) = (-(1957 : ℝ)) := by ring
-  simpa [hy] using h
+  have h := (show ∀ y ∈ Set.Icc (3914 : ℝ) 3914,
+      7 * y ^ 6 * exp (-y / 2) / (log 2) ^ 8 ≤ (1 : ℝ) / 1000000 by
+    interval_bound 20) 3914 ⟨le_refl _, le_refl _⟩
+  simpa [show (-(3914 : ℝ) / 2) = -(1957 : ℝ) by ring] using h
 
 theorem exp_3914_poly_small :
-    2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) ≤ (1 : ℝ) / 1000000 := by
-  have haux : ∀ y ∈ Set.Icc (3914 : ℝ) 3914,
-      2 * y ^ 6 * exp (-y) ≤ (1 : ℝ) / 1000000 := by
-    interval_bound 20
-  exact haux 3914 (by constructor <;> norm_num)
+    2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) ≤ (1 : ℝ) / 1000000 :=
+  (show ∀ y ∈ Set.Icc (3914 : ℝ) 3914, 2 * y ^ 6 * exp (-y) ≤ (1 : ℝ) / 1000000 by
+    interval_bound 20) 3914 ⟨le_refl _, le_refl _⟩
 
 theorem exp_1169_small :
-    exp (-(1.89 : ℝ) * sqrt ((1169 : ℝ) / 5.573412)) ≤ (1 : ℝ) / 10000000 := by
-  have haux : ∀ z ∈ Set.Icc (1169 : ℝ) 1169,
-      exp (-(1.89 : ℝ) * sqrt (z / 5.573412)) ≤ (1 : ℝ) / 10000000 := by
-    interval_bound 20
-  exact haux 1169 (by constructor <;> norm_num)
+    exp (-(1.89 : ℝ) * sqrt ((1169 : ℝ) / 5.573412)) ≤ (1 : ℝ) / 10000000 :=
+  (show ∀ z ∈ Set.Icc (1169 : ℝ) 1169,
+      exp (-(1.89 : ℝ) * sqrt (z / 5.573412)) ≤ (1 : ℝ) / 10000000 by
+    interval_bound 20) 1169 ⟨le_refl _, le_refl _⟩
 
 theorem high_branch_aux {t c : ℝ}
     (ht : t ∈ Set.Icc (exp 1169) (exp 3870))
@@ -148,24 +112,15 @@ theorem high_branch_aux {t c : ℝ}
   have hratio_sq_le :
       (log t / 5.573412) ^ (2 : ℝ) ≤ ((3870 : ℝ) / 5.573412) ^ (2 : ℝ) := by
     exact rpow_le_rpow (by positivity) hratio_le (by positivity)
-  have hexp_le_1169 :
-      exp (-(1.89 : ℝ) * sqrt (log t / 5.573412)) ≤
-        exp (-(1.89 : ℝ) * sqrt ((1169 : ℝ) / 5.573412)) := by
-    have hsqrt_le :
-        sqrt ((1169 : ℝ) / 5.573412) ≤ sqrt (log t / 5.573412) := by
-      apply sqrt_le_sqrt
-      have : (1169 : ℝ) / 5.573412 ≤ log t / 5.573412 := by gcongr
-      exact this
-    have hneg_mul :
-        (-(1.89 : ℝ)) * sqrt (log t / 5.573412) ≤
-          (-(1.89 : ℝ)) * sqrt ((1169 : ℝ) / 5.573412) := by
-      nlinarith
-    simpa [mul_comm, mul_left_comm, mul_assoc] using exp_le_exp.mpr hneg_mul
   have hexp_le :
-      exp (-(1.89 : ℝ) * sqrt (log t / 5.573412)) ≤ (1 : ℝ) / 10000000 :=
-    le_trans hexp_le_1169 exp_1169_small
-  have hlog5_le : (log t) ^ 5 ≤ (3870 : ℝ) ^ 5 := by
-    exact pow_le_pow_left₀ hlog_nonneg hlog_le 5
+      exp (-(1.89 : ℝ) * sqrt (log t / 5.573412)) ≤ (1 : ℝ) / 10000000 := by
+    have : sqrt ((1169 : ℝ) / 5.573412) ≤ sqrt (log t / 5.573412) :=
+      sqrt_le_sqrt (by gcongr)
+    have : (-(1.89 : ℝ)) * sqrt (log t / 5.573412) ≤
+        (-(1.89 : ℝ)) * sqrt ((1169 : ℝ) / 5.573412) := by nlinarith
+    exact le_trans (by simpa [mul_comm, mul_left_comm, mul_assoc] using exp_le_exp.mpr this)
+      exp_1169_small
+  have hlog5_le : (log t) ^ 5 ≤ (3870 : ℝ) ^ 5 := pow_le_pow_left₀ hlog_nonneg hlog_le 5
   calc
     (log t) ^ 5 *
       (c * (log t / 5.573412) ^ (1.52 : ℝ) *
@@ -190,14 +145,10 @@ theorem branch3_aux {t : ℝ} (ht : t ∈ Set.Ico (exp 58) (exp 1169)) :
     have h := log_le_log htpos (le_of_lt ht.2)
     simpa [log_exp] using h
   have hlog_nonneg : 0 ≤ log t := by linarith [hlog_ge]
-  have hsqrt_le_one : sqrt (8 / (17 * Real.pi)) ≤ (1 : ℝ) := by
-    apply (sqrt_le_iff).2
-    constructor
-    · norm_num
-    · have hden : (8 : ℝ) ≤ 17 * Real.pi := by nlinarith [Real.pi_gt_three]
-      have hden_pos : 0 < 17 * Real.pi := by positivity
-      have hmul : (8 : ℝ) ≤ (1 : ℝ) ^ 2 * (17 * Real.pi) := by simpa using hden
-      exact (div_le_iff₀ hden_pos).2 hmul
+  have hsqrt_le_one : sqrt (8 / (17 * Real.pi)) ≤ (1 : ℝ) :=
+    (sqrt_le_iff).2 ⟨by norm_num,
+      (div_le_iff₀ (by positivity : (0 : ℝ) < 17 * Real.pi)).2
+        (by simpa using show (8 : ℝ) ≤ 17 * Real.pi by nlinarith [Real.pi_gt_three])⟩
   have hbase_ge_one : (1 : ℝ) ≤ log t / 6.455 := by
     have : (6.455 : ℝ) ≤ log t := by linarith [hlog_ge]
     exact (one_le_div (by positivity)).2 this
@@ -249,31 +200,25 @@ lemma integral_Icc_split
       intervalIntegral.integral_of_le hbc] using h_split_interval
 
 theorem exp_neg44_small :
-    exp (-(44 : ℝ)) ≤ (1 : ℝ) / 1000000000000000000 := by
-  have haux : ∀ z ∈ Set.Icc (44 : ℝ) 44,
-      exp (-z) ≤ (1 : ℝ) / 1000000000000000000 := by
-    interval_bound 20
-  exact haux 44 (by constructor <;> norm_num)
+    exp (-(44 : ℝ)) ≤ (1 : ℝ) / 1000000000000000000 :=
+  (show ∀ z ∈ Set.Icc (44 : ℝ) 44,
+      exp (-z) ≤ (1 : ℝ) / 1000000000000000000 by interval_bound 20) 44 ⟨le_refl _, le_refl _⟩
 
 theorem exp_neg1979_small :
     exp (-(1979 : ℝ))
-      ≤ (1 : ℝ) / 100000000000000000000000000000000000000000000000000000000000000000000000000000000 := by
-  have haux : ∀ z ∈ Set.Icc (1979 : ℝ) 1979,
-      exp (-z)
-        ≤ (1 : ℝ) / 100000000000000000000000000000000000000000000000000000000000000000000000000000000 := by
-    interval_bound 20
-  exact haux 1979 (by constructor <;> norm_num)
+      ≤ (1 : ℝ) / 100000000000000000000000000000000000000000000000000000000000000000000000000000000 :=
+  (show ∀ z ∈ Set.Icc (1979 : ℝ) 1979, exp (-z)
+      ≤ (1 : ℝ) / 100000000000000000000000000000000000000000000000000000000000000000000000000000000 by
+    interval_bound 20) 1979 ⟨le_refl _, le_refl _⟩
 
 theorem inv_log2_pow8_le_1000 : 1 / (log 2) ^ 8 ≤ (1000 : ℝ) := by
-  have hhalf_aux : ∀ z ∈ Set.Icc (2 : ℝ) 2, (1 / 2 : ℝ) ≤ log z := by
-    interval_bound 20
-  have hhalf : (1 / 2 : ℝ) ≤ log 2 := hhalf_aux 2 (by constructor <;> norm_num)
-  have hpow : (1 / 2 : ℝ) ^ 8 ≤ (log 2) ^ 8 :=
-    pow_le_pow_left₀ (by norm_num : 0 ≤ (1 / 2 : ℝ)) hhalf 8
-  have hdiv : 1 / (log 2) ^ 8 ≤ 1 / (1 / 2 : ℝ) ^ 8 :=
-    one_div_le_one_div_of_le (by positivity : 0 < (1 / 2 : ℝ) ^ 8) hpow
-  have hnum : (1 / (1 / 2 : ℝ) ^ 8) ≤ (1000 : ℝ) := by norm_num
-  exact le_trans hdiv hnum
+  have hhalf : (1 / 2 : ℝ) ≤ log 2 :=
+    (show ∀ z ∈ Set.Icc (2 : ℝ) 2, (1 / 2 : ℝ) ≤ log z by interval_bound 20)
+      2 ⟨le_refl _, le_refl _⟩
+  calc 1 / (log 2) ^ 8
+      ≤ 1 / (1 / 2 : ℝ) ^ 8 :=
+        one_div_le_one_div_of_le (by positivity) (pow_le_pow_left₀ (by norm_num) hhalf 8)
+    _ ≤ (1000 : ℝ) := by norm_num
 
 theorem low_contrib_le_three_tenths :
     (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) *
@@ -296,81 +241,36 @@ theorem low_contrib_le_three_tenths :
   have hA :
       (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * exp (-(44 : ℝ)) / (3870 : ℝ) ^ 7 ≤
         (1 : ℝ) / 20 := by
-    have hnum :
-        (30000000000000000 : ℝ) * ((1 : ℝ) / 1000000000000000000) ≤ (1 : ℝ) / 20 := by
-      norm_num
-    have htmp1 :
-        (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * exp (-(44 : ℝ)) / (3870 : ℝ) ^ 7
-          = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) / (3870 : ℝ) ^ 7) *
-              exp (-(44 : ℝ)) := by
-      ring
-    rw [htmp1]
-    have hstep :
-        ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) / (3870 : ℝ) ^ 7) *
-            exp (-(44 : ℝ))
-          ≤ (30000000000000000 : ℝ) * ((1 : ℝ) / 1000000000000000000) := by
-      exact mul_le_mul hAcoeff exp_neg44_small (by positivity) (by positivity)
-    exact le_trans hstep hnum
+    rw [show (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * exp (-(44 : ℝ)) / (3870 : ℝ) ^ 7
+        = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) / (3870 : ℝ) ^ 7) *
+            exp (-(44 : ℝ)) by ring]
+    exact le_trans (mul_le_mul hAcoeff exp_neg44_small (by positivity) (by positivity))
+      (by norm_num)
   have hC :
       (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) *
         (7 * (2 : ℝ) ^ 8) * exp (-(44 : ℝ)) / (3870 : ℝ) ^ 8 ≤ (1 : ℝ) / 20 := by
-    have hnum :
-        (20000000000000000 : ℝ) * ((1 : ℝ) / 1000000000000000000) ≤ (1 : ℝ) / 20 := by
-      norm_num
-    have htmp1 :
-        (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) *
-            (7 * (2 : ℝ) ^ 8) * exp (-(44 : ℝ)) / (3870 : ℝ) ^ 8
-          = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * (7 * (2 : ℝ) ^ 8) /
-                (3870 : ℝ) ^ 8) * exp (-(44 : ℝ)) := by
-      ring
-    rw [htmp1]
-    have hstep :
-        ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * (7 * (2 : ℝ) ^ 8) / (3870 : ℝ) ^ 8) *
-            exp (-(44 : ℝ))
-          ≤ (20000000000000000 : ℝ) * ((1 : ℝ) / 1000000000000000000) := by
-      exact mul_le_mul hCcoeff exp_neg44_small (by positivity) (by positivity)
-    exact le_trans hstep hnum
+    rw [show (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) *
+          (7 * (2 : ℝ) ^ 8) * exp (-(44 : ℝ)) / (3870 : ℝ) ^ 8
+        = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * (7 * (2 : ℝ) ^ 8) /
+              (3870 : ℝ) ^ 8) * exp (-(44 : ℝ)) by ring]
+    exact le_trans (mul_le_mul hCcoeff exp_neg44_small (by positivity) (by positivity))
+      (by norm_num)
   have hB :
       (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 *
         (exp (-(1979 : ℝ)) / (log 2) ^ 8) ≤ (1 : ℝ) / 20 := by
     have hBcoeff :
         (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 / (log 2) ^ 8
           ≤ (30000000000000000000000000000000000000000000 : ℝ) * 1000 := by
-      have hrewrite :
-          (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 / (log 2) ^ 8
-            = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7) * (1 / (log 2) ^ 8) := by
-        ring
-      rw [hrewrite]
-      have hstep1 :
-          ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7) * (1 / (log 2) ^ 8)
-            ≤ ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7) * 1000 := by
-        exact mul_le_mul_of_nonneg_left inv_log2_pow8_le_1000 (by positivity)
-      have hstep2 :
-          ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7) * 1000
-            ≤ (30000000000000000000000000000000000000000000 : ℝ) * 1000 := by
-        exact mul_le_mul_of_nonneg_right hBcoeff0 (by positivity)
-      exact le_trans hstep1 hstep2
-    have hnum :
-        ((30000000000000000000000000000000000000000000 : ℝ) * 1000) *
-            ((1 : ℝ) /
-              100000000000000000000000000000000000000000000000000000000000000000000000000000000)
-          ≤ (1 : ℝ) / 20 := by
-      norm_num
-    have hrewrite :
-        (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 *
-            (exp (-(1979 : ℝ)) / (log 2) ^ 8)
-          = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 / (log 2) ^ 8) *
-              exp (-(1979 : ℝ)) := by
-      ring
-    rw [hrewrite]
-    have hstep :
-        ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 / (log 2) ^ 8) *
-            exp (-(1979 : ℝ))
-          ≤ ((30000000000000000000000000000000000000000000 : ℝ) * 1000) *
-              ((1 : ℝ) /
-                100000000000000000000000000000000000000000000000000000000000000000000000000000000) := by
-      exact mul_le_mul hBcoeff exp_neg1979_small (by positivity) (by positivity)
-    exact le_trans hstep hnum
+      rw [show (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 / (log 2) ^ 8
+          = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7) * (1 / (log 2) ^ 8) by ring]
+      exact le_trans (mul_le_mul_of_nonneg_left inv_log2_pow8_le_1000 (by positivity))
+        (mul_le_mul_of_nonneg_right hBcoeff0 (by positivity))
+    rw [show (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 *
+          (exp (-(1979 : ℝ)) / (log 2) ^ 8)
+        = ((3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) * 7 / (log 2) ^ 8) *
+            exp (-(1979 : ℝ)) by ring]
+    exact le_trans (mul_le_mul hBcoeff exp_neg1979_small (by positivity) (by positivity))
+      (by norm_num)
   have hrewrite_main :
       (3914 : ℝ) ^ 6 * (100000000000000000720 : ℝ) *
         (exp (-(44 : ℝ)) / (3870 : ℝ) ^ 7
@@ -386,12 +286,8 @@ theorem low_contrib_le_three_tenths :
   nlinarith [hA, hB, hC]
 
 theorem sqrt_exp_3870 : sqrt (exp (3870 : ℝ)) = exp (1935 : ℝ) := by
-  have h : (3870 : ℝ) = (1935 : ℝ) + (1935 : ℝ) := by norm_num
-  rw [h, exp_add, sqrt_mul]
-  · have hs : (sqrt (exp (1935 : ℝ))) ^ 2 = exp (1935 : ℝ) := by
-      simpa [pow_two] using (Real.sq_sqrt (show 0 ≤ exp (1935 : ℝ) by positivity))
-    nlinarith [hs]
-  · positivity
+  rw [show (3870 : ℝ) = 1935 + 1935 by norm_num, exp_add, sqrt_mul (by positivity)]
+  nlinarith [Real.sq_sqrt (show 0 ≤ exp (1935 : ℝ) by positivity)]
 
 theorem low_contrib_raw_le_three_tenths :
     (3914 : ℝ) ^ 6 / exp (3914 : ℝ) *
@@ -424,15 +320,13 @@ theorem low_contrib_raw_le_three_tenths :
   rw [hrewrite]
   exact low_contrib_le_three_tenths
 
-theorem exp_23_gt_4e9 : (4000000000 : ℝ) < exp (23 : ℝ) := by
-  have haux : ∀ y ∈ Set.Icc (23 : ℝ) 23, (4000000000 : ℝ) < exp y := by
-    interval_bound 20
-  exact haux 23 (by constructor <;> norm_num)
+theorem exp_23_gt_4e9 : (4000000000 : ℝ) < exp (23 : ℝ) :=
+  (show ∀ y ∈ Set.Icc (23 : ℝ) 23, (4000000000 : ℝ) < exp y by interval_bound 20)
+    23 ⟨le_refl _, le_refl _⟩
 
-theorem exp_8_lt_3914 : exp (8 : ℝ) < (3914 : ℝ) := by
-  have haux : ∀ y ∈ Set.Icc (8 : ℝ) 8, exp y < (3914 : ℝ) := by
-    interval_bound 20
-  exact haux 8 (by constructor <;> norm_num)
+theorem exp_8_lt_3914 : exp (8 : ℝ) < (3914 : ℝ) :=
+  (show ∀ y ∈ Set.Icc (8 : ℝ) 8, exp y < (3914 : ℝ) by interval_bound 20)
+    8 ⟨le_refl _, le_refl _⟩
 
 namespace Calculations
 
@@ -446,15 +340,11 @@ theorem a_exp_upper_of
     (hpow5 : (5.573412 : ℝ) ^ (5 : ℕ) * ((L / 5.573412) ^ (5 : ℕ)) = L ^ (5 : ℕ))
     (haux : ∀ y ∈ Set.Icc L L, styleVal y ≤ C) :
     a (exp L) ≤ C := by
-  have hge : exp 3000 ≤ exp L := exp_le_exp.mpr hL
-  have hL0 : 0 ≤ L := by linarith
   have hLpos : 0 < L := by linarith
-  rw [ha_eq_admissible_ge_3000 (z := exp L) hge]
+  rw [ha_eq_admissible_ge_3000 (z := exp L) (exp_le_exp.mpr hL)]
   unfold admissible_bound
-  rw [log_exp]
-  have hpos : 0 < (L / 5.573412) := by positivity
-  rw [rpow_652_split hpos]
-  rw [sqrt_ratio_5573412 (y := L) hL0]
+  rw [log_exp, rpow_652_split (by positivity : 0 < L / 5.573412),
+    sqrt_ratio_5573412 (y := L) hLpos.le]
   let A : ℝ := (L / 5.573412) ^ (1.52 : ℝ)
   let E : ℝ := exp (-(1.89 : ℝ) * (sqrt L / sqrt (5.573412 : ℝ)))
   have hrewrite :
@@ -469,12 +359,8 @@ theorem a_exp_upper_of
   exact haux L ⟨le_rfl, le_rfl⟩
 
 theorem sqrt_exp_3914 : sqrt (exp (3914 : ℝ)) = exp (1957 : ℝ) := by
-  have h : (3914 : ℝ) = (1957 : ℝ) + (1957 : ℝ) := by norm_num
-  rw [h, exp_add, sqrt_mul]
-  · have hs : (sqrt (exp (1957 : ℝ))) ^ 2 = exp (1957 : ℝ) := by
-      simpa [pow_two] using (Real.sq_sqrt (show 0 ≤ exp (1957 : ℝ) by positivity))
-    nlinarith [hs]
-  · positivity
+  rw [show (3914 : ℝ) = 1957 + 1957 by norm_num, exp_add, sqrt_mul (by positivity)]
+  nlinarith [Real.sq_sqrt (show 0 ≤ exp (1957 : ℝ) by positivity)]
 
 theorem B_le_small_of
     {xₐ : ℝ}
@@ -486,21 +372,13 @@ theorem B_le_small_of
   rw [hlogxₐ]
   rw [hxₐ, sqrt_exp_3914]
   have htail : 7 * (3914 : ℝ) ^ 6 / (exp (1957 : ℝ) * (log 2) ^ 8) ≤ (1 : ℝ) / 1000000 := by
-    have ht0 : 0 < (exp (1957 : ℝ)) := by positivity
-    have : 7 * (3914 : ℝ) ^ 6 / (exp (1957 : ℝ) * (log 2) ^ 8) =
-      7 * (3914 : ℝ) ^ 6 * exp (-(1957 : ℝ)) / (log 2) ^ 8 := by
-      field_simp [ht0.ne']
-      rw [show (1 : ℝ) = exp (1957 : ℝ) * exp (-(1957 : ℝ)) by
-        rw [← exp_add]; norm_num]
-    rw [this]
+    rw [show 7 * (3914 : ℝ) ^ 6 / (exp (1957 : ℝ) * (log 2) ^ 8) =
+      7 * (3914 : ℝ) ^ 6 * exp (-(1957 : ℝ)) / (log 2) ^ 8 by
+      field_simp [(show (0 : ℝ) < exp (1957 : ℝ) by positivity).ne']
+      rw [show (1 : ℝ) = exp (1957 : ℝ) * exp (-(1957 : ℝ)) by rw [← exp_add]; norm_num]]
     exact tail_small
-  have hmain : (1 / (3914 : ℝ) + 7 * 2 ^ 8 / (3914 : ℝ) ^ 2 + (1 : ℝ) / 1000000) ≤ (3 : ℝ) / 8000 := by
-    norm_num
-  have hle : 1 / (3914 : ℝ) + 7 * 2 ^ 8 / (3914 : ℝ) ^ 2
-      + 7 * (3914 : ℝ) ^ 6 / (exp (1957 : ℝ) * (log 2) ^ 8)
-      ≤ 1 / (3914 : ℝ) + 7 * 2 ^ 8 / (3914 : ℝ) ^ 2 + (1 : ℝ) / 1000000 := by
-    linarith [htail]
-  linarith [hle, hmain]
+  linarith [htail, show (1 / (3914 : ℝ) + 7 * 2 ^ 8 / (3914 : ℝ) ^ 2 +
+    (1 : ℝ) / 1000000) ≤ (3 : ℝ) / 8000 by norm_num]
 
 theorem C3_le_one_of
     {xₐ : ℝ}
@@ -512,46 +390,23 @@ theorem C3_le_one_of
   simp only [Nat.reduceAdd, Nat.one_le_ofNat, Finset.sum_Icc_succ_top, Finset.Icc_self,
     Finset.sum_singleton, Nat.factorial, Nat.succ_eq_add_one, zero_add, mul_one, Nat.cast_one,
     one_div, Nat.cast_ofNat, Nat.reduceMul]
-  have hA : 2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) ≤ (1 : ℝ) / 1000000 := by
-    exact exp_3914_poly_small
+  have hA : 2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) ≤ (1 : ℝ) / 1000000 := exp_3914_poly_small
   let u : ℝ := (log 2)⁻¹
   have hu_le : u ≤ (2 : ℝ) := by
     dsimp [u]
     have hhalf : (1 / 2 : ℝ) ≤ log 2 := by linarith [log_two_gt_d9]
     have h := one_div_le_one_div_of_le (by norm_num : (0 : ℝ) < 1 / 2) hhalf
     simpa [one_div] using h
-  have hBaux :
-      (u ^ 2 + 2 * u ^ 3 + 6 * u ^ 4 + 24 * u ^ 5 + 120 * u ^ 6)
-        ≤ ((2 : ℝ) ^ 2 + 2 * (2 : ℝ) ^ 3 + 6 * (2 : ℝ) ^ 4 + 24 * (2 : ℝ) ^ 5 + 120 * (2 : ℝ) ^ 6) := by
-    gcongr
   have hB :
       ((log 2 ^ 2)⁻¹ + 2 / log 2 ^ 3 + 6 / log 2 ^ 4 + 24 / log 2 ^ 5 + 120 / log 2 ^ 6) ≤ (9000 : ℝ) := by
-    have huform :
-        ((log 2 ^ 2)⁻¹ + 2 / log 2 ^ 3 + 6 / log 2 ^ 4 + 24 / log 2 ^ 5 + 120 / log 2 ^ 6)
-          = u ^ 2 + 2 * u ^ 3 + 6 * u ^ 4 + 24 * u ^ 5 + 120 * u ^ 6 := by
-      dsimp [u]
-      ring_nf
-    rw [huform]
-    have hnum : ((2 : ℝ) ^ 2 + 2 * (2 : ℝ) ^ 3 + 6 * (2 : ℝ) ^ 4 + 24 * (2 : ℝ) ^ 5 + 120 * (2 : ℝ) ^ 6) ≤ (9000 : ℝ) := by
-      norm_num
-    exact le_trans hBaux hnum
-  have hdiv :
-      2 * (3914 : ℝ) ^ 6 / exp (3914 : ℝ)
-      = 2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) := by
-    have he : (1 : ℝ) = exp (3914 : ℝ) * exp (-(3914 : ℝ)) := by
-      rw [← exp_add]
-      norm_num
-    field_simp
-    rw [he]
-  rw [hdiv]
-  have hmul :
-      2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) *
-        ((log 2 ^ 2)⁻¹ + 2 / log 2 ^ 3 + 6 / log 2 ^ 4 + 24 / log 2 ^ 5 + 120 / log 2 ^ 6)
-      ≤ ((1 : ℝ) / 1000000) * (9000 : ℝ) := by
-    exact mul_le_mul hA hB (by positivity) (by positivity)
-  have hnum : ((1 : ℝ) / 1000000) * (9000 : ℝ) ≤ (1 : ℝ) := by
-    norm_num
-  exact le_trans hmul hnum
+    rw [show ((log 2 ^ 2)⁻¹ + 2 / log 2 ^ 3 + 6 / log 2 ^ 4 + 24 / log 2 ^ 5 + 120 / log 2 ^ 6)
+        = u ^ 2 + 2 * u ^ 3 + 6 * u ^ 4 + 24 * u ^ 5 + 120 * u ^ 6 by dsimp [u]; ring_nf]
+    exact le_trans (show u ^ 2 + 2 * u ^ 3 + 6 * u ^ 4 + 24 * u ^ 5 + 120 * u ^ 6
+        ≤ 2 ^ 2 + 2 * 2 ^ 3 + 6 * 2 ^ 4 + 24 * 2 ^ 5 + 120 * 2 ^ 6 by gcongr) (by norm_num)
+  rw [show 2 * (3914 : ℝ) ^ 6 / exp (3914 : ℝ)
+      = 2 * (3914 : ℝ) ^ 6 * exp (-(3914 : ℝ)) by
+    field_simp; rw [show (1 : ℝ) = exp (3914 : ℝ) * exp (-(3914 : ℝ)) by rw [← exp_add]; norm_num]]
+  exact le_trans (mul_le_mul hA hB (by positivity) (by positivity)) (by norm_num)
 
 theorem C1_le_one_of
     {a : ℝ → ℝ} {xₐ : ℝ}
@@ -642,8 +497,8 @@ theorem C1_le_one_of
 
   have hf_int_high : IntegrableOn f (Set.Icc (exp 3870) xₐ) volume :=
     hf_int.mono_set (by intro t ht; exact ⟨le_trans (by linarith [add_one_le_exp (3870 : ℝ)]) ht.1, ht.2⟩)
-  have hconst_high_int : IntegrableOn (fun _ : ℝ ↦ (2520 : ℝ) / (3870 : ℝ) ^ 7) (Set.Icc (exp 3870) xₐ) volume := by
-    exact ContinuousOn.integrableOn_Icc continuousOn_const
+  have hconst_high_int : IntegrableOn (fun _ : ℝ ↦ (2520 : ℝ) / (3870 : ℝ) ^ 7) (Set.Icc (exp 3870) xₐ) volume :=
+    ContinuousOn.integrableOn_Icc continuousOn_const
   have hhigh_pt : ∀ t ∈ Set.Icc (exp 3870) xₐ, f t ≤ (2520 : ℝ) / (3870 : ℝ) ^ 7 := by
     intro t ht
     have ht3000 : exp 3000 ≤ t :=
@@ -678,32 +533,19 @@ theorem C1_le_one_of
     simp [smul_eq_mul, mul_comm]
   have hhigh_le :
       ∫ t in Set.Icc (exp 3870) xₐ, f t
-        ≤ (2520 : ℝ) / (3870 : ℝ) ^ 7 * xₐ := by
-    have htmp : ∫ t in Set.Icc (exp 3870) xₐ, f t
-        ≤ (2520 : ℝ) / (3870 : ℝ) ^ 7 * (xₐ - exp 3870) := by
-      simpa [hhigh_const_eval] using hhigh_le_const
-    have hsub : xₐ - exp 3870 ≤ xₐ := by
-      have : 0 ≤ exp 3870 := by positivity
-      linarith
-    have hcoeff_nonneg : 0 ≤ (2520 : ℝ) / (3870 : ℝ) ^ 7 := by positivity
-    exact le_trans htmp (mul_le_mul_of_nonneg_left hsub hcoeff_nonneg)
+        ≤ (2520 : ℝ) / (3870 : ℝ) ^ 7 * xₐ :=
+    le_trans (by simpa [hhigh_const_eval] using hhigh_le_const)
+      (mul_le_mul_of_nonneg_left (by linarith [show (0 : ℝ) ≤ exp 3870 by positivity])
+        (by positivity))
 
-  have hsum :
-      (∫ t in Set.Icc 2 (exp 3870), f t) + (∫ t in Set.Icc (exp 3870) xₐ, f t)
-        ≤ K * (exp 3870 / log (exp 3870) ^ 7
-          + 7 * (sqrt (exp 3870) / log 2 ^ 8 + 2 ^ 8 * exp 3870 / log (exp 3870) ^ 8))
-          + (2520 : ℝ) / (3870 : ℝ) ^ 7 * xₐ := by
-    linarith [hlow_le, hhigh_le]
-  have hcoef_nonneg : 0 ≤ log xₐ ^ 6 / xₐ := by
-    positivity
   have hmain :
       log xₐ ^ 6 / xₐ *
           ((∫ t in Set.Icc 2 (exp 3870), f t) + (∫ t in Set.Icc (exp 3870) xₐ, f t))
         ≤ log xₐ ^ 6 / xₐ *
             (K * (exp 3870 / log (exp 3870) ^ 7
               + 7 * (sqrt (exp 3870) / log 2 ^ 8 + 2 ^ 8 * exp 3870 / log (exp 3870) ^ 8))
-              + (2520 : ℝ) / (3870 : ℝ) ^ 7 * xₐ) := by
-    exact mul_le_mul_of_nonneg_left hsum hcoef_nonneg
+              + (2520 : ℝ) / (3870 : ℝ) ^ 7 * xₐ) :=
+    mul_le_mul_of_nonneg_left (by linarith [hlow_le, hhigh_le]) (by positivity)
   have hmain' :
       (3914 : ℝ) ^ 6 / exp (3914 : ℝ) *
           ((∫ t in Set.Icc 2 (exp 3870), f t) + (∫ t in Set.Icc (exp 3870) (exp (3914 : ℝ)), f t))
@@ -722,18 +564,7 @@ theorem C1_le_one_of
               + 7 * (sqrt (exp 3870) / log 2 ^ 8 + 2 ^ 8 * exp 3870 / (3870 : ℝ) ^ 8)))
           + (2520 : ℝ) * (3914 : ℝ) ^ 6 / (3870 : ℝ) ^ 7 := by
     field_simp
-  rw [hdecomp] at hmain'
-  dsimp [K] at hmain'
-  have hlow_num :
-      (3914 : ℝ) ^ 6 / exp (3914 : ℝ) *
-          ((100000000000000000720 : ℝ) *
-            (exp 3870 / (3870 : ℝ) ^ 7
-              + 7 *
-                (sqrt (exp 3870) / (log 2) ^ 8
-                  + (2 : ℝ) ^ 8 * exp 3870 / (3870 : ℝ) ^ 8)))
-        ≤ (3 : ℝ) / 10 := low_contrib_raw_le_three_tenths
-  have hhigh_num : (2520 : ℝ) * (3914 : ℝ) ^ 6 / (3870 : ℝ) ^ 7 ≤ (7 : ℝ) / 10 := by
-    norm_num
+  rw [hdecomp] at hmain'; dsimp [K] at hmain'
   have hfin :
       (3914 : ℝ) ^ 6 / exp (3914 : ℝ) *
           ((100000000000000000720 : ℝ) *
@@ -742,49 +573,18 @@ theorem C1_le_one_of
                 (sqrt (exp 3870) / (log 2) ^ 8
                   + (2 : ℝ) ^ 8 * exp 3870 / (3870 : ℝ) ^ 8)))
           + (2520 : ℝ) * (3914 : ℝ) ^ 6 / (3870 : ℝ) ^ 7 ≤ 1 := by
-    nlinarith [hlow_num, hhigh_num]
-  have horig_split :
-      log xₐ ^ 6 / xₐ *
-          ((∫ t in Set.Icc 2 (exp 3870), f t) + (∫ t in Set.Icc (exp 3870) xₐ, f t))
-        ≤ (3914 : ℝ) ^ 6 / exp (3914 : ℝ) *
-            ((100000000000000000720 : ℝ) *
-              (exp 3870 / (3870 : ℝ) ^ 7
-                + 7 *
-                  (sqrt (exp 3870) / (log 2) ^ 8
-                    + (2 : ℝ) ^ 8 * exp 3870 / (3870 : ℝ) ^ 8)))
-            + (2520 : ℝ) * (3914 : ℝ) ^ 6 / (3870 : ℝ) ^ 7 := by
-    simpa [f, hxₐ, log_exp] using hmain'
-  have horig :
-      log xₐ ^ 6 / xₐ * ∫ t in Set.Icc 2 xₐ, (720 + a t) / log t ^ 7
-        ≤ (3914 : ℝ) ^ 6 / exp (3914 : ℝ) *
-            ((100000000000000000720 : ℝ) *
-              (exp 3870 / (3870 : ℝ) ^ 7
-                + 7 *
-                  (sqrt (exp 3870) / (log 2) ^ 8
-                    + (2 : ℝ) ^ 8 * exp 3870 / (3870 : ℝ) ^ 8)))
-            + (2520 : ℝ) * (3914 : ℝ) ^ 6 / (3870 : ℝ) ^ 7 := by
-    rw [hsplit]
-    exact horig_split
-  exact le_trans horig hfin
+    nlinarith [low_contrib_raw_le_three_tenths,
+      show (2520 : ℝ) * (3914 : ℝ) ^ 6 / (3870 : ℝ) ^ 7 ≤ (7 : ℝ) / 10 by norm_num]
+  exact le_trans (by rw [hsplit]; simpa [f, hxₐ, log_exp] using hmain') hfin
 
 theorem m_upper_from_bounds
     {a_xa C1 C2 C3 B : ℝ}
-    (hax0 : 0 ≤ a_xa)
-    (hC3 : 0 ≤ C3)
-    (hB0 : 0 ≤ B)
-    (hC2abs : |C2| ≤ C1)
-    (hC1 : C1 ≤ (1 : ℝ)) :
+    (hax0 : 0 ≤ a_xa) (hC3 : 0 ≤ C3) (hB0 : 0 ≤ B)
+    (hC2abs : |C2| ≤ C1) (hC1 : C1 ≤ (1 : ℝ)) :
     120 - a_xa - (C2 + C3) - a_xa * B ≤ (121 : ℝ) := by
-  have hC2C3 : -(C2 + C3) ≤ |C2| := by
-    have h1 : -(C2 + C3) ≤ -C2 := by linarith
-    have h2 : -C2 ≤ |C2| := by nlinarith [neg_abs_le C2]
-    exact le_trans h1 h2
-  have hmain :
-      120 - a_xa - (C2 + C3) - a_xa * B ≤ 120 + |C2| := by
-    nlinarith [hax0, hC3, hB0, hC2C3]
-  have hmain2 : 120 + |C2| ≤ (121 : ℝ) := by
-    nlinarith [hC2abs, hC1]
-  exact le_trans hmain hmain2
+  have : -(C2 + C3) ≤ |C2| :=
+    le_trans (by linarith : -(C2 + C3) ≤ -C2) (by nlinarith [neg_abs_le C2])
+  nlinarith [hax0, hC3, hB0, hC2abs, hC1]
 
 theorem M_nonneg_from_bounds
     {a_xa a_exa C1 B : ℝ}
@@ -797,49 +597,26 @@ theorem M_nonneg_from_bounds
 
 theorem M_upper_from_bounds
     {a_xa a_exa C1 B : ℝ}
-    (hax0 : 0 ≤ a_xa)
-    (hC1 : C1 ≤ (1 : ℝ))
-    (hax : a_xa ≤ (1311 : ℝ))
-    (haex : a_exa ≤ (13042 / 10 : ℝ))
+    (hax0 : 0 ≤ a_xa) (hC1 : C1 ≤ (1 : ℝ))
+    (hax : a_xa ≤ (1311 : ℝ)) (haex : a_exa ≤ (13042 / 10 : ℝ))
     (hB : B ≤ (3 : ℝ) / 8000) :
     120 + a_exa + C1 + (720 + a_xa) * B ≤ (1426 : ℝ) := by
-  have h720a : 720 + a_xa ≤ (2031 : ℝ) := by linarith
-  have hterm_le : (720 + a_xa) * B ≤ (2031 : ℝ) * ((3 : ℝ) / 8000) := by
-    have h1 :
-        (720 + a_xa) * B ≤ (720 + a_xa) * ((3 : ℝ) / 8000) := by
-      exact mul_le_mul_of_nonneg_left hB (by linarith [hax0])
-    have h2 :
-        (720 + a_xa) * ((3 : ℝ) / 8000) ≤ (2031 : ℝ) * ((3 : ℝ) / 8000) := by
-      exact mul_le_mul_of_nonneg_right h720a (by positivity)
-    exact le_trans h1 h2
-  nlinarith [hC1, haex, hterm_le]
+  have : (720 + a_xa) * B ≤ (2031 : ℝ) * ((3 : ℝ) / 8000) :=
+    le_trans (mul_le_mul_of_nonneg_left hB (by linarith))
+      (mul_le_mul_of_nonneg_right (by linarith) (by positivity))
+  nlinarith [hC1, haex]
 
 theorem m_lower_from_bounds
     {a_xa C1 C2 C3 B : ℝ}
-    (hax0 : 0 ≤ a_xa)
-    (hax : a_xa ≤ (1311 : ℝ))
-    (hC1 : C1 ≤ (1 : ℝ))
-    (hC2abs : |C2| ≤ C1)
-    (hC3 : C3 ≤ (1 : ℝ))
-    (hB : B ≤ (3 : ℝ) / 8000) :
+    (hax0 : 0 ≤ a_xa) (hax : a_xa ≤ (1311 : ℝ))
+    (hC1 : C1 ≤ (1 : ℝ)) (hC2abs : |C2| ≤ C1)
+    (hC3 : C3 ≤ (1 : ℝ)) (hB : B ≤ (3 : ℝ) / 8000) :
     (-1194 : ℝ) ≤ 120 - a_xa - (C2 + C3) - a_xa * B := by
-  have hC2abs1 : |C2| ≤ (1 : ℝ) := le_trans hC2abs hC1
-  have hC2le : C2 ≤ (1 : ℝ) := (abs_le.mp hC2abs1).2
-  have hC2C3_lower : (-2 : ℝ) ≤ -(C2 + C3) := by
-    nlinarith [hC2le, hC3]
-  have hprod_le : a_xa * B ≤ (1311 : ℝ) * ((3 : ℝ) / 8000) := by
-    have h1 :
-        a_xa * B ≤ a_xa * ((3 : ℝ) / 8000) := by
-      exact mul_le_mul_of_nonneg_left hB hax0
-    have h2 : a_xa * ((3 : ℝ) / 8000) ≤ (1311 : ℝ) * ((3 : ℝ) / 8000) := by
-      exact mul_le_mul_of_nonneg_right hax (by positivity)
-    exact le_trans h1 h2
-  have hnegprod :
-      -((1311 : ℝ) * ((3 : ℝ) / 8000)) ≤ -a_xa * B := by
-    nlinarith [hprod_le]
-  have hnega : (-(1311 : ℝ)) ≤ -a_xa := by
-    nlinarith [hax]
-  nlinarith [hnega, hC2C3_lower, hnegprod]
+  have hC2le : C2 ≤ (1 : ℝ) := (abs_le.mp (le_trans hC2abs hC1)).2
+  have : a_xa * B ≤ (1311 : ℝ) * ((3 : ℝ) / 8000) :=
+    le_trans (mul_le_mul_of_nonneg_left hB hax0)
+      (mul_le_mul_of_nonneg_right hax (by positivity))
+  nlinarith
 
 end Calculations
 


### PR DESCRIPTION
Reduce proof verbosity while preserving readability:
- Collapse sequential have/rw chains into single rw calls with inline proofs
- Convert simple lemmas to term-mode proofs
- Inline point-evaluation patterns (∀ y ∈ Icc L L, ... → direct application)
- Simplify mul_le_mul / le_trans chains
- Remove redundant intermediate hypotheses