### PR TITLE
chore(BKLNW): prove bklnw_eq_3_17

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1204,9 +1204,8 @@ In this section we tackle small $x$.
   (proof := /-- This follows from Theorem \ref{buthe-theorem-2c}.  -/)
   (latexEnv := "lemma")
   (discussion := 1258)]
-theorem bklnw_eq_3_17 {x : ℝ} (hx1 : 1 ≤ x) (hx2 : x ≤ 10 ^ 19) : θ x < x - 0.05 * sqrt x := by
-  have hineq : x - θ x > 0.05 * sqrt x := Buthe.theorem_2c hx1 hx2
-  linarith
+theorem bklnw_eq_3_17 {x : ℝ} (hx1 : 1 ≤ x) (hx2 : x ≤ 10 ^ 19) : θ x < x - 0.05 * sqrt x :=
+  lt_tsub_comm.1 (Buthe.theorem_2c hx1 hx2)
 
 @[blueprint
   "bklnw-eq-3-18"

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -56,7 +56,7 @@ theorem buthe_eq_1_7 : ∀ x ∈ Set.Ioc 0 1e19, θ x < x := by
     have htheta: theta x = 0 := by apply Chebyshev.theta_eq_zero_of_lt_two hworse
     linarith
   · have hnewlb : x≥ 1 := by simpa using h
-    have hineq : x - θ x ≥ 5e-2 * √x := by exact Buthe.theorem_2c hnewlb hub'
+    have hineq : x - θ x > 5e-2 * √x := by exact Buthe.theorem_2c hnewlb hub'
     have hsqrtpos: 0 < sqrt x := by exact Real.sqrt_pos.mpr hlb
     linarith
 
@@ -1200,12 +1200,13 @@ In this section we tackle small $x$.
 @[blueprint
   "bklnw-eq-3-17"
   (title := "BKLNW Equation 3.17")
-  (statement := /-- One has $\theta(x) < x - 0.05 \sqrt{x}  \text{ for all } x \le 10^{19}.$ -/)
+  (statement := /-- One has $\theta(x) < x - 0.05 \sqrt{x}  \text{ for all } 1 \le x \le 10^{19}.$ -/)
   (proof := /-- This follows from Theorem \ref{buthe-theorem-2c}.  -/)
   (latexEnv := "lemma")
   (discussion := 1258)]
-theorem bklnw_eq_3_17 : ∀ x ≤ 10 ^ 19, θ x < x - 0.05 * sqrt x := by
-  sorry
+theorem bklnw_eq_3_17 {x : ℝ} (hx1 : 1 ≤ x) (hx2 : x ≤ 10 ^ 19) : θ x < x - 0.05 * sqrt x := by
+  have hineq : x - θ x > 0.05 * sqrt x := Buthe.theorem_2c hx1 hx2
+  linarith
 
 @[blueprint
   "bklnw-eq-3-18"

--- a/PrimeNumberTheoremAnd/Buthe.lean
+++ b/PrimeNumberTheoremAnd/Buthe.lean
@@ -49,7 +49,7 @@ theorem theorem_2b {x : ℝ} (hx1 : 1423 ≤ x) (hx2 : x ≤ 10 ^ 19) :
     $x - \vartheta(x) > 0.05\sqrt{x}$. -/)
   (latexEnv := "theorem")]
 theorem theorem_2c {x : ℝ} (hx1 : 1 ≤ x) (hx2 : x ≤ 10 ^ 19) :
-    x - θ x ≥ 0.05 * sqrt x := by sorry
+    x - θ x > 0.05 * sqrt x := by sorry
 
 @[blueprint
   "buthe-theorem-2d"


### PR DESCRIPTION
This PR attemps to:
- fix a misformalization in Buthe.lean: `theorem_2c` should be strict inequality accroding to original paper by Buthe.
- finish proof of `bklnw_eq_3_17`, which is basically trivial but there should be a lower bound for `x`: Buthe stated the inequality with `x` between 1 and 10^19, and the inequality is false for x < 1/400.

This commit is written with the help of model `Doubao-Seed-2.0-code`.

Close #1258 