### PR TITLE
Add a link to to Bombieri-Vinogradov project

### DIFF
--- a/blueprint/src/blueprint.tex
+++ b/blueprint/src/blueprint.tex
@@ -210,6 +210,10 @@ secondary ones.
 
 \inputleanmodule{PrimeNumberTheoremAnd.IwaniecKowalskiCh1}
 
+\chapter{Bombieri-Vinogradov}\label{BV-chapter}
+
+A formalization of Bombieri-Vinogradov (modulo Siegel-Walfisz) is under way at \url{https://github.com/FLDutchmann/lean-bombieri-vinogradov}
+
 \bibliographystyle{plain} % We choose the "plain" reference style
 \bibliography{references}
 


### PR DESCRIPTION
This PR adds a chapter to PNT+ that purely links to my project formalizing Bombieri-Vinogradov.

The work in my project would be quite at home in PNT+, but I'm working on it by myself and prefer the freedom to work on the blueprint on my own terms. As a middle ground, and to make it public that somebody is working on B-V, I propose adding this link.

I'm opening this PR after a private discussion with @AlexKontorovich 