### PR TITLE
Fix constant in Wiener theorem proof

### DIFF
--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -428,7 +428,7 @@ theorem decay_bounds_W21 (f : W21) (hA : ∀ t, ‖f t‖ ≤ A / (1 + t ^ 2))
   -/)
   (proof := /--
    From two integration by parts we obtain the identity
-  $$ (1+u^2) \hat \psi(u) = \int_{\bf R} (\psi(t) - \frac{u}{4\pi^2} \psi''(t)) e(-tu)\ dt.$$
+  $$ (1+u^2) \hat \psi(u) = \int_{\bf R} (\psi(t) - \frac{1}{4\pi^2} \psi''(t)) e(-tu)\ dt.$$
   Now apply the triangle inequality and the identity $\int_{\bf R} \frac{dt}{1+t^2}\ dt = \pi$ to
   obtain the claim with $C = \pi + 1 / 4 \pi$.
   -/)


### PR DESCRIPTION
In the blueprint proof for `decay_bounds` (Lemma 3.1.7), there is a typo in the integration by parts identity: `\frac{u}{4\pi^2}` should be `\frac{1}{4\pi^2}`.

Keeping the `u` would result in a final constant `C` that depends on `u`, which contradicts the statement that `C` is an absolute constant. Furthermore, this typo contradicts the actual Lean 4 statement directly below it, which correctly uses the absolute constant `(π + 1 / (4 * π))`.

This PR fixes the LaTeX blueprint to match the correct math and the implemented Lean code.