### PR TITLE
Refactor B_plus_mono and B_minus_mono: extract shared lemmas

### DIFF
--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -417,26 +417,27 @@ theorem sinh_add_pi_I (z : ℂ) : sinh (z + π * I) = -sinh z := by
 theorem cosh_add_pi_I (z : ℂ) : cosh (z + π * I) = -cosh z := by
     simp [Complex.cosh_add, cosh_mul_I, sinh_mul_I]
 
-@[simp]
-public theorem tanh_add_pi_I (z : ℂ) : tanh (z + π * I) = tanh z := by
-  rw [Complex.tanh_eq_sinh_div_cosh, Complex.tanh_eq_sinh_div_cosh,
-    sinh_add_pi_I, cosh_add_pi_I]; field_simp
-
-lemma coth_add_pi_mul_I (z : ℂ) : coth (z + π * I) = coth z := by
-  simp [coth]
-
 theorem tanh_add_int_mul_pi_I (z : ℂ) (m : ℤ) : tanh (z + π * I * m) = tanh z := by
+  have step (w : ℂ) : tanh (w + π * I) = tanh w := by
+    rw [Complex.tanh_eq_sinh_div_cosh, Complex.tanh_eq_sinh_div_cosh,
+      sinh_add_pi_I, cosh_add_pi_I]; field_simp
   induction m using Int.induction_on with
   | zero => simp
   | succ n ih =>
     push_cast at ih ⊢
-    rw [show z + ↑π * I * (↑n + 1) = (z + ↑π * I * ↑n) + ↑π * I from by ring]
-    rw [tanh_add_pi_I]; exact ih
+    rw [show z + π * I * (n + 1) = (z + π * I * n) + π * I from by ring, step]; exact ih
   | pred n ih =>
     push_cast at ih ⊢
-    have h := tanh_add_pi_I (z + ↑π * I * (-(↑n : ℂ) - 1))
-    rw [show z + ↑π * I * (-↑n - 1) + ↑π * I = z + ↑π * I * -↑n from by ring] at h
+    have h := step (z + π * I * (-n - 1))
+    rw [show z + π * I * (-n - 1) + π * I = z + π * I * -n from by ring] at h
     rw [← h]; exact ih
+
+@[simp]
+public theorem tanh_add_pi_I (z : ℂ) : tanh (z + π * I) = tanh z := by
+  have := tanh_add_int_mul_pi_I z 1; simp at this; exact this
+
+lemma coth_add_pi_mul_I (z : ℂ) : coth (z + π * I) = coth z := by
+  simp [coth]
 
 @[blueprint
   "Phi-circ-def"

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -425,6 +425,19 @@ public theorem tanh_add_pi_I (z : ℂ) : tanh (z + π * I) = tanh z := by
 lemma coth_add_pi_mul_I (z : ℂ) : coth (z + π * I) = coth z := by
   simp [coth]
 
+theorem tanh_add_int_mul_pi_I (z : ℂ) (m : ℤ) : tanh (z + π * I * m) = tanh z := by
+  induction m using Int.induction_on with
+  | zero => simp
+  | succ n ih =>
+    push_cast at ih ⊢
+    rw [show z + ↑π * I * (↑n + 1) = (z + ↑π * I * ↑n) + ↑π * I from by ring]
+    rw [tanh_add_pi_I]; exact ih
+  | pred n ih =>
+    push_cast at ih ⊢
+    have h := tanh_add_pi_I (z + ↑π * I * (-(↑n : ℂ) - 1))
+    rw [show z + ↑π * I * (-↑n - 1) + ↑π * I = z + ↑π * I * -↑n from by ring] at h
+    rw [← h]; exact ih
+
 @[blueprint
   "Phi-circ-def"
   (title := "Definition of $\\Phi^{\\pm,\\circ}_\\nu$")
@@ -858,36 +871,15 @@ noncomputable def Phi_star (ν ε : ℝ) (z : ℂ) : ℂ :=
 theorem Phi_star_zero (ν ε : ℝ) : Phi_star ν ε 0 = 0 := by simp [Phi_star]
 
 @[fun_prop]
-lemma meromorphic_tanh : Meromorphic Complex.tanh := by
-  intro z
-  apply MeromorphicAt.div <;> fun_prop
+lemma meromorphic_tanh : Meromorphic Complex.tanh := fun z => meromorphicAt_tanh z
 
-lemma meromorphic_coth : Meromorphic coth := by
-  intro z
-  apply MeromorphicAt.div <;> fun_prop
+lemma meromorphic_coth : Meromorphic coth := fun z => meromorphicAt_coth z
 
 lemma meromorphic_coth' : Meromorphic (fun s : ℂ => Complex.cosh s / Complex.sinh s) := by
-  have : Meromorphic (fun s : ℂ => 1 / Complex.tanh s) := by
-    convert meromorphic_coth using 1
-  simpa [Complex.tanh_eq_sinh_div_cosh] using this
+  intro z; apply MeromorphicAt.div <;> fun_prop
 
 lemma meromorphic_coth'' : Meromorphic (fun s : ℂ => Complex.cosh (s / 2) / Complex.sinh (s / 2)) := by
-  intro s
-  obtain ⟨n, hn⟩ := meromorphic_coth' (s / 2)
-  refine ⟨n, ?_⟩
-  have h_comp : AnalyticAt ℂ
-      (fun z => (z / 2 - s / 2) ^ n •
-        (fun s => Complex.cosh s / Complex.sinh s) (z / 2)) s := by
-    apply_rules [ContDiffAt.analyticAt]
-    have : ContDiffAt ℂ ⊤
-        (fun z => (z - s / 2) ^ n •
-          (fun s => Complex.cosh s / Complex.sinh s) z) (s / 2) :=
-      hn.contDiffAt
-    convert this.comp s (contDiffAt_id.div_const 2) using 1
-  convert h_comp.mul (show AnalyticAt ℂ (fun _ => 2 ^ n) s from analyticAt_const)
-    using 2; norm_num
-  rw [show ((_ : ℂ) - s) = 2 * ((_ : ℂ) * (1 / 2) + s * (-1 / 2)) by ring]
-  rw [mul_pow]; ring
+  intro z; apply MeromorphicAt.div <;> fun_prop
 
 lemma meromorphicAt_B (ε : ℝ) (z₀ : ℂ) : MeromorphicAt (B ε) z₀ := by
   have h_comp : ∀ z, MeromorphicAt
@@ -2241,22 +2233,9 @@ theorem B_affine_periodic (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) (m : ℤ)
   have h_tanh_periodic :
       Complex.tanh ((-2 * Real.pi * I * (z - m) + ν) / 2) =
         Complex.tanh ((-2 * Real.pi * I * z + ν) / 2) := by
-    rw [Complex.tanh_eq_sinh_div_cosh, Complex.tanh_eq_sinh_div_cosh]
-    ring_nf; norm_num [Complex.sinh, Complex.cosh]; ring_nf
-    norm_num [Complex.exp_add, Complex.exp_sub]; ring_nf
-    have hexp : Complex.exp (Real.pi * I * m) = (-1) ^ m := by
-      rw [← Complex.exp_pi_mul_I, ← Complex.exp_int_mul]; ring_nf
-    norm_num [hexp]; ring_nf
-    rcases Int.even_or_odd' m with ⟨k, rfl | rfl⟩ <;>
-      norm_num [zpow_add₀, zpow_mul]
-    ring_nf; norm_num [Complex.exp_ne_zero] at *
-    rw [show -(Complex.exp (-(Real.pi * I * z)) * Complex.exp (ν * (1 / 2))) -
-          Complex.exp (Real.pi * I * z) * Complex.exp (-(ν * (1 / 2))) =
-        -(Complex.exp (-(Real.pi * I * z)) * Complex.exp (ν * (1 / 2)) +
-          Complex.exp (Real.pi * I * z) *
-            Complex.exp (-(ν * (1 / 2)))) from by ring,
-      inv_neg]
-    ring
+    rw [show (-2 * ↑π * I * (z - ↑m) + ↑ν) / 2 =
+      (-2 * ↑π * I * z + ↑ν) / 2 + ↑π * I * ↑m by ring]
+    exact tanh_add_int_mul_pi_I _ m
   grind
 
 @[blueprint

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -453,6 +453,16 @@ noncomputable def Phi_circ (ν ε : ℝ) (z : ℂ) : ℂ :=
 attribute [fun_prop] MeromorphicAt.comp_analyticAt
 
 @[fun_prop]
+theorem analyticAt_tanh (z : ℂ) (hz : Complex.cosh z ≠ 0) : AnalyticAt ℂ Complex.tanh z := by
+  simpa [Complex.tanh_eq_sinh_div_cosh] using
+    (Complex.analyticAt_sinh.div Complex.analyticAt_cosh hz :
+      AnalyticAt ℂ (fun z => Complex.sinh z / Complex.cosh z) z)
+
+@[fun_prop]
+theorem continuousAt_tanh (z : ℂ) (hz : Complex.cosh z ≠ 0) : ContinuousAt Complex.tanh z := by
+  exact (analyticAt_tanh z hz).continuousAt
+
+@[fun_prop]
 theorem meromorphicAt_tanh (z : ℂ) : MeromorphicAt Complex.tanh z := by fun_prop [Complex.tanh]
 
 @[fun_prop]
@@ -659,8 +669,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
             omega
           exact absurd hord_neg (not_lt.mpr ((tendsto_zero_iff_meromorphicOrderAt_pos h_mero_tanh).mp h).le)
         · have hcts : ContinuousAt Complex.tanh (w z / 2) := by
-            change ContinuousAt (fun z => Complex.sinh z / Complex.cosh z) _
-            exact Complex.analyticAt_sinh.continuousAt.div Complex.analyticAt_cosh.continuousAt hc
+            fun_prop (disch := exact hc)
           have hval : Complex.tanh (w z / 2) = 0 :=
             tendsto_nhds_unique (hcts.tendsto.mono_left nhdsWithin_le_nhds) h
           rw [Complex.tanh_eq_sinh_div_cosh, div_eq_zero_iff] at hval
@@ -672,8 +681,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
           rw [heq, h, zero_add] at hsum
           exact absurd hsum.symm (Complex.exp_ne_zero _)
         have hcts : ContinuousAt Complex.tanh (w z / 2) := by
-          change ContinuousAt (fun z => Complex.sinh z / Complex.cosh z) _
-          exact Complex.analyticAt_sinh.continuousAt.div Complex.analyticAt_cosh.continuousAt hc
+          fun_prop (disch := exact hc)
         have hval : Complex.tanh (w z / 2) = 0 := by
           rw [Complex.tanh_eq_sinh_div_cosh, h, zero_div]
         convert hcts.tendsto.mono_left nhdsWithin_le_nhds using 1
@@ -841,15 +849,22 @@ theorem B.continuous_zero (ε : ℝ) : ContinuousAt (B ε) 0 := by
   convert H hx' hx using 1; norm_num [coth]
   norm_num [Complex.tanh_eq_sinh_div_cosh]; ring_nf
 
+lemma sinh_ofReal_half_ne_zero {x : ℝ} (hx : x ≠ 0) : Complex.sinh ((x : ℂ) / 2) ≠ 0 := by
+  apply sinh_ne_zero_of_re_ne_zero
+  simpa using (div_ne_zero hx (by norm_num : (2 : ℝ) ≠ 0))
+
+lemma B_ofReal_eq (ε ν : ℝ) (hν : ν ≠ 0) :
+    B ε ν = ν * (Complex.cosh (ν / 2) / Complex.sinh (ν / 2) + ε) / 2 := by
+  simp [B, ofReal_eq_zero, hν, coth, Complex.tanh_eq_sinh_div_cosh]
+
 theorem B.continuousAt_ofReal_pos (ε s : ℝ) (hs : 0 < s) :
     ContinuousAt (fun t : ℝ ↦ B ε (t : ℂ)) s := by
   have h_eq : (fun t : ℝ ↦ (t : ℂ) * (coth ((t : ℂ) / 2) + ε) / 2) =ᶠ[nhds s] (fun t : ℝ ↦ B ε (t : ℂ)) := by
     filter_upwards [eventually_ne_nhds hs.ne'] with t ht
     simp [B, ht]
   refine ContinuousAt.congr ?_ h_eq
-  have h_re : ((s : ℂ) / 2).re ≠ 0 := by simp [hs.ne']
   refine ContinuousAt.div_const (ContinuousAt.mul (by fun_prop) (ContinuousAt.add ?_ continuousAt_const)) 2
-  exact ContinuousAt.coth (by fun_prop) (sinh_ne_zero_of_re_ne_zero h_re)
+  exact ContinuousAt.coth (by fun_prop) (by simpa using sinh_ofReal_half_ne_zero hs.ne')
 
 @[blueprint
   "Phi-star-def"
@@ -1445,9 +1460,8 @@ theorem ϕ_star_bound_right (ν₀ ν₁ ε c : ℝ) (hν₀ : 0 < ν₀) (hν�
   obtain ⟨C₂, hC₂⟩ : ∃ C₂ : ℝ, ∀ ν ∈ Set.Icc ν₀ ν₁, ‖B ε ν‖ ≤ C₂ := by
     have hB_def : ∀ ν ∈ Set.Icc ν₀ ν₁, B ε ν =
         ν * (Complex.cosh (ν / 2) / Complex.sinh (ν / 2) + ε) / 2 := by
-      unfold B coth
-      norm_num [Complex.tanh_eq_sinh_div_cosh]
-      intros; linarith
+      intro ν hν
+      exact B_ofReal_eq ε ν (by linarith [hν.1])
     have h_cont : ContinuousOn
         (fun ν : ℝ => ν * (Complex.cosh (ν / 2) / Complex.sinh (ν / 2) + ε) / 2)
         (Set.Icc ν₀ ν₁) := by
@@ -1458,9 +1472,7 @@ theorem ϕ_star_bound_right (ν₀ ν₁ ε c : ℝ) (hν₀ : 0 < ν₀) (hν�
       · fun_prop
       · fun_prop
       · intro x hx
-        have h3 : (↑x / 2 : ℂ) = ↑(x / 2) := by push_cast; ring
-        rw [h3]
-        exact_mod_cast ne_of_gt (by rw [Real.sinh_eq]; nlinarith [Real.exp_lt_exp.mpr (show -(x/2) < x/2 by linarith [hx.1])])
+        simpa using sinh_ofReal_half_ne_zero (by linarith [hx.1])
     obtain ⟨C₂, hC₂⟩ := IsCompact.exists_bound_of_continuousOn
       CompactIccSpace.isCompact_Icc h_cont
     exact ⟨C₂, fun ν hν => by aesop⟩
@@ -1514,8 +1526,7 @@ theorem ϕ_star_bound_left (ν₀ ν₁ ε c : ℝ) (hν₀ : 0 < ν₀) (hν₁
   obtain ⟨M, hM⟩ : ∃ M : ℝ, ∀ ν ∈ Set.Icc ν₀ ν₁, ‖B ε ν‖ ≤ M := by
     have hB_def : ∀ ν : ℝ, ν ≠ 0 →
         B ε ν = ν * (Complex.cosh (ν / 2) / Complex.sinh (ν / 2) + ε) / 2 := by
-      intros ν hν_nonzero
-      simp [B, ofReal_eq_zero, hν_nonzero, coth, Complex.tanh_eq_sinh_div_cosh]
+      exact B_ofReal_eq ε
     have hB_cont : ContinuousOn
         (fun ν : ℝ => ν * (Complex.cosh (ν / 2) / Complex.sinh (ν / 2) + ε) / 2)
         (Set.Icc ν₀ ν₁) := by
@@ -1525,12 +1536,9 @@ theorem ϕ_star_bound_left (ν₀ ν₁ ε c : ℝ) (hν₀ : 0 < ν₀) (hν₁
       refine ContinuousOn.div ?_ ?_ ?_
       · fun_prop
       · fun_prop
-      · norm_num [Complex.sinh]
-        intro x hx₁ hx₂
-        apply sub_ne_zero_of_ne
-        apply ne_of_apply_ne Complex.re
-        norm_num [Complex.exp_re]
-        grind
+      · intro x hx₁ hx₂
+        have hx_ne : x ≠ 0 := ne_of_gt (lt_of_lt_of_le hν₀ hx₁.1)
+        exact sinh_ofReal_half_ne_zero hx_ne hx₂
     obtain ⟨M, hM⟩ := IsCompact.exists_bound_of_continuousOn
       CompactIccSpace.isCompact_Icc hB_cont
     refine ⟨M, fun ν hν => ?_⟩

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -688,14 +688,14 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
   constructor
   · rintro ⟨k, hk⟩
     use -k
-    apply (mul_left_inj' (show (2 * ↑π * I : ℂ) ≠ 0 by simp [pi_ne_zero])).mp
+    apply (mul_left_inj' (show (2 * π * I : ℂ) ≠ 0 by simp [pi_ne_zero])).mp
     field_simp [pi_ne_zero, I_ne_zero] at hk ⊢
-    have h1 : 2 * ↑π * I * z = ↑ν - 2 * ↑k * ↑π * I := by rw [← hk]; dsimp [w]; ring
+    have h1 : 2 * π * I * z = ν - 2 * k * π * I := by rw [← hk]; dsimp [w]; ring
     calc
-      (2 * ↑π * z : ℂ) = (2 * ↑π * I * z) * (-I) := by ring_nf; simp
-      _ = (↑ν - 2 * ↑k * ↑π * I) * (-I) := by rw [h1]
-      _ = 2 * ↑k * ↑π * Complex.I^2 - I * ν := by ring
-      _ = 2 * ↑π * ↑(-k) - I * ↑ν := by simp; ring
+      (2 * π * z : ℂ) = (2 * π * I * z) * (-I) := by ring_nf; simp
+      _ = (ν - 2 * k * π * I) * (-I) := by rw [h1]
+      _ = 2 * k * π * Complex.I^2 - I * ν := by ring
+      _ = 2 * π * ↑(-k) - I * ν := by simp; ring
   · rintro ⟨n, rfl⟩
     use -n
     dsimp [w]
@@ -731,12 +731,12 @@ theorem Phi_circ.residue (ν ε : ℝ) (_hν : ν > 0) (n : ℤ) :
     rw [h_s_z₀, show -n * π * I = -(n * π * I) by ring, Complex.sinh_neg,
         Complex.sinh_mul_I, Complex.sin_int_mul_pi]
     simp
-  have h_s_deriv : HasDerivAt s (-↑π * I) z₀ := by
+  have h_s_deriv : HasDerivAt s (-π * I) z₀ := by
     dsimp [s, w]
-    have h := (((hasDerivAt_id z₀).const_mul (-2 * ↑π * I)).add
-                (hasDerivAt_const z₀ (↑ν : ℂ))).div_const 2
+    have h := (((hasDerivAt_id z₀).const_mul (-2 * π * I)).add
+                (hasDerivAt_const z₀ (ν : ℂ))).div_const 2
     convert h using 1; simp only [mul_one, add_zero]; ring
-  have h_sinh_deriv : HasDerivAt (fun z ↦ Complex.sinh (s z)) (-↑π * I * Complex.cosh (s z₀)) z₀ := by
+  have h_sinh_deriv : HasDerivAt (fun z ↦ Complex.sinh (s z)) (-π * I * Complex.cosh (s z₀)) z₀ := by
     convert (Complex.hasDerivAt_sinh (s z₀)).comp z₀ h_s_deriv using 1; ring
   have h_slope2 : Filter.Tendsto (fun z => Complex.sinh (s z) / (z - z₀)) (nhdsWithin z₀ {z₀}ᶜ) (nhds (-π * I * Complex.cosh (s z₀))) := by
     have h_eq : slope (fun z => Complex.sinh (s z)) z₀ = fun z => Complex.sinh (s z) / (z - z₀) := by
@@ -759,7 +759,7 @@ theorem Phi_circ.residue (ν ε : ℝ) (_hν : ν > 0) (n : ℤ) :
   rw [show (I / (2 * π) : ℂ) = (1 / 2 : ℂ) * (-π * I * Complex.cosh (s z₀))⁻¹ * Complex.cosh (s z₀) + 0 by
     rw [add_zero, mul_inv]
     field_simp [show Complex.cosh (s z₀) ≠ 0 by rw [h_cosh_z₀]; exact zpow_ne_zero n (by norm_num),
-      show (-↑π * I : ℂ) ≠ 0 by simp [pi_ne_zero, I_ne_zero]]
+      show (-π * I : ℂ) ≠ 0 by simp [pi_ne_zero, I_ne_zero]]
     ring_nf; simp]
   refine Filter.Tendsto.congr (fun z => ?_) ((h_lim_sinh.const_mul (1 / 2 : ℂ)).mul h_lim_cosh |>.add h_lim_eps)
   rw [Phi_circ, coth]
@@ -917,7 +917,7 @@ theorem Phi_star.meromorphic (ν ε : ℝ) : Meromorphic (Phi_star ν ε) := by
       MeromorphicAt (fun _ => B ε ν) z₀ := by
     constructor
     · exact (meromorphicAt_B ε _).comp_analyticAt (by fun_prop)
-    · exact MeromorphicAt.const (B ε ↑ν) z₀
+    · exact MeromorphicAt.const (B ε ν) z₀
   exact (h_comp.1.sub h_comp.2).div (MeromorphicAt.const _ z₀)
 
 @[blueprint
@@ -1043,7 +1043,7 @@ theorem Phi_cancel (ν ε σ : ℝ) (hν : ν > 0) (hσ : |σ| = 1) :
       (Filter.Tendsto.const_mul (n : ℂ) (Phi_star.residue ν ε hν n hn_cases)) using 1
     · ext z; ring
     · ring_nf
-      suffices h : (0 : ℂ) = I * (↑π)⁻¹ * (1 / 2) + I * (↑π)⁻¹ * (↑n) ^ 2 * (-1 / 2) by exact congr_arg nhds h
+      suffices h : (0 : ℂ) = I * (↑π)⁻¹ * (1 / 2) + I * (↑π)⁻¹ * (n : ℂ) ^ 2 * (-1 / 2) by exact congr_arg nhds h
       have hn_sq : (n : ℂ) ^ 2 = 1 := by
         exact_mod_cast sq_eq_one_iff.mpr hσ
       simp only [hn_sq]
@@ -1145,7 +1145,7 @@ theorem Phi_circ.continuousAt_imag (ν ε t : ℝ) (ht : 0 ≤ t) (hν : ν > 0)
 theorem Phi_star.continuousAt_imag (ν ε t : ℝ) (ht : 0 ≤ t) (hν : ν > 0) :
     ContinuousAt (fun s : ℝ ↦ Phi_star ν ε (I * ↑s)) t := by
   simp only [Phi_star]
-  have h_eq (s : ℝ) : -2 * ↑π * I * (I * ↑s) + ↑ν = ↑(2 * π * s + ν) := by
+  have h_eq (s : ℝ) : -2 * π * I * (I * s) + ν = ↑(2 * π * s + ν) := by
     ring_nf; simp
   simp_rw [h_eq]
   apply ContinuousAt.div_const
@@ -1245,9 +1245,9 @@ hence, by Definition \ref{phi-pm-def}, $\varphi^{\pm}_{\nu}(t) = 0$. Thus, $\var
   (latexEnv := "lemma")
   (discussion := 1075)]
 theorem ϕ_continuous (ν ε : ℝ) (hlam : ν ≠ 0) : Continuous (ϕ_pm ν ε) := by
-  have tanh_add_pi (z : ℂ) : Complex.tanh (z + ↑Real.pi * I) = Complex.tanh z := by simp
-  have tanh_sub_pi (z : ℂ) : Complex.tanh (z - ↑Real.pi * I) = Complex.tanh z := by
-    have h := tanh_add_pi (z - ↑Real.pi * I); rw [sub_add_cancel] at h; exact h.symm
+  have tanh_add_pi (z : ℂ) : Complex.tanh (z + Real.pi * I) = Complex.tanh z := by simp
+  have tanh_sub_pi (z : ℂ) : Complex.tanh (z - Real.pi * I) = Complex.tanh z := by
+    have h := tanh_add_pi (z - Real.pi * I); rw [sub_add_cancel] at h; exact h.symm
   unfold ϕ_pm
   apply continuous_if
   · intro a ha
@@ -1258,24 +1258,24 @@ theorem ϕ_continuous (ν ε : ℝ) (hlam : ν ≠ 0) : Continuous (ϕ_pm ν ε)
     rcases ha with rfl | rfl
     · unfold Phi_circ Phi_star B coth
       dsimp only []; push_cast; simp only [Real.sign_neg, Real.sign_one, ofReal_neg, ofReal_one]
-      have hw_ne : -2 * ↑Real.pi * I * (-1 : ℂ) + ↑ν ≠ 0 := by
+      have hw_ne : -2 * Real.pi * I * (-1 : ℂ) + ν ≠ 0 := by
         intro h; have := congr_arg Complex.im h; simp at this
       have hν_ne : (ν : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hlam
       simp only [hw_ne, hν_ne, ↓reduceIte]
-      have hw2 : (-2 * ↑Real.pi * I * (-1 : ℂ) + ↑ν) / 2 = ↑ν / 2 + ↑Real.pi * I := by ring
+      have hw2 : (-2 * Real.pi * I * (-1 : ℂ) + ν) / 2 = ν / 2 + Real.pi * I := by ring
       rw [hw2, tanh_add_pi]
-      have hpi : (↑Real.pi : ℂ) * I ≠ 0 := by
+      have hpi : (Real.pi : ℂ) * I ≠ 0 := by
         apply mul_ne_zero (by exact_mod_cast Real.pi_ne_zero) I_ne_zero
       grind
     · unfold Phi_circ Phi_star B coth
       dsimp only []; push_cast; simp only [Real.sign_one, ofReal_one]
-      have hw_ne : -2 * ↑Real.pi * I * (1 : ℂ) + ↑ν ≠ 0 := by
+      have hw_ne : -2 * Real.pi * I * (1 : ℂ) + ν ≠ 0 := by
         intro h; have := congr_arg Complex.im h; simp at this
       have hν_ne : (ν : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hlam
       simp only [hw_ne, hν_ne, ↓reduceIte]
-      have hw2 : (-2 * ↑Real.pi * I * (1 : ℂ) + ↑ν) / 2 = ↑ν / 2 - ↑Real.pi * I := by ring
+      have hw2 : (-2 * Real.pi * I * (1 : ℂ) + ν) / 2 = ν / 2 - Real.pi * I := by ring
       rw [hw2, tanh_sub_pi]
-      have hpi : (↑Real.pi : ℂ) * I ≠ 0 := by
+      have hpi : (Real.pi : ℂ) * I ≠ 0 := by
         apply mul_ne_zero (by exact_mod_cast Real.pi_ne_zero) I_ne_zero
       field_simp
       ring
@@ -2234,8 +2234,8 @@ theorem B_affine_periodic (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) (m : ℤ)
   have h_tanh_periodic :
       Complex.tanh ((-2 * Real.pi * I * (z - m) + ν) / 2) =
         Complex.tanh ((-2 * Real.pi * I * z + ν) / 2) := by
-    rw [show (-2 * ↑π * I * (z - ↑m) + ↑ν) / 2 =
-      (-2 * ↑π * I * z + ↑ν) / 2 + ↑π * I * ↑m by ring]
+    rw [show (-2 * π * I * (z - m) + ν) / 2 =
+      (-2 * π * I * z + ν) / 2 + π * I * m by ring]
     exact tanh_add_int_mul_pi_I _ m
   grind
 

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -1574,64 +1574,139 @@ Since $e^u$ is convex, $e^u \geq 1 + u$ for all $u \in \mathbb{R}$. We apply thi
 . -/)
   (latexEnv := "lemma")
   (discussion := 1077)]
+private lemma rexp_sub_one_pos_of_pos {t : ℝ} (ht : 0 < t) : rexp t - 1 > 0 :=
+  by linarith [Real.add_one_le_exp t]
+
+private lemma rexp_sub_one_neg_of_neg {t : ℝ} (ht : t < 0) : rexp t - 1 < 0 := by
+  nlinarith [Real.exp_pos t, Real.exp_neg t,
+    mul_inv_cancel₀ (ne_of_gt (Real.exp_pos t)), Real.add_one_le_exp (-t)]
+
+/-- The derivative numerator `(exp t - 1) - t * exp t` is nonpositive, since `exp t ≥ 1 + t`. -/
+private lemma deriv_num_nonpos (c : ℝ) :
+    1 * (rexp c - 1) - c * rexp c ≤ 0 := by
+  nlinarith [Real.exp_pos c, Real.exp_neg c,
+    mul_inv_cancel₀ (ne_of_gt (Real.exp_pos c)),
+    Real.add_one_le_exp c, Real.add_one_le_exp (-c)]
+
+/-- `HasDerivAt` for `t / (exp t - 1)`. -/
+private lemma hasDerivAt_div_exp (c : ℝ) (hne : rexp c - 1 ≠ 0) :
+    HasDerivAt (fun s => s / (rexp s - 1))
+      ((1 * (rexp c - 1) - c * rexp c) / (rexp c - 1) ^ 2) c :=
+  (hasDerivAt_id c).div (show HasDerivAt (fun s => rexp s - 1) (rexp c) c by
+    have := (Real.hasDerivAt_exp c).sub (hasDerivAt_const c (1 : ℝ))
+    simp only [sub_zero] at this; exact this) hne
+
+/-- `t / (exp t - 1)` is antitone on any interval where `exp t - 1 ≠ 0`, by MVT. -/
+private lemma div_exp_sub_one_anti (t1 t2 : ℝ)
+    (hall : ∀ x, t1 ≤ x → x ≤ t2 → rexp x - 1 ≠ 0) (hlt : t1 < t2) :
+    t2 / (rexp t2 - 1) ≤ t1 / (rexp t1 - 1) := by
+  obtain ⟨c, hc, hc_eq⟩ : ∃ c ∈ Set.Ioo t1 t2,
+      deriv (fun s => s / (rexp s - 1)) c =
+        ((fun s => s / (rexp s - 1)) t2 - (fun s => s / (rexp s - 1)) t1) / (t2 - t1) := by
+    rw [show (fun s => s / (rexp s - 1)) = (_root_.id / fun x => rexp x - 1) from by
+      ext x; simp [_root_.id]]
+    exact exists_deriv_eq_slope _ hlt
+      (ContinuousOn.div continuousOn_id
+        (ContinuousOn.sub Real.continuous_exp.continuousOn continuousOn_const)
+        (fun x hx => hall x hx.1 hx.2))
+      (DifferentiableOn.div differentiableOn_id
+        (DifferentiableOn.sub Real.differentiable_exp.differentiableOn (differentiableOn_const _))
+        (fun x hx => hall x (le_of_lt hx.1) (le_of_lt hx.2)))
+  have hne := hall c (le_of_lt hc.1) (le_of_lt hc.2)
+  rw [(hasDerivAt_div_exp c hne).deriv] at hc_eq
+  have := div_nonpos_of_nonpos_of_nonneg (deriv_num_nonpos c) (sq_nonneg (rexp c - 1))
+  rw [hc_eq] at this
+  cases div_nonpos_iff.mp this with
+  | inl h => linarith [h.1] | inr h => linarith [h.2]
+
+/-- For `t ≠ 0`, `(B 1 t).re = t * exp t / (exp t - 1)`. -/
+lemma B_plus_re_eq {t : ℝ} (ht : t ≠ 0) :
+    (B 1 (t : ℂ)).re = t * Real.exp t / (Real.exp t - 1) := by
+  unfold B
+  unfold coth; norm_num [ Complex.tanh, Complex.exp_re, Complex.exp_im ] ; ring_nf;
+  norm_num [ Complex.cosh, Complex.sinh, Complex.exp_re, Complex.exp_im, ht ] ; ring_nf;
+  norm_num [ Complex.normSq, Complex.exp_re, Complex.exp_im ] ; ring_nf;
+  field_simp;
+  rw [ one_add_div, ← add_div, div_eq_div_iff ] <;> ring_nf <;> norm_num [ sub_ne_zero, ht, Real.exp_ne_zero ];
+  · simpa [ ← Real.exp_add ] using by ring_nf;
+  · cases lt_or_gt_of_ne ht <;> linarith;
+  · exact fun h => ht <| by rw [ add_eq_zero_iff_eq_neg ] at h; replace h := congr_arg Real.log h; norm_num at h; linarith;
+  · cases lt_or_gt_of_ne ht <;> linarith
+
+/-- `t * exp t / (exp t - 1) ≤ 1` for `t < 0`. -/
+private lemma mul_exp_div_exp_sub_one_le_one {t : ℝ} (ht : t < 0) :
+    t * Real.exp t / (Real.exp t - 1) ≤ 1 := by
+  rw [ div_le_iff_of_neg ] <;> nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ]
+
+/-- `1 ≤ t * exp t / (exp t - 1)` for `t > 0`. -/
+private lemma one_le_mul_exp_div_exp_sub_one {t : ℝ} (ht : 0 < t) :
+    1 ≤ t * Real.exp t / (Real.exp t - 1) := by
+  rw [ le_div_iff₀ ] <;> try linarith [ Real.add_one_le_exp t ];
+  nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ]
+
+/-- `t * exp t / (exp t - 1)` is monotone on `(0, ∞)`. -/
+private lemma monotoneOn_mul_exp_div_Ioi :
+    MonotoneOn (fun t : ℝ ↦ t * Real.exp t / (Real.exp t - 1)) (Set.Ioi 0) := by
+  have h_deriv_pos : ∀ t > 0, deriv (fun t => t * Real.exp t / (Real.exp t - 1)) t ≥ 0 := by
+    intro t ht; norm_num [ Real.differentiableAt_exp, ne_of_gt, ht, ne_of_gt, Real.exp_pos t, ne_of_gt, sub_pos, Real.exp_pos, ht, sub_ne_zero.mpr, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t ];
+    exact div_nonneg ( by nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ] ) ( sq_nonneg _ )
+  intro a ha b hb hab
+  have h_mean_val : ∀ a b : ℝ, 0 < a → a < b → ∃ c ∈ Set.Ioo a b, deriv (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) c = ( (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) b - (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) a ) / (b - a) := by
+    intros a b ha hb; apply_rules [ exists_deriv_eq_slope ];
+    · exact continuousOn_of_forall_continuousAt fun t ht => by
+        fun_prop (disch := exact sub_ne_zero_of_ne (by linarith [Real.add_one_le_exp t, ht.1]))
+    · exact DifferentiableOn.div ( DifferentiableOn.mul differentiableOn_id ( Real.differentiable_exp.differentiableOn ) ) ( DifferentiableOn.sub ( Real.differentiable_exp.differentiableOn ) ( differentiableOn_const _ ) ) fun x hx => ne_of_gt ( by norm_num; linarith [ hx.1 ] );
+  cases eq_or_lt_of_le hab
+  · aesop
+  obtain ⟨ c, hc₁, hc₂ ⟩ := h_mean_val a b ha ‹_›
+  have := h_deriv_pos c ( lt_trans ha.out hc₁.1 )
+  rw [ hc₂, ge_iff_le, le_div_iff₀ (by lia) ] at this
+  linarith
+
+/-- `t * exp t / (exp t - 1)` is monotone on `(-∞, 0)`. -/
+private lemma monotoneOn_mul_exp_div_Iio :
+    MonotoneOn (fun t : ℝ ↦ t * Real.exp t / (Real.exp t - 1)) (Set.Iio 0) := by
+  have h_deriv_nonneg : ∀ t : ℝ, t < 0 → 0 ≤ deriv (fun t => t * Real.exp t / (Real.exp t - 1)) t := by
+    intro t ht; norm_num [ Real.differentiableAt_exp, ne_of_lt, ht, sub_ne_zero ];
+    exact div_nonneg ( by nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ] ) ( sq_nonneg _ );
+  intros t ht u hu htu;
+  by_contra h_contra; push_neg at h_contra; (
+  obtain ⟨c, hc⟩ : ∃ c ∈ Set.Ioo t u, deriv (fun t => t * Real.exp t / (Real.exp t - 1)) c = (u * Real.exp u / (Real.exp u - 1) - t * Real.exp t / (Real.exp t - 1)) / (u - t) := by
+    apply_rules [ exists_deriv_eq_slope ]
+    · exact htu.lt_of_ne ( by rintro rfl; linarith )
+    · exact continuousOn_of_forall_continuousAt fun x hx => by
+        fun_prop (disch := exact sub_ne_zero_of_ne (by norm_num; linarith [hx.1, hx.2, ht.out, hu.out]))
+    · exact fun x hx => DifferentiableAt.differentiableWithinAt ( by exact DifferentiableAt.div ( differentiableAt_id.mul ( Real.differentiableAt_exp ) ) ( Real.differentiableAt_exp.sub_const _ ) ( sub_ne_zero_of_ne ( by norm_num; linarith [ hx.1, hx.2, hu.out, ht.out ] ) ) )
+  rw [ eq_div_iff ] at hc <;> nlinarith [ hc.1.1, hc.1.2, h_deriv_nonneg c ( by linarith [ hc.1.1, hc.1.2, hu.out ] ) ]);
+
 theorem B_plus_mono : Monotone (fun t:ℝ ↦ (B 1 t).re) := by
-  have B_plus_re_eq : ∀ t : ℝ, t ≠ 0 → (B 1 (t : ℂ)).re = t * Real.exp t / (Real.exp t - 1) := by
-    intro t ht
-    unfold B
-    unfold coth; norm_num [ Complex.tanh, Complex.exp_re, Complex.exp_im ] ; ring_nf;
-    norm_num [ Complex.cosh, Complex.sinh, Complex.exp_re, Complex.exp_im, ht ] ; ring_nf;
-    norm_num [ Complex.normSq, Complex.exp_re, Complex.exp_im ] ; ring_nf;
-    field_simp;
-    rw [ one_add_div, ← add_div, div_eq_div_iff ] <;> ring_nf <;> norm_num [ sub_ne_zero, ht, Real.exp_ne_zero ];
-    · simpa [ ← Real.exp_add ] using by ring_nf;
-    · cases lt_or_gt_of_ne ht <;> linarith;
-    · exact fun h => ht <| by rw [ add_eq_zero_iff_eq_neg ] at h; replace h := congr_arg Real.log h; norm_num at h; linarith;
-    · cases lt_or_gt_of_ne ht <;> linarith
-  have f_le_one_neg : ∀ t : ℝ, t < 0 → t * Real.exp t / (Real.exp t - 1) ≤ 1 := by
-    intro t ht
-    rw [ div_le_iff_of_neg ] <;> nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ]
-  have f_ge_one_pos : ∀ t : ℝ, 0 < t → 1 ≤ t * Real.exp t / (Real.exp t - 1) := by
-    intro t ht
-    rw [ le_div_iff₀ ] <;> try linarith [ Real.add_one_le_exp t ];
-    nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ]
-  have f_mono_pos : MonotoneOn (fun t : ℝ ↦ t * Real.exp t / (Real.exp t - 1)) (Set.Ioi 0) := by
-    have h_deriv_pos : ∀ t > 0, deriv (fun t => t * Real.exp t / (Real.exp t - 1)) t ≥ 0 := by
-      intro t ht; norm_num [ Real.differentiableAt_exp, ne_of_gt, ht, ne_of_gt, Real.exp_pos t, ne_of_gt, sub_pos, Real.exp_pos, ht, sub_ne_zero.mpr, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t, ne_of_gt, ht, Real.exp_pos t ];
-      exact div_nonneg ( by nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ] ) ( sq_nonneg _ )
-    intro a ha b hb hab
-    have h_mean_val : ∀ a b : ℝ, 0 < a → a < b → ∃ c ∈ Set.Ioo a b, deriv (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) c = ( (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) b - (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) a ) / (b - a) := by
-      intros a b ha hb; apply_rules [ exists_deriv_eq_slope ];
-      · exact continuousOn_of_forall_continuousAt fun t ht => by
-          fun_prop (disch := exact sub_ne_zero_of_ne (by linarith [Real.add_one_le_exp t, ht.1]))
-      · exact DifferentiableOn.div ( DifferentiableOn.mul differentiableOn_id ( Real.differentiable_exp.differentiableOn ) ) ( DifferentiableOn.sub ( Real.differentiable_exp.differentiableOn ) ( differentiableOn_const _ ) ) fun x hx => ne_of_gt ( by norm_num; linarith [ hx.1 ] );
-    cases eq_or_lt_of_le hab
-    · aesop
-    obtain ⟨ c, hc₁, hc₂ ⟩ := h_mean_val a b ha ‹_›
-    have := h_deriv_pos c ( lt_trans ha.out hc₁.1 )
-    rw [ hc₂, ge_iff_le, le_div_iff₀ (by lia) ] at this
-    linarith
-  have f_mono_neg : MonotoneOn (fun t : ℝ ↦ t * Real.exp t / (Real.exp t - 1)) (Set.Iio 0) := by
-    have h_deriv_nonneg : ∀ t : ℝ, t < 0 → 0 ≤ deriv (fun t => t * Real.exp t / (Real.exp t - 1)) t := by
-      intro t ht; norm_num [ Real.differentiableAt_exp, ne_of_lt, ht, sub_ne_zero ];
-      exact div_nonneg ( by nlinarith [ Real.exp_pos t, Real.exp_neg t, mul_inv_cancel₀ ( ne_of_gt ( Real.exp_pos t ) ), Real.add_one_le_exp t, Real.add_one_le_exp ( -t ) ] ) ( sq_nonneg _ );
-    intros t ht u hu htu;
-    by_contra h_contra; push_neg at h_contra; (
-    obtain ⟨c, hc⟩ : ∃ c ∈ Set.Ioo t u, deriv (fun t => t * Real.exp t / (Real.exp t - 1)) c = (u * Real.exp u / (Real.exp u - 1) - t * Real.exp t / (Real.exp t - 1)) / (u - t) := by
-      apply_rules [ exists_deriv_eq_slope ]
-      · exact htu.lt_of_ne ( by rintro rfl; linarith )
-      · exact continuousOn_of_forall_continuousAt fun x hx => by
-          fun_prop (disch := exact sub_ne_zero_of_ne (by norm_num; linarith [hx.1, hx.2, ht.out, hu.out]))
-      · exact fun x hx => DifferentiableAt.differentiableWithinAt ( by exact DifferentiableAt.div ( differentiableAt_id.mul ( Real.differentiableAt_exp ) ) ( Real.differentiableAt_exp.sub_const _ ) ( sub_ne_zero_of_ne ( by norm_num; linarith [ hx.1, hx.2, hu.out, ht.out ] ) ) )
-    rw [ eq_div_iff ] at hc <;> nlinarith [ hc.1.1, hc.1.2, h_deriv_nonneg c ( by linarith [ hc.1.1, hc.1.2, hu.out ] ) ]);
-  intro t₁ t₂ ht;
-  by_cases h₁ : t₁ = 0 <;> by_cases h₂ : t₂ = 0
-  · grind [one_re, B, ofReal_eq_zero, ofReal_one]
-  · grind [one_re, B, ofReal_eq_zero, ofReal_one]
-  · grind [one_re, B, ofReal_eq_zero, ofReal_one]
-  · simp only [ne_eq, B, ofReal_eq_zero, ofReal_one] at B_plus_re_eq
-    simp only [B, ofReal_eq_zero, ofReal_one, h₁, h₂, ite_false, div_ofNat_re, mul_re, ofReal_re, add_re, one_re, ofReal_im, add_im, one_im]
-    simp_all
-    grind [MonotoneOn]
+  intro t₁ t₂ ht
+  simp only
+  by_cases h₁ : t₁ = 0
+  · subst h₁; simp only [ofReal_zero]; by_cases h₂ : t₂ = 0
+    · subst h₂; exact le_refl _
+    · have hB0 : (B 1 (0 : ℂ)).re = 1 := by simp [B]
+      rw [hB0, B_plus_re_eq h₂]
+      exact one_le_mul_exp_div_exp_sub_one (lt_of_le_of_ne (by linarith) (Ne.symm h₂))
+  · by_cases h₂ : t₂ = 0
+    · subst h₂; simp only [ofReal_zero]
+      have hB0 : (B 1 (0 : ℂ)).re = 1 := by simp [B]
+      rw [hB0, B_plus_re_eq h₁]
+      exact mul_exp_div_exp_sub_one_le_one (lt_of_le_of_ne (by linarith) h₁)
+    · rw [show (t₁ : ℂ) = ((t₁ : ℝ) : ℂ) from rfl, show (t₂ : ℂ) = ((t₂ : ℝ) : ℂ) from rfl,
+        B_plus_re_eq h₁, B_plus_re_eq h₂]
+      by_cases hpos : 0 < t₁
+      · exact monotoneOn_mul_exp_div_Ioi (Set.mem_Ioi.mpr hpos)
+          (Set.mem_Ioi.mpr (lt_of_lt_of_le hpos ht)) ht
+      · push_neg at hpos
+        have ht₁_neg : t₁ < 0 := lt_of_le_of_ne hpos h₁
+        by_cases hneg : t₂ < 0
+        · exact monotoneOn_mul_exp_div_Iio (Set.mem_Iio.mpr ht₁_neg)
+            (Set.mem_Iio.mpr hneg) ht
+        · push_neg at hneg
+          have ht₂_pos : 0 < t₂ := lt_of_le_of_ne hneg (Ne.symm h₂)
+          linarith [mul_exp_div_exp_sub_one_le_one ht₁_neg,
+            one_le_mul_exp_div_exp_sub_one ht₂_pos]
 
 lemma B_im_eq_zero (ε : ℝ) (t : ℝ) : (B ε t).im = 0 := by
   unfold B; split
@@ -1641,6 +1716,42 @@ lemma B_im_eq_zero (ε : ℝ) (t : ℝ) : (B ε t).im = 0 := by
     simp [ofReal_im, ofReal_re]
 
 theorem B_plus_real (t : ℝ) : (B 1 t).im = 0 := B_im_eq_zero 1 t
+
+/-- For `t ≠ 0`, `(B (-1) t).re = t / (exp t - 1)`. -/
+lemma B_minus_re_eq {t : ℝ} (ht : t ≠ 0) :
+    (B (-1) (t : ℂ)).re = t / (rexp t - 1) := by
+  unfold B coth
+  have ht' : (t : ℂ) ≠ 0 := by exact_mod_cast ht
+  simp only [ht', ↓reduceIte, one_div]
+  rw [show ((-1 : ℝ) : ℂ) = -1 from by push_cast; ring]
+  conv_lhs => rw [show (t : ℂ) / 2 = ((t / 2 : ℝ) : ℂ) from by push_cast; ring]
+  rw [show Complex.tanh ((t / 2 : ℝ) : ℂ) = ((Real.tanh (t / 2) : ℝ) : ℂ) from by
+      apply Complex.ext <;> simp,
+    show ((Real.tanh (t / 2) : ℝ) : ℂ)⁻¹ = ((Real.tanh (t / 2))⁻¹ : ℝ) from by push_cast; ring,
+    show (↑t * (↑(Real.tanh (t / 2))⁻¹ + (-1 : ℂ)) / 2 : ℂ) =
+      ((t * ((Real.tanh (t / 2))⁻¹ + (-1 : ℝ)) / 2 : ℝ) : ℂ) from by push_cast; ring]
+  simp only [Complex.ofReal_re]; rw [Real.tanh_eq]
+  have h2 : rexp (t / 2) - rexp (-(t / 2)) ≠ 0 := by
+    intro h; exact ht (by linarith [Real.exp_injective (show rexp (t/2) = rexp (-(t/2)) by linarith)])
+  have h3 : rexp t - 1 ≠ 0 := by
+    intro h; exact ht ((Real.exp_eq_one_iff t).mp (by linarith))
+  rw [inv_div]; field_simp
+  nlinarith [show rexp t = rexp (t / 2) * rexp (t / 2) by rw [← Real.exp_add]; ring_nf,
+    show rexp (t / 2) * rexp (-(t / 2)) = 1 by rw [← Real.exp_add]; simp,
+    Real.exp_pos (t/2), Real.exp_pos (-(t/2))]
+
+/-- `t / (exp t - 1) ≤ 1` for `t > 0`. -/
+private lemma div_exp_sub_one_le_one {t : ℝ} (ht : 0 < t) :
+    t / (rexp t - 1) ≤ 1 := by
+  rw [div_le_iff₀ (rexp_sub_one_pos_of_pos ht)]; linarith [Real.add_one_le_exp t]
+
+/-- `1 ≤ t / (exp t - 1)` for `t < 0`. -/
+private lemma one_le_div_exp_sub_one {t : ℝ} (ht : t < 0) :
+    1 ≤ t / (rexp t - 1) := by
+  rw [le_div_iff_of_neg (rexp_sub_one_neg_of_neg ht)]
+  nlinarith [Real.exp_pos t, Real.exp_neg t,
+    mul_inv_cancel₀ (ne_of_gt (Real.exp_pos t)),
+    Real.add_one_le_exp t, Real.add_one_le_exp (-t)]
 
 @[blueprint
   "B-minus-mono"
@@ -1653,49 +1764,6 @@ theorem B_plus_real (t : ℝ) : (B 1 t).im = 0 := B_im_eq_zero 1 t
   (latexEnv := "lemma")
   (discussion := 1078)]
 theorem B_minus_mono : Antitone (fun t:ℝ ↦ (B (-1) t).re) := by
-  have hasDerivAt_div_exp (c : ℝ) (hne : rexp c - 1 ≠ 0) :
-      HasDerivAt (fun s => s / (rexp s - 1))
-        ((1 * (rexp c - 1) - c * rexp c) / (rexp c - 1) ^ 2) c :=
-    (hasDerivAt_id c).div (show HasDerivAt (fun s => rexp s - 1) (rexp c) c by
-      have := (Real.hasDerivAt_exp c).sub (hasDerivAt_const c (1 : ℝ))
-      simp only [sub_zero] at this; exact this) hne
-  have deriv_nonpos (c : ℝ) (hne : rexp c - 1 ≠ 0) :
-      (1 * (rexp c - 1) - c * rexp c) / (rexp c - 1) ^ 2 ≤ 0 :=
-    div_nonpos_of_nonpos_of_nonneg
-      (by nlinarith [Real.exp_pos c, Real.exp_neg c,
-        mul_inv_cancel₀ (ne_of_gt (Real.exp_pos c)),
-        Real.add_one_le_exp c, Real.add_one_le_exp (-c)])
-      (sq_nonneg _)
-  have mvt_anti (t1 t2 : ℝ) (hall : ∀ x, t1 ≤ x → x ≤ t2 → rexp x - 1 ≠ 0) (hlt : t1 < t2) :
-      t2 / (rexp t2 - 1) ≤ t1 / (rexp t1 - 1) := by
-    obtain ⟨c, hc, hc_eq⟩ : ∃ c ∈ Set.Ioo t1 t2,
-        deriv (fun s => s / (rexp s - 1)) c =
-          ((fun s => s / (rexp s - 1)) t2 - (fun s => s / (rexp s - 1)) t1) / (t2 - t1) := by
-      rw [show (fun s => s / (rexp s - 1)) = (_root_.id / fun x => rexp x - 1) from by
-        ext x; simp [_root_.id]]
-      exact exists_deriv_eq_slope _ hlt
-        (ContinuousOn.div continuousOn_id
-          (ContinuousOn.sub Real.continuous_exp.continuousOn continuousOn_const)
-          (fun x hx => hall x hx.1 hx.2))
-        (DifferentiableOn.div differentiableOn_id
-          (DifferentiableOn.sub Real.differentiable_exp.differentiableOn (differentiableOn_const _))
-          (fun x hx => hall x (le_of_lt hx.1) (le_of_lt hx.2)))
-    have hne := hall c (le_of_lt hc.1) (le_of_lt hc.2)
-    rw [(hasDerivAt_div_exp c hne).deriv] at hc_eq
-    have := deriv_nonpos c hne; rw [hc_eq] at this
-    cases div_nonpos_iff.mp this with
-    | inl h => linarith [h.1] | inr h => linarith [h.2]
-  have exp_sub_pos (x : ℝ) (hx : 0 < x) : rexp x - 1 > 0 := by linarith [Real.add_one_le_exp x]
-  have exp_sub_neg (x : ℝ) (hx : x < 0) : rexp x - 1 < 0 := by
-    nlinarith [Real.exp_pos x, Real.exp_neg x,
-      mul_inv_cancel₀ (ne_of_gt (Real.exp_pos x)), Real.add_one_le_exp (-x)]
-  have div_exp_le_one (t : ℝ) (ht : 0 < t) : t / (rexp t - 1) ≤ 1 := by
-    rw [div_le_iff₀ (exp_sub_pos t ht)]; linarith [Real.add_one_le_exp t]
-  have div_exp_ge_one (t : ℝ) (ht : t < 0) : 1 ≤ t / (rexp t - 1) := by
-    rw [le_div_iff_of_neg (exp_sub_neg t ht)]
-    nlinarith [Real.exp_pos t, Real.exp_neg t,
-      mul_inv_cancel₀ (ne_of_gt (Real.exp_pos t)),
-      Real.add_one_le_exp t, Real.add_one_le_exp (-t)]
   suffices heq : (fun t:ℝ ↦ (B (-1) t).re) =
       fun t : ℝ => if t = 0 then (1 : ℝ) else t / (rexp t - 1) by
     rw [heq]; intro a b hab
@@ -1703,42 +1771,25 @@ theorem B_minus_mono : Antitone (fun t:ℝ ↦ (B (-1) t).re) := by
     simp only
     by_cases ha0 : a = 0
     · subst ha0; simp only [ite_true, show ¬b = 0 from by linarith, ite_false]
-      exact div_exp_le_one b (by linarith)
+      exact div_exp_sub_one_le_one (by linarith)
     · by_cases hb0 : b = 0
       · subst hb0; simp only [ite_true, ha0, ite_false]
-        exact div_exp_ge_one a (lt_of_le_of_ne (not_lt.mp (fun h => ha0 (by linarith))) ha0)
+        exact one_le_div_exp_sub_one (lt_of_le_of_ne (not_lt.mp (fun h => ha0 (by linarith))) ha0)
       · simp only [ha0, hb0, ite_false]
         by_cases hpos : 0 < a
-        · exact mvt_anti a b (fun x hxa hxb => ne_of_gt (exp_sub_pos x (by linarith))) hlt
+        · exact div_exp_sub_one_anti a b
+            (fun x hxa hxb => ne_of_gt (rexp_sub_one_pos_of_pos (by linarith))) hlt
         · push_neg at hpos
           have ha_neg : a < 0 := lt_of_le_of_ne hpos ha0
           by_cases hneg : b < 0
-          · exact mvt_anti a b (fun x hxa hxb => ne_of_lt (exp_sub_neg x (by linarith))) hlt
+          · exact div_exp_sub_one_anti a b
+              (fun x hxa hxb => ne_of_lt (rexp_sub_one_neg_of_neg (by linarith))) hlt
           · push_neg at hneg
             have hb_pos : 0 < b := lt_of_le_of_ne hneg (Ne.symm hb0)
-            linarith [div_exp_le_one b hb_pos, div_exp_ge_one a ha_neg]
+            linarith [div_exp_sub_one_le_one hb_pos, one_le_div_exp_sub_one ha_neg]
   funext t; split
   · next h => subst h; unfold B; simp
-  · next ht =>
-    unfold B coth
-    have ht' : (t : ℂ) ≠ 0 := by exact_mod_cast ht
-    simp only [ht', ↓reduceIte, one_div]
-    rw [show ((-1 : ℝ) : ℂ) = -1 from by push_cast; ring]
-    conv_lhs => rw [show (t : ℂ) / 2 = ((t / 2 : ℝ) : ℂ) from by push_cast; ring]
-    rw [show Complex.tanh ((t / 2 : ℝ) : ℂ) = ((Real.tanh (t / 2) : ℝ) : ℂ) from by
-        apply Complex.ext <;> simp,
-      show ((Real.tanh (t / 2) : ℝ) : ℂ)⁻¹ = ((Real.tanh (t / 2))⁻¹ : ℝ) from by push_cast; ring,
-      show (↑t * (↑(Real.tanh (t / 2))⁻¹ + (-1 : ℂ)) / 2 : ℂ) =
-        ((t * ((Real.tanh (t / 2))⁻¹ + (-1 : ℝ)) / 2 : ℝ) : ℂ) from by push_cast; ring]
-    simp only [Complex.ofReal_re]; rw [Real.tanh_eq]
-    have h2 : rexp (t / 2) - rexp (-(t / 2)) ≠ 0 := by
-      intro h; exact ht (by linarith [Real.exp_injective (show rexp (t/2) = rexp (-(t/2)) by linarith)])
-    have h3 : rexp t - 1 ≠ 0 := by
-      intro h; exact ht ((Real.exp_eq_one_iff t).mp (by linarith))
-    rw [inv_div]; field_simp
-    nlinarith [show rexp t = rexp (t / 2) * rexp (t / 2) by rw [← Real.exp_add]; ring_nf,
-      show rexp (t / 2) * rexp (-(t / 2)) = 1 by rw [← Real.exp_add]; simp,
-      Real.exp_pos (t/2), Real.exp_pos (-(t/2))]
+  · next ht => exact B_minus_re_eq ht
 
 theorem B_minus_real (t : ℝ) : (B (-1) t).im = 0 := B_im_eq_zero (-1) t
 

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -531,10 +531,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
       rw [show (fun z ↦ coth (w z / 2) + ε) = (fun z ↦ coth (w z / 2)) + (fun _ ↦ (ε : ℂ)) from rfl]
       rw [meromorphicOrderAt_add_of_ne h_coth_mero (by fun_prop) h_ne]
       simp [h]
-  have h_mero_tanh : MeromorphicAt Complex.tanh (w z / 2) := by
-    rw [show Complex.tanh = fun x => Complex.sinh x / Complex.cosh x from
-      funext Complex.tanh_eq_sinh_div_cosh]
-    exact Complex.analyticAt_sinh.meromorphicAt.fun_div Complex.analyticAt_cosh.meromorphicAt
+  have h_mero_tanh : MeromorphicAt Complex.tanh (w z / 2) := by fun_prop
   have h_cosh_eventually_ne : ∀ᶠ (x : ℂ) in nhdsWithin (w z / 2) {w z / 2}ᶜ, Complex.cosh x ≠ 0 := by
     apply (meromorphicOrderAt_ne_top_iff_eventually_ne_zero Complex.analyticAt_cosh.meromorphicAt).mp
     intro h_top
@@ -895,8 +892,7 @@ lemma meromorphic_coth'' : Meromorphic (fun s : ℂ => Complex.cosh (s / 2) / Co
 lemma meromorphicAt_B (ε : ℝ) (z₀ : ℂ) : MeromorphicAt (B ε) z₀ := by
   have h_comp : ∀ z, MeromorphicAt
       (fun s => s * (Complex.cosh (s / 2) / Complex.sinh (s / 2) + ε) / 2) z := by
-    have meromorphic_coth'' : Meromorphic (fun s : ℂ => Complex.cosh (s / 2) / Complex.sinh (s / 2)) := by
-      exact meromorphic_coth''
+    have meromorphic_coth'' := meromorphic_coth''
     intro z
     exact (by apply_rules [MeromorphicAt.div, MeromorphicAt.add, MeromorphicAt.mul,
       MeromorphicAt.id, MeromorphicAt.const])
@@ -1011,18 +1007,13 @@ theorem Phi_star.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
   · exact fun h ↦ (Phi_star.poles ν ε hν z).mp (h ▸ by decide)
   · rintro ⟨n, hn, rfl⟩
     set z₀ := (n : ℂ) - I * ν / (2 * π)
-    have hsub : MeromorphicAt (· - z₀ : ℂ → ℂ) z₀ := by fun_prop
+    have hsub : MeromorphicAt (· - z₀) z₀ := by fun_prop
     have hf : MeromorphicAt (Phi_star ν ε) z₀ := by fun_prop
     have heq : (fun z ↦ (z - z₀) * Phi_star ν ε z) =ᶠ[nhdsWithin z₀ {z₀}ᶜ] ((· - z₀) * Phi_star ν ε) :=
       Filter.Eventually.of_forall fun _ ↦ rfl
-    have hL : -I * ↑n / (2 * ↑(π : ℝ)) ≠ (0 : ℂ) := by
-      simp only [neg_mul, ne_eq, div_eq_zero_iff, neg_eq_zero, mul_eq_zero, I_ne_zero,
-        Int.cast_eq_zero, false_or, OfNat.ofNat_ne_zero, ofReal_eq_zero, pi_ne_zero, or_self,
-        or_false]
-      exact_mod_cast hn
-    have hord₀ : meromorphicOrderAt ((· - z₀) * Phi_star ν ε) z₀ = 0 :=
-      (tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (hsub.mul hf)).mp
-        ⟨_, hL, (Phi_star.residue ν ε hν n hn).congr' heq⟩
+    have hord₀ : meromorphicOrderAt ((· - z₀) * Phi_star ν ε) z₀ = 0 := by
+      rw [← tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (hsub.mul hf)]
+      exact ⟨_, by simp [hn, pi_ne_zero], (Phi_star.residue ν ε hν n hn).congr' heq⟩
     have hord₁ : meromorphicOrderAt (· - z₀) z₀ = (1 : ℤ) := by
       rw [meromorphicOrderAt_eq_int_iff hsub]
       exact ⟨1, analyticAt_const, one_ne_zero, by simp⟩
@@ -1030,10 +1021,10 @@ theorem Phi_star.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
     obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp
       (by rintro h; simp [h] at hord₀ : meromorphicOrderAt (Phi_star ν ε) z₀ ≠ ⊤)
     rw [← hm] at hord₀ ⊢
-    have h1 : (↑(1 : ℤ) + ↑m : WithTop ℤ) = ↑(1 + m : ℤ) := by push_cast; ring_nf
+    have h1 : ((1 : ℤ) + m : WithTop ℤ) = (1 + m : ℤ) := by push_cast; ring_nf
     rw [h1] at hord₀
     have : 1 + m = 0 := by exact_mod_cast hord₀
-    change (↑m : WithTop ℤ) = ↑(-1 : ℤ); congr 1; omega
+    change (m : WithTop ℤ) = (-1 : ℤ); congr 1; omega
 
 @[blueprint
   "Phi-cancel"
@@ -1140,12 +1131,8 @@ theorem Phi_circ.contDiff_real (ν ε : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 
         refine ContDiff.div_const ?_ _
         refine (ContDiff.add ?_ contDiff_const)
         exact (ContDiff.mul contDiff_const <| Complex.ofRealCLM.contDiff)
-      · have h_cosh_entire : ContDiff ℝ 2 (fun t : ℂ => Complex.cosh t) := by
-          have : ContDiff ℂ 2 Complex.cosh := by
-            unfold Complex.cosh
-            exact ContDiff.div_const (Complex.contDiff_exp.add (Complex.contDiff_exp.comp contDiff_neg)) _
-          exact this.restrict_scalars ℝ
-        exact h_cosh_entire.comp (ContDiff.div_const (ContDiff.add (ContDiff.mul contDiff_const Complex.ofRealCLM.contDiff) contDiff_const) _)
+      · have h_cosh_entire : ContDiff ℂ 2 Complex.cosh := by fun_prop
+        exact (h_cosh_entire.restrict_scalars ℝ).comp (ContDiff.div_const (ContDiff.add (ContDiff.mul contDiff_const Complex.ofRealCLM.contDiff) contDiff_const) _)
       · norm_num [Complex.sinh, Complex.exp_ne_zero]
         norm_num [sub_eq_zero, Complex.exp_ne_zero]
         intro t ht; rw [Complex.exp_eq_exp_iff_exists_int] at ht
@@ -1265,18 +1252,9 @@ hence, by Definition \ref{phi-pm-def}, $\varphi^{\pm}_{\nu}(t) = 0$. Thus, $\var
   (latexEnv := "lemma")
   (discussion := 1075)]
 theorem ϕ_continuous (ν ε : ℝ) (hlam : ν ≠ 0) : Continuous (ϕ_pm ν ε) := by
-  have tanh_add_pi : ∀ z : ℂ, Complex.tanh (z + ↑Real.pi * I) = Complex.tanh z := by
-    intro z
-    simp only [Complex.tanh_eq_sinh_div_cosh]
-    have h1 : Complex.sinh (z + ↑Real.pi * I) = -Complex.sinh z := by
-      simp only [Complex.sinh, Complex.exp_add, Complex.exp_neg]; rw [exp_pi_mul_I]; simp; ring
-    have h2 : Complex.cosh (z + ↑Real.pi * I) = -Complex.cosh z := by
-      simp only [Complex.cosh, Complex.exp_add, Complex.exp_neg]; rw [exp_pi_mul_I]; simp; ring
-    rw [h1, h2, neg_div_neg_eq]
-  have tanh_sub_pi : ∀ z : ℂ, Complex.tanh (z - ↑Real.pi * I) = Complex.tanh z := by
-    intro z
-    have h := tanh_add_pi (z - ↑Real.pi * I)
-    rw [sub_add_cancel] at h; exact h.symm
+  have tanh_add_pi (z : ℂ) : Complex.tanh (z + ↑Real.pi * I) = Complex.tanh z := by simp
+  have tanh_sub_pi (z : ℂ) : Complex.tanh (z - ↑Real.pi * I) = Complex.tanh z := by
+    have h := tanh_add_pi (z - ↑Real.pi * I); rw [sub_add_cancel] at h; exact h.symm
   unfold ϕ_pm
   apply continuous_if
   · intro a ha

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -524,6 +524,102 @@ lemma _root_.ContinuousAt.coth {f : ℝ → ℂ} {s : ℝ} (hf : ContinuousAt f 
   rw [this]
   exact (Complex.continuous_cosh.continuousAt.comp hf).div (Complex.continuous_sinh.continuousAt.comp hf) h_sinh
 
+/-- If `cosh z = 0` then `sinh z ≠ 0`, since `cosh² z - sinh² z = 1`. -/
+lemma _root_.Complex.sinh_ne_zero_of_cosh_zero {z : ℂ} (h : Complex.cosh z = 0) :
+    Complex.sinh z ≠ 0 := by
+  intro hs; have := Complex.cosh_sq_sub_sinh_sq z; simp [h, hs] at this
+
+/-- If `sinh z = 0` then `cosh z ≠ 0`, since `cosh² z - sinh² z = 1`. -/
+lemma _root_.Complex.cosh_ne_zero_of_sinh_zero {z : ℂ} (h : Complex.sinh z = 0) :
+    Complex.cosh z ≠ 0 := by
+  intro hc; have := Complex.cosh_sq_sub_sinh_sq z; simp [h, hc] at this
+
+/-- `Complex.cosh` is not identically zero near any point, so its `meromorphicOrderAt` is finite. -/
+lemma meromorphicOrderAt_cosh_ne_top (z : ℂ) : meromorphicOrderAt Complex.cosh z ≠ ⊤ := by
+  intro h_top
+  have h_p : ∀ᶠ x in nhdsWithin z {z}ᶜ, Complex.cosh x = 0 :=
+    meromorphicOrderAt_eq_top_iff.mp h_top
+  have h_val : Complex.cosh z = 0 := tendsto_nhds_unique
+    (Complex.continuous_cosh.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
+    (Filter.EventuallyEq.tendsto h_p)
+  have h_nhds : (fun x => Complex.cosh x) =ᶠ[nhds z] (fun _ => (0 : ℂ)) := by
+    rw [eventually_nhdsWithin_iff] at h_p
+    filter_upwards [h_p] with x hx
+    exact if hxz : x = z then hxz ▸ h_val else hx hxz
+  have h_sinh : Complex.sinh z = 0 := by
+    simpa [deriv_const, (Complex.hasDerivAt_cosh z).deriv] using h_nhds.deriv_eq
+  exact absurd h_sinh (Complex.sinh_ne_zero_of_cosh_zero h_val)
+
+/-- `Complex.sinh` is not identically zero near any point, so its `meromorphicOrderAt` is finite. -/
+lemma meromorphicOrderAt_sinh_ne_top (z : ℂ) : meromorphicOrderAt Complex.sinh z ≠ ⊤ := by
+  intro h_top
+  have h_p : ∀ᶠ x in nhdsWithin z {z}ᶜ, Complex.sinh x = 0 :=
+    meromorphicOrderAt_eq_top_iff.mp h_top
+  have h_val : Complex.sinh z = 0 := tendsto_nhds_unique
+    (Complex.continuous_sinh.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
+    (Filter.EventuallyEq.tendsto h_p)
+  have h_nhds : (fun x => Complex.sinh x) =ᶠ[nhds z] (fun _ => (0 : ℂ)) := by
+    rw [eventually_nhdsWithin_iff] at h_p
+    filter_upwards [h_p] with x hx
+    exact if hxz : x = z then hxz ▸ h_val else hx hxz
+  have h_cosh : Complex.cosh z = 0 := by
+    simpa [deriv_const, (Complex.hasDerivAt_sinh z).deriv] using h_nhds.deriv_eq
+  exact absurd h_val (Complex.sinh_ne_zero_of_cosh_zero h_cosh)
+
+/-- `coth` has a pole at `z` if and only if `sinh z = 0`. -/
+lemma meromorphicOrderAt_coth_lt_zero_iff (z : ℂ) :
+    meromorphicOrderAt coth z < 0 ↔ Complex.sinh z = 0 := by
+  have h_coth_eq : coth = Complex.tanh⁻¹ := funext fun z => by unfold coth; simp [one_div]
+  have h_mero_tanh : MeromorphicAt Complex.tanh z := by fun_prop
+  have hne_top_tanh : meromorphicOrderAt Complex.tanh z ≠ ⊤ := by
+    apply (meromorphicOrderAt_ne_top_iff_eventually_ne_zero h_mero_tanh).mpr
+    have h_sinh_ne : ∀ᶠ x in nhdsWithin z {z}ᶜ, Complex.sinh x ≠ 0 :=
+      (meromorphicOrderAt_ne_top_iff_eventually_ne_zero Complex.analyticAt_sinh.meromorphicAt).mp
+        (meromorphicOrderAt_sinh_ne_top z)
+    have h_cosh_ne : ∀ᶠ x in nhdsWithin z {z}ᶜ, Complex.cosh x ≠ 0 :=
+      (meromorphicOrderAt_ne_top_iff_eventually_ne_zero Complex.analyticAt_cosh.meromorphicAt).mp
+        (meromorphicOrderAt_cosh_ne_top z)
+    filter_upwards [h_sinh_ne, h_cosh_ne] with x hs hc
+    rw [Complex.tanh_eq_sinh_div_cosh, div_ne_zero_iff]
+    exact ⟨hs, hc⟩
+  rw [h_coth_eq, meromorphicOrderAt_inv]
+  have h_neg_lt : -meromorphicOrderAt Complex.tanh z < 0 ↔
+      0 < meromorphicOrderAt Complex.tanh z := by
+    lift meromorphicOrderAt Complex.tanh z to ℤ using hne_top_tanh with a
+    norm_cast; omega
+  rw [h_neg_lt]
+  constructor
+  · intro h
+    by_cases hc : Complex.cosh z = 0
+    · exfalso
+      have hsinh_ne := Complex.sinh_ne_zero_of_cosh_zero hc
+      have hsinh_ord : meromorphicOrderAt Complex.sinh z = 0 := by
+        rw [← tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (by fun_prop)]
+        exact ⟨_, hsinh_ne, Complex.analyticAt_sinh.continuousAt.continuousWithinAt⟩
+      have hcosh_ord : 0 < meromorphicOrderAt Complex.cosh z := by
+        rw [← tendsto_zero_iff_meromorphicOrderAt_pos (by fun_prop)]
+        exact hc ▸ Complex.analyticAt_cosh.continuousAt.continuousWithinAt
+      have hord_neg : meromorphicOrderAt Complex.tanh z < 0 := by
+        rw [show Complex.tanh = fun x => Complex.sinh x / Complex.cosh x from
+              funext Complex.tanh_eq_sinh_div_cosh]
+        push (disch := fun_prop) meromorphicOrderAt
+        rw [hsinh_ord]
+        lift meromorphicOrderAt Complex.cosh z to ℤ using meromorphicOrderAt_cosh_ne_top z with m hm
+        norm_cast at hcosh_ord ⊢; omega
+      exact absurd hord_neg (not_lt.mpr h.le)
+    · have hcts : ContinuousAt Complex.tanh z := by fun_prop (disch := exact hc)
+      have h_tendsto := (tendsto_zero_iff_meromorphicOrderAt_pos h_mero_tanh).mpr h
+      have hval : Complex.tanh z = 0 :=
+        tendsto_nhds_unique (hcts.tendsto.mono_left nhdsWithin_le_nhds) h_tendsto
+      rw [Complex.tanh_eq_sinh_div_cosh, div_eq_zero_iff] at hval
+      exact hval.resolve_right hc
+  · intro h
+    have hc : Complex.cosh z ≠ 0 := Complex.cosh_ne_zero_of_sinh_zero h
+    have hcts : ContinuousAt Complex.tanh z := by fun_prop (disch := exact hc)
+    have hval : Complex.tanh z = 0 := by rw [Complex.tanh_eq_sinh_div_cosh, h, zero_div]
+    rw [← tendsto_zero_iff_meromorphicOrderAt_pos h_mero_tanh]
+    convert hcts.tendsto.mono_left nhdsWithin_le_nhds using 1; simp [hval]
+
 @[blueprint
   "Phi-circ-poles"
   (title := "$\\Phi^{\\pm,\\circ}_\\nu$ poles")
@@ -535,12 +631,12 @@ lemma _root_.ContinuousAt.coth {f : ℝ → ℂ} {s : ℝ} (hf : ContinuousAt f 
   (discussion := 1069)]
 theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
     meromorphicOrderAt (Phi_circ ν ε) z < 0 ↔ ∃ n : ℤ, z = n - I * ν / (2 * π) := by
+  -- Step 1: Reduce Phi_circ to coth (w/2)
   let w : ℂ → ℂ := fun z ↦ -2 * π * I * z + ν
   have h_ord_eq : meromorphicOrderAt (Phi_circ ν ε) z < 0 ↔ meromorphicOrderAt (fun z ↦ coth (w z / 2)) z < 0 := by
     rw [show Phi_circ ν ε = (fun _ ↦ (1 / 2 : ℂ)) * (fun z ↦ coth (w z / 2) + ε) from rfl]
     rw [meromorphicOrderAt_mul_of_ne_zero (analyticAt_const (v := (1/2 : ℂ)) (x := z)) (by norm_num : (1/2 : ℂ) ≠ 0)]
-    have h_coth_mero : MeromorphicAt (fun z ↦ coth (w z / 2)) z := by
-      fun_prop
+    have h_coth_mero : MeromorphicAt (fun z ↦ coth (w z / 2)) z := by fun_prop
     constructor
     · intro h
       contrapose! h
@@ -555,58 +651,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
       rw [show (fun z ↦ coth (w z / 2) + ε) = (fun z ↦ coth (w z / 2)) + (fun _ ↦ (ε : ℂ)) from rfl]
       rw [meromorphicOrderAt_add_of_ne h_coth_mero (by fun_prop) h_ne]
       simp [h]
-  have h_mero_tanh : MeromorphicAt Complex.tanh (w z / 2) := by fun_prop
-  have h_cosh_eventually_ne : ∀ᶠ (x : ℂ) in nhdsWithin (w z / 2) {w z / 2}ᶜ, Complex.cosh x ≠ 0 := by
-    apply (meromorphicOrderAt_ne_top_iff_eventually_ne_zero Complex.analyticAt_cosh.meromorphicAt).mp
-    intro h_top
-    have h_zero_nhds : ∀ᶠ x in nhds (w z / 2), Complex.cosh x = 0 := by
-      have h_p : ∀ᶠ x in nhdsWithin (w z / 2) {w z / 2}ᶜ, Complex.cosh x = 0 :=
-        meromorphicOrderAt_eq_top_iff.mp h_top
-      have h_eval : Complex.cosh (w z / 2) = 0 := tendsto_nhds_unique
-        (Complex.continuous_cosh.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
-        (Filter.EventuallyEq.tendsto h_p)
-      rw [eventually_nhdsWithin_iff] at h_p
-      filter_upwards [h_p] with x hx
-      obtain rfl | hne := eq_or_ne x (w z / 2)
-      · exact h_eval
-      · exact hx hne
-    have h_eq : (fun x => Complex.cosh x) =ᶠ[nhds (w z / 2)] (fun x => 0) := h_zero_nhds
-    have h_cosh_c : Complex.cosh (w z / 2) = 0 := h_eq.eq_of_nhds
-    have h_deriv_eq : Complex.sinh (w z / 2) = 0 := by
-      simpa [deriv_const, (Complex.hasDerivAt_cosh (w z / 2)).deriv] using h_eq.deriv_eq
-    have key := Complex.cosh_sq_sub_sinh_sq (w z / 2)
-    simp [h_cosh_c, h_deriv_eq] at key
-  have hne_top_tanh : meromorphicOrderAt Complex.tanh (w z / 2) ≠ ⊤ := by
-    apply (meromorphicOrderAt_ne_top_iff_eventually_ne_zero h_mero_tanh).mpr
-    have h_tanh_eq : ∀ x : ℂ, Complex.tanh x = 0 ↔ Complex.sinh x = 0 ∨ Complex.cosh x = 0 := by
-      intro x
-      rw [Complex.tanh_eq_sinh_div_cosh, div_eq_zero_iff]
-    have h_sinh_eventually_ne : ∀ᶠ (x : ℂ) in nhdsWithin (w z / 2) {w z / 2}ᶜ, Complex.sinh x ≠ 0 := by
-      apply (meromorphicOrderAt_ne_top_iff_eventually_ne_zero Complex.analyticAt_sinh.meromorphicAt).mp
-      intro h_top
-      have h_zero_nhds : ∀ᶠ x in nhds (w z / 2), Complex.sinh x = 0 := by
-        have h_p : ∀ᶠ x in nhdsWithin (w z / 2) {w z / 2}ᶜ, Complex.sinh x = 0 :=
-          meromorphicOrderAt_eq_top_iff.mp h_top
-        have h_eval : Complex.sinh (w z / 2) = 0 := tendsto_nhds_unique
-          (Complex.continuous_sinh.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
-          (Filter.EventuallyEq.tendsto h_p)
-        rw [eventually_nhdsWithin_iff] at h_p
-        filter_upwards [h_p] with x hx
-        obtain rfl | hne := eq_or_ne x (w z / 2)
-        · exact h_eval
-        · exact hx hne
-      have h_eq : (fun x => Complex.sinh x) =ᶠ[nhds (w z / 2)] (fun x => 0) := h_zero_nhds
-      have h_sinh_c : Complex.sinh (w z / 2) = 0 := h_eq.eq_of_nhds
-      have h_deriv_eq : Complex.cosh (w z / 2) = 0 := by
-        simpa [deriv_const, (Complex.hasDerivAt_sinh (w z / 2)).deriv] using h_eq.deriv_eq
-      have key := Complex.cosh_sq_sub_sinh_sq (w z / 2)
-      simp [h_sinh_c, h_deriv_eq] at key
-    filter_upwards [h_sinh_eventually_ne, h_cosh_eventually_ne] with x hx1 hx2
-    intro h
-    rcases (h_tanh_eq x).mp h with h1 | h2
-    · exact hx1 h1
-    · exact hx2 h2
-  rw [h_ord_eq]
+  -- Step 2: Apply "pole of coth iff zero of sinh" via composition
   have h_pole_iff : meromorphicOrderAt (fun z ↦ coth (w z / 2)) z < 0 ↔ (Complex.sinh (w z / 2) = 0) := by
     have h_mero_w : AnalyticAt ℂ (fun z => w z / 2) z := by dsimp [w]; fun_prop
     have h_deriv_w : deriv (fun z => w z / 2) z ≠ 0 := by
@@ -616,83 +661,10 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
       rw [hd.deriv]; simp [pi_ne_zero, I_ne_zero]
     have h_comp : meromorphicOrderAt (fun z ↦ coth (w z / 2)) z = meromorphicOrderAt coth (w z / 2) :=
       meromorphicOrderAt_comp_of_deriv_ne_zero (f := coth) h_mero_w h_deriv_w
-    have h_inv : meromorphicOrderAt coth (w z / 2) = -meromorphicOrderAt Complex.tanh (w z / 2) := by
-      have hcoth_eq : coth = Complex.tanh⁻¹ := funext fun z => by unfold coth; simp [one_div]
-      rw [hcoth_eq]
-      exact meromorphicOrderAt_inv
-    have h_mero_tanh : MeromorphicAt Complex.tanh (w z / 2) := by
-      fun_prop
-    have h_pos : (0 < meromorphicOrderAt Complex.tanh (w z / 2)) ↔ (Complex.sinh (w z / 2) = 0) := by
-      rw [← tendsto_zero_iff_meromorphicOrderAt_pos h_mero_tanh]
-      constructor
-      · intro h
-        by_cases hc : Complex.cosh (w z / 2) = 0
-        · exfalso
-          have hsinh_ne : Complex.sinh (w z / 2) ≠ 0 := by
-            intro hs
-            have key := Complex.cosh_sq_sub_sinh_sq (w z / 2)
-            rw [hc, hs] at key
-            norm_num at key
-          have hord_neg : meromorphicOrderAt Complex.tanh (w z / 2) < 0 := by
-            rw [show Complex.tanh = fun x => Complex.sinh x / Complex.cosh x from
-                  funext Complex.tanh_eq_sinh_div_cosh]
-            have hsinh_mero : MeromorphicAt Complex.sinh (w z / 2) := by fun_prop
-            have hcosh_mero : MeromorphicAt Complex.cosh (w z / 2) := by fun_prop
-            have hsinh_ord : meromorphicOrderAt Complex.sinh (w z / 2) = 0 := by
-              rw [← tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero hsinh_mero]
-              exact ⟨Complex.sinh (w z / 2), hsinh_ne,
-                     Complex.analyticAt_sinh.continuousAt.continuousWithinAt⟩
-            have hcosh_ord : 0 < meromorphicOrderAt Complex.cosh (w z / 2) := by
-              rw [← tendsto_zero_iff_meromorphicOrderAt_pos hcosh_mero]
-              have hana : AnalyticAt ℂ Complex.cosh (w z / 2) := Complex.analyticAt_cosh
-              exact hc ▸ hana.continuousAt.continuousWithinAt
-            push (disch := fun_prop) meromorphicOrderAt
-            rw [hsinh_ord]
-            have hne_top_cosh : meromorphicOrderAt Complex.cosh (w z / 2) ≠ ⊤ := by
-              rw [ne_eq, meromorphicOrderAt_eq_top_iff]
-              intro h_cosh_zero
-              have h_eq_pw : (fun x => Complex.cosh x) =ᶠ[nhdsWithin (w z / 2) {w z / 2}ᶜ]
-                  (fun _ => (0 : ℂ)) := h_cosh_zero
-              have h_eval : Complex.cosh (w z / 2) = 0 := -- simpler proof here?
-                tendsto_nhds_unique
-                  (Complex.continuous_cosh.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
-                  h_eq_pw.tendsto
-              have h_nhds : (fun x => Complex.cosh x) =ᶠ[nhds (w z / 2)] (fun _ => (0 : ℂ)) := by
-                rw [eventually_nhdsWithin_iff] at h_cosh_zero
-                filter_upwards [h_cosh_zero] with x hx
-                exact if h : x = w z / 2 then h ▸ h_eval else hx h
-              have h_deriv := h_nhds.deriv_eq
-              rw [deriv_const, (Complex.hasDerivAt_cosh (w z / 2)).deriv] at h_deriv
-              exact hsinh_ne h_deriv
-            lift meromorphicOrderAt Complex.cosh (w z / 2) to ℤ using hne_top_cosh with m hm
-            norm_cast at hcosh_ord ⊢
-            omega
-          exact absurd hord_neg (not_lt.mpr ((tendsto_zero_iff_meromorphicOrderAt_pos h_mero_tanh).mp h).le)
-        · have hcts : ContinuousAt Complex.tanh (w z / 2) := by
-            fun_prop (disch := exact hc)
-          have hval : Complex.tanh (w z / 2) = 0 :=
-            tendsto_nhds_unique (hcts.tendsto.mono_left nhdsWithin_le_nhds) h
-          rw [Complex.tanh_eq_sinh_div_cosh, div_eq_zero_iff] at hval
-          exact hval.resolve_right hc
-      · intro h
-        have hc : Complex.cosh (w z / 2) ≠ 0 := by
-          intro heq
-          have hsum := Complex.cosh_add_sinh (w z / 2)
-          rw [heq, h, zero_add] at hsum
-          exact absurd hsum.symm (Complex.exp_ne_zero _)
-        have hcts : ContinuousAt Complex.tanh (w z / 2) := by
-          fun_prop (disch := exact hc)
-        have hval : Complex.tanh (w z / 2) = 0 := by
-          rw [Complex.tanh_eq_sinh_div_cosh, h, zero_div]
-        convert hcts.tendsto.mono_left nhdsWithin_le_nhds using 1
-        simp [hval]
-    rw [h_comp, h_inv]
-    have h_finish : -meromorphicOrderAt Complex.tanh (w z / 2) < 0 ↔
-        0 < meromorphicOrderAt Complex.tanh (w z / 2) := by
-      lift meromorphicOrderAt Complex.tanh (w z / 2) to ℤ using hne_top_tanh with a
-      norm_cast; omega
-    rw [h_finish, h_pos]
-  rw [h_pole_iff, sinh_zero_iff]
+    rw [h_comp]
+    exact meromorphicOrderAt_coth_lt_zero_iff _
+  -- Step 3: Rewrite with sinh_zero_iff and solve the linear equation
+  rw [h_ord_eq, h_pole_iff, sinh_zero_iff]
   constructor
   · rintro ⟨k, hk⟩
     use -k

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -434,7 +434,7 @@ theorem tanh_add_int_mul_pi_I (z : ℂ) (m : ℤ) : tanh (z + π * I * m) = tanh
 
 @[simp]
 public theorem tanh_add_pi_I (z : ℂ) : tanh (z + π * I) = tanh z := by
-  have := tanh_add_int_mul_pi_I z 1; simp at this; exact this
+  simpa using tanh_add_int_mul_pi_I z 1
 
 lemma coth_add_pi_mul_I (z : ℂ) : coth (z + π * I) = coth z := by
   simp [coth]
@@ -1077,17 +1077,30 @@ lemma ContDiff.div_real_complex {f g : ℝ → ℂ} {n} (hf : ContDiff ℝ n f) 
 @[fun_prop]
 lemma Complex.ofRealCLM.contDiff2 : ContDiff ℝ 2 ofReal := Complex.ofRealCLM.contDiff
 
+@[fun_prop]
+lemma Complex.contDiff_normSq {n : ℕ∞} : ContDiff ℝ n (normSq : ℂ → ℝ) := by
+  have hre : ContDiff ℝ n (Complex.reCLM : ℂ → ℝ) := Complex.reCLM.contDiff
+  have him : ContDiff ℝ n (Complex.imCLM : ℂ → ℝ) := Complex.imCLM.contDiff
+  change ContDiff ℝ n (fun z : ℂ => z.re * z.re + z.im * z.im)
+  exact (hre.mul hre).add (him.mul him)
+
+@[fun_prop]
+lemma Complex.contDiff_sinh_real {n : ℕ∞} : ContDiff ℝ n (Complex.sinh : ℂ → ℂ) :=
+  Complex.contDiff_sinh.restrict_scalars ℝ
+
+@[fun_prop]
+lemma Complex.contDiff_cosh_real {n : ℕ∞} : ContDiff ℝ n (Complex.cosh : ℂ → ℂ) :=
+  Complex.contDiff_cosh.restrict_scalars ℝ
+
 lemma h_B_rational (ε : ℝ) : ∀ w : ℂ, w ≠ 0 → B ε w = w * (Complex.cosh (w / 2) / Complex.sinh (w / 2) + ε) / 2 := by
   simp +contextual [Complex.tanh_eq_sinh_div_cosh, B, coth]
 
 lemma h_comp (ε ν : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 (fun t : ℝ => (-2 * Real.pi * Complex.I * t + ν) * (Complex.cosh ((-2 * Real.pi * Complex.I * t + ν) / 2) / Complex.sinh ((-2 * Real.pi * Complex.I * t + ν) / 2) + ε) / 2) := by
   apply_rules [ContDiff.div, ContDiff.mul, ContDiff.add, contDiff_const, contDiff_id] <;> try fun_prop
-  · exact Complex.conjCLE.contDiff.comp (by simp only [Complex.sinh, neg_mul]; fun_prop)
+  · exact Complex.conjCLE.contDiff.comp (by fun_prop)
   · refine Complex.ofRealCLM.contDiff.comp ?_
     refine ContDiff.inv ?_ ?_
-    · norm_num [Complex.normSq, Complex.sinh]
-      norm_num [Complex.exp_re, Complex.exp_im]
-      exact ContDiff.div_const (by fun_prop) _
+    · fun_prop
     · intro x; rw [ne_eq, Complex.normSq_eq_zero]
       exact sinh_ne_zero_of_re_ne_zero (by simp [hlam])
 

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -1455,8 +1455,8 @@ theorem ϕ_star_bound_right (ν₀ ν₁ ε c : ℝ) (hν₀ : 0 < ν₀) (hν�
       refine ContinuousOn.mul Complex.continuous_ofReal.continuousOn
         (ContinuousOn.add ?_ continuousOn_const)
       refine ContinuousOn.div ?_ ?_ ?_
-      · exact Continuous.continuousOn (by continuity)
-      · exact Continuous.continuousOn (by continuity)
+      · fun_prop
+      · fun_prop
       · intro x hx
         have h3 : (↑x / 2 : ℂ) = ↑(x / 2) := by push_cast; ring
         rw [h3]
@@ -1621,7 +1621,8 @@ theorem B_plus_mono : Monotone (fun t:ℝ ↦ (B 1 t).re) := by
     intro a ha b hb hab
     have h_mean_val : ∀ a b : ℝ, 0 < a → a < b → ∃ c ∈ Set.Ioo a b, deriv (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) c = ( (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) b - (fun t : ℝ => t * Real.exp t / (Real.exp t - 1)) a ) / (b - a) := by
       intros a b ha hb; apply_rules [ exists_deriv_eq_slope ];
-      · exact continuousOn_of_forall_continuousAt fun t ht => ContinuousAt.div ( ContinuousAt.mul continuousAt_id ( Real.continuous_exp.continuousAt ) ) ( ContinuousAt.sub ( Real.continuous_exp.continuousAt ) continuousAt_const ) ( sub_ne_zero_of_ne ( by linarith [ Real.add_one_le_exp t, ht.1 ] ) );
+      · exact continuousOn_of_forall_continuousAt fun t ht => by
+          fun_prop (disch := exact sub_ne_zero_of_ne (by linarith [Real.add_one_le_exp t, ht.1]))
       · exact DifferentiableOn.div ( DifferentiableOn.mul differentiableOn_id ( Real.differentiable_exp.differentiableOn ) ) ( DifferentiableOn.sub ( Real.differentiable_exp.differentiableOn ) ( differentiableOn_const _ ) ) fun x hx => ne_of_gt ( by norm_num; linarith [ hx.1 ] );
     cases eq_or_lt_of_le hab
     · aesop
@@ -1638,7 +1639,8 @@ theorem B_plus_mono : Monotone (fun t:ℝ ↦ (B 1 t).re) := by
     obtain ⟨c, hc⟩ : ∃ c ∈ Set.Ioo t u, deriv (fun t => t * Real.exp t / (Real.exp t - 1)) c = (u * Real.exp u / (Real.exp u - 1) - t * Real.exp t / (Real.exp t - 1)) / (u - t) := by
       apply_rules [ exists_deriv_eq_slope ]
       · exact htu.lt_of_ne ( by rintro rfl; linarith )
-      · exact continuousOn_of_forall_continuousAt fun x hx => ContinuousAt.div ( ContinuousAt.mul continuousAt_id ( Real.continuous_exp.continuousAt ) ) ( ContinuousAt.sub ( Real.continuous_exp.continuousAt ) continuousAt_const ) ( sub_ne_zero_of_ne ( by norm_num; linarith [ hx.1, hx.2, ht.out, hu.out ] ) )
+      · exact continuousOn_of_forall_continuousAt fun x hx => by
+          fun_prop (disch := exact sub_ne_zero_of_ne (by norm_num; linarith [hx.1, hx.2, ht.out, hu.out]))
       · exact fun x hx => DifferentiableAt.differentiableWithinAt ( by exact DifferentiableAt.div ( differentiableAt_id.mul ( Real.differentiableAt_exp ) ) ( Real.differentiableAt_exp.sub_const _ ) ( sub_ne_zero_of_ne ( by norm_num; linarith [ hx.1, hx.2, hu.out, ht.out ] ) ) )
     rw [ eq_div_iff ] at hc <;> nlinarith [ hc.1.1, hc.1.2, h_deriv_nonneg c ( by linarith [ hc.1.1, hc.1.2, hu.out ] ) ]);
   intro t₁ t₂ ht;
@@ -1966,8 +1968,8 @@ theorem integrable_phi_fourier_ray (ν ε σ x : ℝ) (hν : ν > 0) (hsigma : �
       rcases hf_formula with h_eq | h_eq <;> rw [h_eq]
       · exact ((Phi_circ.analytic ν ε z hν hy_im).add (Phi_star.analytic ν ε z hν hy_im)).mul hE
       · exact ((Phi_circ.analytic ν ε z hν hy_im).sub (Phi_star.analytic ν ε z hν hy_im)).mul hE
-    have h_ray : ContinuousAt (fun (y' : ℝ) => ↑σ + ↑y' * I) y :=
-      continuousAt_const.add (Complex.continuous_ofReal.continuousAt.mul continuousAt_const)
+    have h_ray : ContinuousAt (fun (y' : ℝ) => ↑σ + ↑y' * I) y := by
+      fun_prop
     exact ContinuousAt.comp_of_eq h_anal_at_z.continuousAt h_ray rfl |>.continuousWithinAt
   obtain ⟨C, hC⟩ : ∃ C, ∀ y : ℝ, y ≥ 1 → ‖f (σ + y * I)‖ ≤ C * (y + 1) * rexp (2 * π * x * y) := by
     apply phi_fourier_ray_bound ν ε σ x hν hsigma
@@ -2040,7 +2042,7 @@ lemma horizontal_integral_phi_fourier_vanish (ν ε x a b : ℝ) (hν : ν > 0) 
           · refine ContinuousOn.intervalIntegrable ?_
             refine ContinuousOn.norm ?_
             rw [Set.uIcc_of_le hab]
-            have hg : Continuous (fun t : ℝ ↦ (↑t : ℂ) + I * ↑T) := by continuity
+            have hg : Continuous (fun t : ℝ ↦ (↑t : ℂ) + I * ↑T) := by fun_prop
             have h_seg_in : (fun t ↦ ↑t + I * ↑T) '' Set.Icc a b ⊆ Rectangle a (b + I * T) := by
               intro z ⟨t, ht, hz⟩
               subst hz

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -1048,8 +1048,7 @@ theorem Phi_cancel (ν ε σ : ℝ) (hν : ν > 0) (hσ : |σ| = 1) :
         exact_mod_cast sq_eq_one_iff.mpr hσ
       simp only [hn_sq]
       ring
-  have h_mero_mul : MeromorphicAt (fun z ↦ (z - z₀) * f z) z₀ := by fun_prop
-  rw [tendsto_zero_iff_meromorphicOrderAt_pos h_mero_mul] at h_tendsto_zero
+  rw [tendsto_zero_iff_meromorphicOrderAt_pos (by fun_prop)] at h_tendsto_zero
   change 0 < meromorphicOrderAt ((· - z₀) * f) z₀ at h_tendsto_zero
   rw [meromorphicOrderAt_mul (by fun_prop) h_mero_f] at h_tendsto_zero
   rw [show meromorphicOrderAt (· - z₀) z₀ = (1 : ℤ) from
@@ -1082,26 +1081,15 @@ lemma h_B_rational (ε : ℝ) : ∀ w : ℂ, w ≠ 0 → B ε w = w * (Complex.c
   simp +contextual [Complex.tanh_eq_sinh_div_cosh, B, coth]
 
 lemma h_comp (ε ν : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 (fun t : ℝ => (-2 * Real.pi * Complex.I * t + ν) * (Complex.cosh ((-2 * Real.pi * Complex.I * t + ν) / 2) / Complex.sinh ((-2 * Real.pi * Complex.I * t + ν) / 2) + ε) / 2) := by
-  apply_rules [ContDiff.div, ContDiff.mul, ContDiff.add, contDiff_const, contDiff_id]
-  · fun_prop
-  · fun_prop
-  · fun_prop
-  · have h_conj : ContDiff ℝ 2 (fun x : ℝ => Complex.sinh ((-2 * Real.pi * Complex.I * x + ν) / 2)) := by
-      have h_conj : ContDiff ℝ 2 (fun x : ℝ => Complex.exp ((-2 * Real.pi * Complex.I * x + ν) / 2)) := by fun_prop
-      simp_all only [ne_eq, Complex.sinh, neg_mul]
-      fun_prop
-    rw [contDiff_iff_contDiffAt] at *
-    intro x; specialize h_conj x; exact (by
-    convert Complex.conjCLE.contDiff.contDiffAt.comp x h_conj using 1)
+  apply_rules [ContDiff.div, ContDiff.mul, ContDiff.add, contDiff_const, contDiff_id] <;> try fun_prop
+  · exact Complex.conjCLE.contDiff.comp (by simp only [Complex.sinh, neg_mul]; fun_prop)
   · refine Complex.ofRealCLM.contDiff.comp ?_
     refine ContDiff.inv ?_ ?_
     · norm_num [Complex.normSq, Complex.sinh]
       norm_num [Complex.exp_re, Complex.exp_im]
       exact ContDiff.div_const (by fun_prop) _
-    · norm_num [Complex.sinh, Complex.exp_re, Complex.exp_im, Complex.normSq]
-      intro x; ring_nf; norm_num [Real.exp_ne_zero, hlam]
-      norm_num [Real.sin_sq, Real.cos_sq, mul_assoc, mul_left_comm, ← Real.exp_add, ← Real.exp_nat_mul]; ring_nf
-      cases lt_or_gt_of_ne hlam <;> nlinarith [Real.cos_le_one (Real.pi * x * 2), Real.exp_pos ν, Real.exp_pos (-ν), Real.exp_neg ν, mul_inv_cancel₀ (ne_of_gt (Real.exp_pos ν)), Real.add_one_le_exp ν, Real.add_one_le_exp (-ν)]
+    · intro x; rw [ne_eq, Complex.normSq_eq_zero]
+      exact sinh_ne_zero_of_re_ne_zero (by simp [hlam])
 
 theorem Phi_star.contDiff_real (ν ε : ℝ) (hlam : ν ≠ 0) :
     ContDiff ℝ 2 (fun (t : ℝ) ↦ Phi_star ν ε (t : ℂ)) := by

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -409,20 +409,21 @@ In this section we construct extremal approximants to the truncated exponential 
 
 noncomputable def coth (z : ℂ) : ℂ := 1 / tanh z
 
-lemma coth_add_pi_mul_I (z : ℂ) : coth (z + π * I) = coth z := by
-  have hexp_neg : exp (-(π * I)) = -1 := by
-    rw [Complex.exp_neg, exp_pi_mul_I, inv_neg, inv_one]
-  have hsinh : Complex.sinh (z + π * I) = -Complex.sinh z := by
-    rw [Complex.sinh, Complex.sinh, Complex.exp_add, neg_add, Complex.exp_add,
-        exp_pi_mul_I, hexp_neg]; ring
-  have hcosh : Complex.cosh (z + π * I) = -Complex.cosh z := by
-    rw [Complex.cosh, Complex.cosh, Complex.exp_add, neg_add, Complex.exp_add,
-        exp_pi_mul_I, hexp_neg]; ring
-  have h_tanh : tanh (z + π * I) = tanh z := by
-    rw [Complex.tanh_eq_sinh_div_cosh, Complex.tanh_eq_sinh_div_cosh,
-        hsinh, hcosh]; field_simp
-  simp [coth, h_tanh]
+@[simp]
+theorem sinh_add_pi_I (z : ℂ) : sinh (z + π * I) = -sinh z := by
+    simp [Complex.sinh_add, sinh_mul_I, cosh_mul_I]
 
+@[simp]
+theorem cosh_add_pi_I (z : ℂ) : cosh (z + π * I) = -cosh z := by
+    simp [Complex.cosh_add, cosh_mul_I, sinh_mul_I]
+
+@[simp]
+public theorem tanh_add_pi_I (z : ℂ) : tanh (z + π * I) = tanh z := by
+  rw [Complex.tanh_eq_sinh_div_cosh, Complex.tanh_eq_sinh_div_cosh,
+    sinh_add_pi_I, cosh_add_pi_I]; field_simp
+
+lemma coth_add_pi_mul_I (z : ℂ) : coth (z + π * I) = coth z := by
+  simp [coth]
 
 @[blueprint
   "Phi-circ-def"
@@ -435,6 +436,14 @@ noncomputable def Phi_circ (ν ε : ℝ) (z : ℂ) : ℂ :=
   let w := -2 * π * I * z + (ν : ℂ)
   (1 / 2) * (coth (w / 2) + ε)
 
+attribute [fun_prop] MeromorphicAt.comp_analyticAt
+
+@[fun_prop]
+theorem meromorphicAt_tanh (z : ℂ) : MeromorphicAt Complex.tanh z := by fun_prop [Complex.tanh]
+
+@[fun_prop]
+theorem meromorphicAt_coth (z : ℂ) : MeromorphicAt coth z := by fun_prop [CH2.coth]
+
 @[blueprint
   "Phi-circ-mero"
   (title := "$\\Phi^{\\pm,\\circ}_\\nu$ meromorphic")
@@ -444,15 +453,9 @@ noncomputable def Phi_circ (ν ε : ℝ) (z : ℂ) : ℂ :=
   (proof := /-- This follows from the definition of $\Phi^{\pm,\circ}_\nu$ and the properties of the $\coth$ function. -/)]
 theorem Phi_circ.meromorphic (ν ε : ℝ) : Meromorphic (Phi_circ ν ε) := by
   intro z
-  have hw : AnalyticAt ℂ (fun z => (-2 * π * I * z + ν) / 2) z := by fun_prop
-  apply MeromorphicAt.fun_mul (MeromorphicAt.const ..)
-  apply MeromorphicAt.fun_add _ (MeromorphicAt.const ..)
-  apply MeromorphicAt.fun_div (MeromorphicAt.const ..)
-  apply (analyticAt_sinh.comp hw).meromorphicAt.fun_div
-  apply AnalyticAt.meromorphicAt
-  fun_prop
+  fun_prop [CH2.Phi_circ]
 
-@[to_fun] theorem meromorphicOrderAt_div {𝕜 : Type*} [NontriviallyNormedField 𝕜] {x : 𝕜}
+@[to_fun (attr := push)] theorem meromorphicOrderAt_div {𝕜 : Type*} [NontriviallyNormedField 𝕜] {x : 𝕜}
     {f g : 𝕜 → 𝕜} (hf : MeromorphicAt f x) (hg : MeromorphicAt g x) :
     meromorphicOrderAt (f / g) x = meromorphicOrderAt f x - meromorphicOrderAt g x := by
   rw [div_eq_mul_inv, meromorphicOrderAt_mul hf hg.inv, meromorphicOrderAt_inv, sub_eq_add_neg]
@@ -513,9 +516,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
     rw [show Phi_circ ν ε = (fun _ ↦ (1 / 2 : ℂ)) * (fun z ↦ coth (w z / 2) + ε) from rfl]
     rw [meromorphicOrderAt_mul_of_ne_zero (analyticAt_const (v := (1/2 : ℂ)) (x := z)) (by norm_num : (1/2 : ℂ) ≠ 0)]
     have h_coth_mero : MeromorphicAt (fun z ↦ coth (w z / 2)) z := by
-      unfold coth Complex.tanh
-      have h_an : AnalyticAt ℂ (fun z ↦ w z / 2) z := by fun_prop
-      exact (MeromorphicAt.const 1 z).fun_div ((analyticAt_sinh.comp h_an).meromorphicAt.fun_div (analyticAt_cosh.comp h_an).meromorphicAt)
+      fun_prop
     constructor
     · intro h
       contrapose! h
@@ -528,7 +529,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
       have h_ne : meromorphicOrderAt (fun z ↦ coth (w z / 2)) z ≠ meromorphicOrderAt (fun _ ↦ (ε : ℂ)) z := by
         rw [meromorphicOrderAt_const]; split_ifs <;> simp [h.ne_top, h.ne]
       rw [show (fun z ↦ coth (w z / 2) + ε) = (fun z ↦ coth (w z / 2)) + (fun _ ↦ (ε : ℂ)) from rfl]
-      rw [meromorphicOrderAt_add_of_ne h_coth_mero (MeromorphicAt.const (ε : ℂ) z) h_ne]
+      rw [meromorphicOrderAt_add_of_ne h_coth_mero (by fun_prop) h_ne]
       simp [h]
   have h_mero_tanh : MeromorphicAt Complex.tanh (w z / 2) := by
     rw [show Complex.tanh = fun x => Complex.sinh x / Complex.cosh x from
@@ -599,9 +600,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
       rw [hcoth_eq]
       exact meromorphicOrderAt_inv
     have h_mero_tanh : MeromorphicAt Complex.tanh (w z / 2) := by
-      rw [show Complex.tanh = fun x => Complex.sinh x / Complex.cosh x from
-        funext Complex.tanh_eq_sinh_div_cosh]
-      exact Complex.analyticAt_sinh.meromorphicAt.fun_div Complex.analyticAt_cosh.meromorphicAt
+      fun_prop
     have h_pos : (0 < meromorphicOrderAt Complex.tanh (w z / 2)) ↔ (Complex.sinh (w z / 2) = 0) := by
       rw [← tendsto_zero_iff_meromorphicOrderAt_pos h_mero_tanh]
       constructor
@@ -616,10 +615,8 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
           have hord_neg : meromorphicOrderAt Complex.tanh (w z / 2) < 0 := by
             rw [show Complex.tanh = fun x => Complex.sinh x / Complex.cosh x from
                   funext Complex.tanh_eq_sinh_div_cosh]
-            have hsinh_mero : MeromorphicAt Complex.sinh (w z / 2) :=
-              Complex.analyticAt_sinh.meromorphicAt
-            have hcosh_mero : MeromorphicAt Complex.cosh (w z / 2) :=
-              Complex.analyticAt_cosh.meromorphicAt
+            have hsinh_mero : MeromorphicAt Complex.sinh (w z / 2) := by fun_prop
+            have hcosh_mero : MeromorphicAt Complex.cosh (w z / 2) := by fun_prop
             have hsinh_ord : meromorphicOrderAt Complex.sinh (w z / 2) = 0 := by
               rw [← tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero hsinh_mero]
               exact ⟨Complex.sinh (w z / 2), hsinh_ne,
@@ -628,14 +625,14 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
               rw [← tendsto_zero_iff_meromorphicOrderAt_pos hcosh_mero]
               have hana : AnalyticAt ℂ Complex.cosh (w z / 2) := Complex.analyticAt_cosh
               exact hc ▸ hana.continuousAt.continuousWithinAt
-            rw [fun_meromorphicOrderAt_div hsinh_mero hcosh_mero,
-                hsinh_ord]
+            push (disch := fun_prop) meromorphicOrderAt
+            rw [hsinh_ord]
             have hne_top_cosh : meromorphicOrderAt Complex.cosh (w z / 2) ≠ ⊤ := by
               rw [ne_eq, meromorphicOrderAt_eq_top_iff]
               intro h_cosh_zero
               have h_eq_pw : (fun x => Complex.cosh x) =ᶠ[nhdsWithin (w z / 2) {w z / 2}ᶜ]
                   (fun _ => (0 : ℂ)) := h_cosh_zero
-              have h_eval : Complex.cosh (w z / 2) = 0 :=
+              have h_eval : Complex.cosh (w z / 2) = 0 := -- simpler proof here?
                 tendsto_nhds_unique
                   (Complex.continuous_cosh.continuousAt.tendsto.mono_left nhdsWithin_le_nhds)
                   h_eq_pw.tendsto
@@ -686,7 +683,7 @@ theorem Phi_circ.poles (ν ε : ℝ) (_hν : ν > 0) (z : ℂ) :
     calc
       (2 * ↑π * z : ℂ) = (2 * ↑π * I * z) * (-I) := by ring_nf; simp
       _ = (↑ν - 2 * ↑k * ↑π * I) * (-I) := by rw [h1]
-      _ = 2 * ↑k * ↑π * Complex.I^2 - I * ↑ν := by ring
+      _ = 2 * ↑k * ↑π * Complex.I^2 - I * ν := by ring
       _ = 2 * ↑π * ↑(-k) - I * ↑ν := by simp; ring
   · rintro ⟨n, rfl⟩
     use -n
@@ -779,23 +776,20 @@ theorem Phi_circ.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
     have hf : MeromorphicAt (Phi_circ ν ε) z₀ := (Phi_circ.meromorphic ν ε).meromorphicAt
     have heq : (fun z ↦ (z - z₀) * Phi_circ ν ε z) =ᶠ[nhdsWithin z₀ {z₀}ᶜ] ((· - z₀) * Phi_circ ν ε) :=
       Filter.Eventually.of_forall fun _ ↦ rfl
-    have hL : (I : ℂ) / (2 * ↑π) ≠ 0 := by
-      apply div_ne_zero I_ne_zero
-      exact mul_ne_zero two_ne_zero (ofReal_ne_zero.mpr pi_ne_zero)
-    have hord₀ : meromorphicOrderAt ((· - z₀) * Phi_circ ν ε) z₀ = 0 :=
-      (tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (hsub.mul hf)).mp
-        ⟨_, hL, (Phi_circ.residue ν ε hν n).congr' heq⟩
-    have hord₁ : meromorphicOrderAt (· - z₀ : ℂ → ℂ) z₀ = (1 : ℤ) := by
+    have hord₀ : meromorphicOrderAt ((· - z₀) * Phi_circ ν ε) z₀ = 0 := by
+      rw [← tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (hsub.mul hf)]
+      exact ⟨_, by norm_num, (Phi_circ.residue ν ε hν n).congr' heq⟩
+    have hord₁ : meromorphicOrderAt (· - z₀) z₀ = (1 : ℤ) := by
       rw [meromorphicOrderAt_eq_int_iff hsub]
       exact ⟨1, analyticAt_const, one_ne_zero, by simp⟩
     rw [meromorphicOrderAt_mul hsub hf, hord₁] at hord₀
     obtain ⟨m, hm⟩ := WithTop.ne_top_iff_exists.mp
       (by rintro h; simp [h] at hord₀ : meromorphicOrderAt (Phi_circ ν ε) z₀ ≠ ⊤)
     rw [← hm] at hord₀ ⊢
-    have h1 : (↑(1 : ℤ) + ↑m : WithTop ℤ) = ↑(1 + m : ℤ) := by push_cast; ring_nf
+    have h1 : ((1 : ℤ) + m : WithTop ℤ) = (1 + m : ℤ) := by push_cast; ring_nf
     rw [h1] at hord₀
     have : 1 + m = 0 := by exact_mod_cast hord₀
-    change (↑m : WithTop ℤ) = ↑(-1 : ℤ); congr 1; omega
+    change (m : WithTop ℤ) = (-1 : ℤ); congr 1; omega
 
 @[blueprint
   "B-def"
@@ -927,7 +921,7 @@ lemma meromorphicAt_B (ε : ℝ) (z₀ : ℂ) : MeromorphicAt (B ε) z₀ := by
   (statement := /--
   $$\Phi^{\pm,\ast}_\nu(z)$$ is meromorphic.
   -/)
-  (proof := /-- This follows from the definition of $\Phi^{\pm,\ast}_\nu$ and the properties of the $B^\pm$ function. -/)]
+  (proof := /-- This follows from the definition of $\Phi^{\pm,\ast}_\nu$ and the properties of the $B^\pm$ function. -/), fun_prop]
 theorem Phi_star.meromorphic (ν ε : ℝ) : Meromorphic (Phi_star ν ε) := by
   intro z₀
   have h_comp : MeromorphicAt (fun z => B ε (-2 * Real.pi * Complex.I * z + ν)) z₀ ∧
@@ -1018,7 +1012,7 @@ theorem Phi_star.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
   · rintro ⟨n, hn, rfl⟩
     set z₀ := (n : ℂ) - I * ν / (2 * π)
     have hsub : MeromorphicAt (· - z₀ : ℂ → ℂ) z₀ := by fun_prop
-    have hf : MeromorphicAt (Phi_star ν ε) z₀ := (Phi_star.meromorphic ν ε).meromorphicAt
+    have hf : MeromorphicAt (Phi_star ν ε) z₀ := by fun_prop
     have heq : (fun z ↦ (z - z₀) * Phi_star ν ε z) =ᶠ[nhdsWithin z₀ {z₀}ᶜ] ((· - z₀) * Phi_star ν ε) :=
       Filter.Eventually.of_forall fun _ ↦ rfl
     have hL : -I * ↑n / (2 * ↑(π : ℝ)) ≠ (0 : ℂ) := by
@@ -1029,7 +1023,7 @@ theorem Phi_star.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
     have hord₀ : meromorphicOrderAt ((· - z₀) * Phi_star ν ε) z₀ = 0 :=
       (tendsto_ne_zero_iff_meromorphicOrderAt_eq_zero (hsub.mul hf)).mp
         ⟨_, hL, (Phi_star.residue ν ε hν n hn).congr' heq⟩
-    have hord₁ : meromorphicOrderAt (· - z₀ : ℂ → ℂ) z₀ = (1 : ℤ) := by
+    have hord₁ : meromorphicOrderAt (· - z₀) z₀ = (1 : ℤ) := by
       rw [meromorphicOrderAt_eq_int_iff hsub]
       exact ⟨1, analyticAt_const, one_ne_zero, by simp⟩
     rw [meromorphicOrderAt_mul hsub hf, hord₁] at hord₀
@@ -1052,15 +1046,14 @@ theorem Phi_star.poles_simple (ν ε : ℝ) (hν : ν > 0) (z : ℂ) :
   (discussion := 1074)]
 theorem Phi_cancel (ν ε σ : ℝ) (hν : ν > 0) (hσ : |σ| = 1) :
     meromorphicOrderAt (fun z ↦ Phi_circ ν ε z + σ * Phi_star ν ε z) ((σ : ℂ) - I * ν / (2 * π)) ≥ 0 := by
+  have hσ : σ = 1 ∨ σ = -1 := by grind
   obtain ⟨n, rfl, hn_cases⟩ : ∃ n : ℤ, σ = n ∧ n ≠ 0 := by
-    rcases (abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hσ with h | h
+    rcases hσ with h | h
     · exact ⟨1, by exact_mod_cast h, one_ne_zero⟩
     · exact ⟨-1, by exact_mod_cast h, by norm_num⟩
-  set z₀ : ℂ := ↑n - I * ν / (2 * π)
-  set f : ℂ → ℂ := fun z ↦ Phi_circ ν ε z + (n : ℂ) * Phi_star ν ε z
-  have h_mero_f : MeromorphicAt f z₀ :=
-    (Phi_circ.meromorphic ν ε z₀).add <|
-      (MeromorphicAt.const (↑n : ℂ) z₀).mul (Phi_star.meromorphic ν ε z₀)
+  set z₀ : ℂ := n - I * ν / (2 * π)
+  set f := fun z ↦ Phi_circ ν ε z + n * Phi_star ν ε z
+  have h_mero_f : MeromorphicAt f z₀ := by fun_prop [CH2.Phi_circ]
   have h_tendsto_zero : (nhdsWithin z₀ {z₀}ᶜ).Tendsto (fun z ↦ (z - z₀) * f z) (nhds 0) := by
     convert Filter.Tendsto.add (Phi_circ.residue ν ε hν n)
       (Filter.Tendsto.const_mul (n : ℂ) (Phi_star.residue ν ε hν n hn_cases)) using 1
@@ -1068,15 +1061,14 @@ theorem Phi_cancel (ν ε σ : ℝ) (hν : ν > 0) (hσ : |σ| = 1) :
     · ring_nf
       suffices h : (0 : ℂ) = I * (↑π)⁻¹ * (1 / 2) + I * (↑π)⁻¹ * (↑n) ^ 2 * (-1 / 2) by exact congr_arg nhds h
       have hn_sq : (n : ℂ) ^ 2 = 1 := by
-        exact_mod_cast sq_eq_one_iff.mpr ((abs_eq (by norm_num : (0 : ℝ) ≤ 1)).mp hσ)
+        exact_mod_cast sq_eq_one_iff.mpr hσ
       simp only [hn_sq]
       ring
-  have h_mero_mul : MeromorphicAt (fun z ↦ (z - z₀) * f z) z₀ :=
-    (by fun_prop : MeromorphicAt (fun z ↦ z - z₀) z₀).mul h_mero_f
+  have h_mero_mul : MeromorphicAt (fun z ↦ (z - z₀) * f z) z₀ := by fun_prop
   rw [tendsto_zero_iff_meromorphicOrderAt_pos h_mero_mul] at h_tendsto_zero
-  change 0 < meromorphicOrderAt ((· - z₀ : ℂ → ℂ) * f) z₀ at h_tendsto_zero
+  change 0 < meromorphicOrderAt ((· - z₀) * f) z₀ at h_tendsto_zero
   rw [meromorphicOrderAt_mul (by fun_prop) h_mero_f] at h_tendsto_zero
-  rw [show meromorphicOrderAt (· - z₀ : ℂ → ℂ) z₀ = (1 : ℤ) from
+  rw [show meromorphicOrderAt (· - z₀) z₀ = (1 : ℤ) from
     (meromorphicOrderAt_eq_int_iff (by fun_prop)).mpr ⟨1, analyticAt_const, one_ne_zero, by simp⟩] at h_tendsto_zero
   change (0 : WithTop ℤ) ≤ meromorphicOrderAt f z₀
   cases h_ord : meromorphicOrderAt f z₀ <;> simp_all
@@ -1099,37 +1091,43 @@ lemma ContDiff.div_real_complex {f g : ℝ → ℂ} {n} (hf : ContDiff ℝ n f) 
     ContDiff ℝ n (fun x => f x / g x) :=
   hf.mul (hg.inv h0)
 
+@[fun_prop]
+lemma Complex.ofRealCLM.contDiff2 : ContDiff ℝ 2 ofReal := Complex.ofRealCLM.contDiff
+
+lemma h_B_rational (ε : ℝ) : ∀ w : ℂ, w ≠ 0 → B ε w = w * (Complex.cosh (w / 2) / Complex.sinh (w / 2) + ε) / 2 := by
+  simp +contextual [Complex.tanh_eq_sinh_div_cosh, B, coth]
+
+lemma h_comp (ε ν : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 (fun t : ℝ => (-2 * Real.pi * Complex.I * t + ν) * (Complex.cosh ((-2 * Real.pi * Complex.I * t + ν) / 2) / Complex.sinh ((-2 * Real.pi * Complex.I * t + ν) / 2) + ε) / 2) := by
+  apply_rules [ContDiff.div, ContDiff.mul, ContDiff.add, contDiff_const, contDiff_id]
+  · fun_prop
+  · fun_prop
+  · fun_prop
+  · have h_conj : ContDiff ℝ 2 (fun x : ℝ => Complex.sinh ((-2 * Real.pi * Complex.I * x + ν) / 2)) := by
+      have h_conj : ContDiff ℝ 2 (fun x : ℝ => Complex.exp ((-2 * Real.pi * Complex.I * x + ν) / 2)) := by fun_prop
+      simp_all only [ne_eq, Complex.sinh, neg_mul]
+      fun_prop
+    rw [contDiff_iff_contDiffAt] at *
+    intro x; specialize h_conj x; exact (by
+    convert Complex.conjCLE.contDiff.contDiffAt.comp x h_conj using 1)
+  · refine Complex.ofRealCLM.contDiff.comp ?_
+    refine ContDiff.inv ?_ ?_
+    · norm_num [Complex.normSq, Complex.sinh]
+      norm_num [Complex.exp_re, Complex.exp_im]
+      exact ContDiff.div_const (by fun_prop) _
+    · norm_num [Complex.sinh, Complex.exp_re, Complex.exp_im, Complex.normSq]
+      intro x; ring_nf; norm_num [Real.exp_ne_zero, hlam]
+      norm_num [Real.sin_sq, Real.cos_sq, mul_assoc, mul_left_comm, ← Real.exp_add, ← Real.exp_nat_mul]; ring_nf
+      cases lt_or_gt_of_ne hlam <;> nlinarith [Real.cos_le_one (Real.pi * x * 2), Real.exp_pos ν, Real.exp_pos (-ν), Real.exp_neg ν, mul_inv_cancel₀ (ne_of_gt (Real.exp_pos ν)), Real.add_one_le_exp ν, Real.add_one_le_exp (-ν)]
+
 theorem Phi_star.contDiff_real (ν ε : ℝ) (hlam : ν ≠ 0) :
     ContDiff ℝ 2 (fun (t : ℝ) ↦ Phi_star ν ε (t : ℂ)) := by
   have h_diff_B : ContDiff ℝ 2 (fun t : ℝ => B ε (-2 * Real.pi * Complex.I * t + ν)) := by
-    have h_B_rational : ∀ w : ℂ, w ≠ 0 → B ε w = w * (Complex.cosh (w / 2) / Complex.sinh (w / 2) + ε) / 2 := by
-      unfold B; unfold coth
-      simp +contextual [Complex.tanh_eq_sinh_div_cosh]
-    have h_comp : ContDiff ℝ 2 (fun t : ℝ => (-2 * Real.pi * Complex.I * t + ν) * (Complex.cosh ((-2 * Real.pi * Complex.I * t + ν) / 2) / Complex.sinh ((-2 * Real.pi * Complex.I * t + ν) / 2) + ε) / 2) := by
-      apply_rules [ContDiff.div, ContDiff.mul, ContDiff.add, contDiff_const, contDiff_id]
-      · exact Complex.ofRealCLM.contDiff
-      · exact Complex.contDiff_exp.comp (ContDiff.div_const (ContDiff.add (ContDiff.mul contDiff_const Complex.ofRealCLM.contDiff) contDiff_const) _)
-      · exact Complex.contDiff_exp.comp (ContDiff.neg (ContDiff.div_const (ContDiff.add (ContDiff.mul contDiff_const Complex.ofRealCLM.contDiff) contDiff_const) _))
-      · have h_conj : ContDiff ℝ 2 (fun x : ℝ => Complex.sinh ((-2 * Real.pi * Complex.I * x + ν) / 2)) := by
-          have h_conj : ContDiff ℝ 2 (fun x : ℝ => Complex.exp ((-2 * Real.pi * Complex.I * x + ν) / 2)) :=
-            Complex.contDiff_exp.comp (ContDiff.div_const (ContDiff.add (ContDiff.mul contDiff_const Complex.ofRealCLM.contDiff) contDiff_const) _)
-          simp_all only [ne_eq, Complex.sinh, neg_mul]
-          exact ContDiff.div_const (h_conj.sub (Complex.contDiff_exp.comp (by exact ContDiff.neg (by exact ContDiff.div_const (by exact ContDiff.add (ContDiff.neg (by exact ContDiff.mul contDiff_const Complex.ofRealCLM.contDiff)) contDiff_const) _)))) _
-        rw [contDiff_iff_contDiffAt] at *
-        intro x; specialize h_conj x; exact (by
-        convert Complex.conjCLE.contDiff.contDiffAt.comp x h_conj using 1)
-      · refine Complex.ofRealCLM.contDiff.comp ?_
-        refine ContDiff.inv ?_ ?_
-        · norm_num [Complex.normSq, Complex.sinh]
-          norm_num [Complex.exp_re, Complex.exp_im]
-          exact ContDiff.div_const (ContDiff.add (ContDiff.mul (ContDiff.sub (ContDiff.mul contDiff_const (Real.contDiff_cos.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _))) (ContDiff.mul contDiff_const (Real.contDiff_cos.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _)))) (ContDiff.sub (ContDiff.mul contDiff_const (Real.contDiff_cos.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _))) (ContDiff.mul contDiff_const (Real.contDiff_cos.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _))))) (ContDiff.mul (ContDiff.add (ContDiff.mul contDiff_const (Real.contDiff_sin.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _))) (ContDiff.mul contDiff_const (Real.contDiff_sin.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _)))) (ContDiff.add (ContDiff.mul contDiff_const (Real.contDiff_sin.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _))) (ContDiff.mul contDiff_const (Real.contDiff_sin.comp (by exact ContDiff.div_const (ContDiff.neg (contDiff_const.mul contDiff_id)) _)))))) _
-        · norm_num [Complex.sinh, Complex.exp_re, Complex.exp_im, Complex.normSq]
-          intro x; ring_nf; norm_num [Real.exp_ne_zero, hlam]
-          norm_num [Real.sin_sq, Real.cos_sq, mul_assoc, mul_left_comm, ← Real.exp_add, ← Real.exp_nat_mul]; ring_nf
-          cases lt_or_gt_of_ne hlam <;> nlinarith [Real.cos_le_one (Real.pi * x * 2), Real.exp_pos ν, Real.exp_pos (-ν), Real.exp_neg ν, mul_inv_cancel₀ (ne_of_gt (Real.exp_pos ν)), Real.add_one_le_exp ν, Real.add_one_le_exp (-ν)]
+    have h_comp := h_comp ε ν hlam
     convert h_comp using 1
-    ext t; by_cases h : (-(2 * Real.pi * Complex.I * t) + ν : ℂ) = 0 <;> simp_all [Complex.sinh, Complex.cosh]; ring_nf
-    norm_num [Complex.ext_iff] at h; aesop
+    ext t
+    by_cases h : (-(2 * Real.pi * Complex.I * t) + ν : ℂ) = 0 <;> simp_all [Complex.sinh, Complex.cosh, h_B_rational]; ring_nf
+    norm_num [Complex.ext_iff] at h
+    simp_all only [not_true_eq_false]
   convert h_diff_B.sub contDiff_const |> fun h => h.div_const (2 * Real.pi * Complex.I) using 1
 
 theorem Phi_circ.contDiff_real (ν ε : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 (fun t : ℝ => Phi_circ ν ε (t : ℂ)) := by
@@ -1137,10 +1135,11 @@ theorem Phi_circ.contDiff_real (ν ε : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 
     simp only [Complex.tanh_eq_sinh_div_cosh]
     have h_sinh_cosh_diff : ContDiff ℝ 2 (fun t : ℝ => Complex.sinh ((-2 * Real.pi * Complex.I * t + ν) / 2)) ∧ ContDiff ℝ 2 (fun t : ℝ => Complex.cosh ((-2 * Real.pi * Complex.I * t + ν) / 2)) ∧ ∀ t : ℝ, Complex.sinh ((-2 * Real.pi * Complex.I * t + ν) / 2) ≠ 0 := by
       refine ⟨?_, ?_, ?_⟩
-      · have h_sinh_entire : ContDiff ℂ 2 Complex.sinh := by
-          unfold Complex.sinh
-          exact ContDiff.div_const (Complex.contDiff_exp.sub (Complex.contDiff_exp.comp contDiff_neg)) _
-        exact h_sinh_entire.restrict_scalars ℝ |> ContDiff.comp <| ContDiff.div_const (ContDiff.add (ContDiff.mul contDiff_const <| Complex.ofRealCLM.contDiff) contDiff_const) _
+      · have h_sinh_entire : ContDiff ℂ 2 Complex.sinh := by fun_prop
+        apply h_sinh_entire.restrict_scalars ℝ |> ContDiff.comp
+        refine ContDiff.div_const ?_ _
+        refine (ContDiff.add ?_ contDiff_const)
+        exact (ContDiff.mul contDiff_const <| Complex.ofRealCLM.contDiff)
       · have h_cosh_entire : ContDiff ℝ 2 (fun t : ℂ => Complex.cosh t) := by
           have : ContDiff ℂ 2 Complex.cosh := by
             unfold Complex.cosh
@@ -1200,7 +1199,7 @@ theorem Phi_star.analytic (ν ε : ℝ) (z : ℂ) (hν : ν > 0) (hz_im : 0 ≤ 
     have heq : B ε =ᶠ[nhds w] (fun s ↦ s * (Complex.cosh (s / 2) / Complex.sinh (s / 2) + ε) / 2) := by
       filter_upwards [continuous_id.continuousAt.eventually_ne hw_ne] with s hs
       dsimp at hs
-      simp only [B, coth, hs, ↓reduceIte, Complex.tanh_eq_sinh_div_cosh, one_div_div]
+      simp [B, coth, hs, Complex.tanh_eq_sinh_div_cosh]
     apply (analyticAt_congr heq).mpr
     fun_prop (disch := exact sinh_ne_zero_of_re_ne_zero (by simp; linarith))
   unfold Phi_star; fun_prop (disch := exact [hB_an.comp (by fun_prop), by simp [w]; fun_prop,

--- a/PrimeNumberTheoremAnd/CH2.lean
+++ b/PrimeNumberTheoremAnd/CH2.lean
@@ -1074,7 +1074,7 @@ lemma ContDiff.div_real_complex {f g : ℝ → ℂ} {n} (hf : ContDiff ℝ n f) 
     ContDiff ℝ n (fun x => f x / g x) :=
   hf.mul (hg.inv h0)
 
-@[fun_prop]
+@[fun_prop] -- a bit of a hack to specialize Complex.ofRealCLM.contDiff to n=2
 lemma Complex.ofRealCLM.contDiff2 : ContDiff ℝ 2 ofReal := Complex.ofRealCLM.contDiff
 
 @[fun_prop]
@@ -1099,10 +1099,9 @@ lemma h_comp (ε ν : ℝ) (hlam : ν ≠ 0) : ContDiff ℝ 2 (fun t : ℝ => (-
   apply_rules [ContDiff.div, ContDiff.mul, ContDiff.add, contDiff_const, contDiff_id] <;> try fun_prop
   · exact Complex.conjCLE.contDiff.comp (by fun_prop)
   · refine Complex.ofRealCLM.contDiff.comp ?_
-    refine ContDiff.inv ?_ ?_
-    · fun_prop
-    · intro x; rw [ne_eq, Complex.normSq_eq_zero]
-      exact sinh_ne_zero_of_re_ne_zero (by simp [hlam])
+    refine ContDiff.inv (by fun_prop) ?_
+    intro x; rw [ne_eq, Complex.normSq_eq_zero]
+    exact sinh_ne_zero_of_re_ne_zero (by simp [hlam])
 
 theorem Phi_star.contDiff_real (ν ε : ℝ) (hlam : ν ≠ 0) :
     ContDiff ℝ 2 (fun (t : ℝ) ↦ Phi_star ν ε (t : ℂ)) := by

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -707,7 +707,7 @@ lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouvil
   The Euler totient function $\varphi(n)$ counts the positive integers up to $n$ that are relatively prime to $n$. It is a multiplicative function, and its value at prime powers is given by $\varphi(p^k) = p^k - p^{k-1}$. The Dirichlet series of $\varphi$ can be expressed as an Euler product over primes:
 \[
 L(\varphi, s) = \prod_{p} \left(1 + \varphi(p)p^{-s} + \varphi(p^2)p^{-2s} + \ldots\right) = \prod_{p} \left(1 - p^{-s  +1}\right)^{-1} \left(1 - p^{-s}\right) = \frac{\zeta(s-1)}{\zeta(s)}.
-\ ]
+\]
   -/)]
 lemma LSeries_totient_eq {s : ℂ} (hs : 1 < s.re) :
     LSeries (↗totient) s = riemannZeta (s - 1) / riemannZeta s := by


### PR DESCRIPTION
## Summary
- Extract shared real-analysis infrastructure (`rexp_sub_one_pos_of_pos`, `deriv_num_nonpos`, `hasDerivAt_div_exp`, `div_exp_sub_one_anti`) used by both `B_plus_mono` and `B_minus_mono`
- Extract per-function lemmas: `B_plus_re_eq`, `B_minus_re_eq`, bridge inequalities, half-line monotonicity
- Both theorems collapse to short case-split wrappers over the extracted lemmas

⚠️ Stacked on #1293 — merge that first.

## Test plan
- [x] `lake env lean PrimeNumberTheoremAnd/CH2.lean` compiles with 0 errors (only pre-existing `sorry` warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)