### PR TITLE
Fix BKLNW.thm_1b_table (BKLNW table 15)

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1752,9 +1752,11 @@ theorem thm_1b (k : ℕ) (hk : k ≤ 5) {X₀ X₁ x : ℝ} (hX₀ : X₀ > 1) (
   "bklnw-thm-1b-table"
   (title := "BKLNW Theorem 1b, table form")
   (statement := /--  See \cite[Table 15]{BKLNW} for values of $m_k$ and $M_k$, for $k \in \{1,2,3,4,5\}$.
+  The first column of the table is the logarithmic threshold \(b = \log X_0\), so a row with first
+  component \(b\) applies for \(x \geq \exp b\).
   -/)
   (latexEnv := "theorem")]
-theorem thm_1b_table {X₀ : ℝ} (hX₀ : X₀ > 1) {M : Fin 5 → ℝ} (h : (X₀, M) ∈ Table_15) (k : Fin 5) {x : ℝ} (hx : x ≥ X₀) :
+theorem thm_1b_table {b : ℝ} (hb : b > 0) {M : Fin 5 → ℝ} (h : (b, M) ∈ Table_15) (k : Fin 5) {x : ℝ} (hx : x ≥ exp b) :
   x * (1 - M k / (log x)^(k.val + 1)) ≤ θ x ∧ θ x ≤ x * (1 + M k / (log x)^(k.val + 1)) :=
   by sorry
 

--- a/PrimeNumberTheoremAnd/Dusart.lean
+++ b/PrimeNumberTheoremAnd/Dusart.lean
@@ -433,15 +433,17 @@ theorem proposition_5_4a : HasPrimeInInterval.log_thm 4e18 3 := by
   have hlog_pos : 0 < log x := Real.log_pos (by linarith)
   have hpow_pos : 0 < (log x) ^ 3 := by positivity
   -- Use BKLNW Table_15 row (29, M₂₉) which gives θ bounds with M 2 = 2.4334e-2.
-  -- This row applies for x ≥ 29, trivially satisfied for x ≥ 4e18.
+  -- This row applies for x ≥ exp 29, satisfied for x ≥ 4e18.
   set M₂₉ : Fin 5 → ℝ := ![2.7336e-5, 7.9272e-4, 2.4334e-2, 5.7184e1, 1.3441e5]
   have htab : ((29 : ℝ), M₂₉) ∈ BKLNW.Table_15 := by
     simp [BKLNW.Table_15, M₂₉]
   have hM : M₂₉ ⟨2, by norm_num⟩ = 2.4334e-2 := rfl
   have hfin_val : (⟨2, by norm_num⟩ : Fin 5).val + 1 = 3 := rfl
-  have hx_ge_29 : x ≥ (29 : ℝ) := by linarith
+  have hx_ge_exp29 : x ≥ exp (29 : ℝ) := by
+    have : exp (29 : ℝ) ≤ (4e18 : ℝ) := by interval_decide
+    linarith
   obtain ⟨hlb_x, hub_x⟩ :=
-    BKLNW.thm_1b_table (by norm_num : (29 : ℝ) > 1) htab ⟨2, by norm_num⟩ hx_ge_29
+    BKLNW.thm_1b_table (by norm_num : (29 : ℝ) > 0) htab ⟨2, by norm_num⟩ hx_ge_exp29
   rw [hM, hfin_val] at hlb_x hub_x
   -- Derive Eθ x ≤ 2.4334e-2 / (log x)^3 from the θ bounds
   have hEθ_x : Eθ x ≤ 2.4334e-2 / (log x) ^ 3 := by
@@ -457,8 +459,8 @@ theorem proposition_5_4a : HasPrimeInInterval.log_thm 4e18 3 := by
   set h := x / (log x) ^ 3 with hh_def
   have hh_pos : 0 < h := by positivity
   obtain ⟨hlb_xh, hub_xh⟩ :=
-    BKLNW.thm_1b_table (by norm_num : (29 : ℝ) > 1) htab ⟨2, by norm_num⟩
-      (show x + h ≥ (29 : ℝ) by linarith)
+    BKLNW.thm_1b_table (by norm_num : (29 : ℝ) > 0) htab ⟨2, by norm_num⟩
+      (show x + h ≥ exp (29 : ℝ) by linarith)
   rw [hM, hfin_val] at hlb_xh hub_xh
   have hEθ_xh : Eθ (x + h) ≤ 2.4334e-2 / (log x) ^ 3 := by
     have hxh_pos : 0 < x + h := by linarith

--- a/PrimeNumberTheoremAnd/Ramanujan.lean
+++ b/PrimeNumberTheoremAnd/Ramanujan.lean
@@ -752,16 +752,20 @@ theorem pi_bound_3 (x : ℝ) (hx : x ∈ Set.Ico (exp 58) (exp 1169)) :
   have htab43 : ((43 : ℝ), M₄₃) ∈ BKLNW.Table_15 := by simp [BKLNW.Table_15, M₄₃]
   have hM43 : M₄₃ ⟨1, by norm_num⟩ = 3.7979e-5 := rfl
   have hfin43 : (⟨1, by norm_num⟩ : Fin 5).val + 1 = 2 := rfl
-  have hx_ge43 : x ≥ (43 : ℝ) := by
-    have : (43 : ℝ) ≤ exp 58 := by interval_decide
+  have hx_ge_exp43 : x ≥ exp (43 : ℝ) := by
+    have : exp (43 : ℝ) ≤ exp 58 := by
+      exact exp_le_exp.mpr (by norm_num)
     linarith [hx.1]
   obtain ⟨hlb43, hub43⟩ :=
-    BKLNW.thm_1b_table (by norm_num : (43 : ℝ) > 1) htab43 ⟨1, by norm_num⟩ hx_ge43
+    BKLNW.thm_1b_table (by norm_num : (43 : ℝ) > 0) htab43 ⟨1, by norm_num⟩ hx_ge_exp43
   rw [hM43, hfin43] at hlb43 hub43
   have hE : Eθ x ≤ (3.7979e-5 : ℝ) / (log x) ^ 2 := by
     unfold Eθ
     have hxpos : 0 < x := lt_of_lt_of_le (exp_pos _) hx.1
-    have hpow_pos : 0 < (log x) ^ 2 := pow_pos (log_pos (by linarith [add_one_le_exp (58:ℝ)])) 2
+    have hx_gt_one : 1 < x := by
+      have : (1 : ℝ) < exp 58 := by nlinarith [add_one_le_exp (58 : ℝ)]
+      linarith [hx.1]
+    have hpow_pos : 0 < (log x) ^ 2 := pow_pos (log_pos hx_gt_one) 2
     rw [div_le_div_iff₀ hxpos hpow_pos]
     have h1 : θ x - x ≤ 3.7979e-5 / (log x) ^ 2 * x := by nlinarith
     have h2 : x - θ x ≤ 3.7979e-5 / (log x) ^ 2 * x := by nlinarith

--- a/PrimeNumberTheoremAnd/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/TMEEMT.lean
@@ -159,25 +159,27 @@ private lemma log_ge_22 {x : ℝ} (hx : x ≥ exp 22) : log x ≥ 22 := by
     _ ≤ log x := log_le_log (exp_pos _) hx
 
 private lemma theta_err {x : ℝ} (hx : x ≥ exp 22) :
-    |θ x - x| ≤ 3.7979e-5 * x / (log x) ^ 2 := by
-  -- BKLNW Table_15 row (43, M₄₃), k=⟨1,_⟩ → Eθ x ≤ 3.7979e-5 / (log x)²
-  set M₄₃ : Fin 5 → ℝ := ![8.6315e-7, 3.7979e-5, 2.4334e-2, 5.7184e1, 1.3441e5]
-  have htab : ((43 : ℝ), M₄₃) ∈ BKLNW.Table_15 := by simp [BKLNW.Table_15, M₄₃]
-  have hM : M₄₃ ⟨1, by norm_num⟩ = 3.7979e-5 := rfl
-  have hfin_val : (⟨1, by norm_num⟩ : Fin 5).val + 1 = 2 := rfl
+    |θ x - x| ≤ 4.2065e-1 * x / (log x) ^ 3 := by
+  -- BKLNW Table_15 row (log 1e9, M₁e9), k=⟨2,_⟩ → Eθ x ≤ 4.2065e-1 / (log x)^3
+  set M₁e9 : Fin 5 → ℝ := ![9.5913e-4, 2.0087e-2, 4.2065e-1, 5.7184e1, 1.3441e5]
+  have htab : ((log 1e9 : ℝ), M₁e9) ∈ BKLNW.Table_15 := by simp [BKLNW.Table_15, M₁e9]
+  have hM : M₁e9 ⟨2, by norm_num⟩ = 4.2065e-1 := rfl
+  have hfin_val : (⟨2, by norm_num⟩ : Fin 5).val + 1 = 3 := rfl
   have hxpos : 0 < x := lt_of_lt_of_le (exp_pos _) hx
-  have hlog_pos : 0 < log x := log_pos (by linarith [add_one_le_exp (22:ℝ)])
-  have hpow_pos : 0 < (log x) ^ 2 := pow_pos hlog_pos 2
-  have hx_ge43 : x ≥ (43 : ℝ) := by
-    have : (43 : ℝ) ≤ exp 22 := by interval_decide
+  have hlog_pos : 0 < log x := by linarith [log_ge_22 hx]
+  have hpow_pos : 0 < (log x) ^ 3 := pow_pos hlog_pos 3
+  have hx_ge_exp_log_1e9 : x ≥ exp (log 1e9) := by
+    have h_exp_le : exp (log 1e9 : ℝ) ≤ exp (22 : ℝ) := by
+      rw [exp_log (by norm_num : (0 : ℝ) < 1e9)]
+      interval_decide
     linarith
   obtain ⟨hlb, hub⟩ :=
-    BKLNW.thm_1b_table (by norm_num : (43:ℝ) > 1) htab ⟨1, by norm_num⟩ hx_ge43
+    BKLNW.thm_1b_table (by positivity) htab ⟨2, by norm_num⟩ hx_ge_exp_log_1e9
   rw [hM, hfin_val] at hlb hub
-  have h1 : θ x - x ≤ 3.7979e-5 / (log x) ^ 2 * x := by nlinarith
-  have h2 : x - θ x ≤ 3.7979e-5 / (log x) ^ 2 * x := by nlinarith
-  calc |θ x - x| ≤ 3.7979e-5 / (log x) ^ 2 * x := abs_le.mpr ⟨by linarith, h1⟩
-    _ = 3.7979e-5 * x / (log x) ^ 2 := by ring
+  have h1 : θ x - x ≤ 4.2065e-1 / (log x) ^ 3 * x := by nlinarith
+  have h2 : x - θ x ≤ 4.2065e-1 / (log x) ^ 3 * x := by nlinarith
+  calc |θ x - x| ≤ 4.2065e-1 / (log x) ^ 3 * x := abs_le.mpr ⟨by linarith, h1⟩
+    _ = 4.2065e-1 * x / (log x) ^ 3 := by ring
 
 private lemma psi_theta_err {x : ℝ} (hx : x > 0) :
     ψ x - θ x ≤ 1.001 * sqrt x + 1.78 * x ^ (1 / 3 : ℝ) := by
@@ -190,11 +192,19 @@ private lemma psi_triangle (x : ℝ) :
   · rw [abs_of_nonneg (sub_nonneg_of_le <| Chebyshev.theta_le_psi x)]
 
 private lemma theta_err_simpl {x : ℝ} (hx : x ≥ exp 22) :
-    3.7979e-5 * x / (log x) ^ 2 ≤ 3.7979e-5 / 22 * x / log x := by
+    4.2065e-1 * x / (log x) ^ 3 ≤ 0.0009 * x / log x := by
   have hlog_pos : (0 : ℝ) < log x := by linarith [log_ge_22 hx]
-  rw [div_le_div_iff₀ (pow_pos hlog_pos 2) hlog_pos]
-  nlinarith [mul_le_mul_of_nonneg_right (log_ge_22 hx) hlog_pos.le, sq (log x),
-    mul_pos (by linarith [exp_pos (22 : ℝ)] : (0:ℝ) < x) hlog_pos]
+  have hxlog : 0 ≤ x / log x :=
+    div_nonneg (le_of_lt (lt_of_lt_of_le (exp_pos _) hx)) hlog_pos.le
+  have hlog_sq : (22 : ℝ) ^ 2 ≤ (log x) ^ 2 :=
+    pow_le_pow_left₀ (by norm_num) (log_ge_22 hx) 2
+  have hcoeff : (4.2065e-1 : ℝ) / (log x) ^ 2 ≤ 0.0009 := by
+    rw [div_le_iff₀ (pow_pos hlog_pos 2)]
+    nlinarith
+  calc 4.2065e-1 * x / (log x) ^ 3
+      = (4.2065e-1 / (log x) ^ 2) * (x / log x) := by ring
+    _ ≤ 0.0009 * (x / log x) := mul_le_mul_of_nonneg_right hcoeff hxlog
+    _ = 0.0009 * x / log x := by ring
 
 private lemma sqrt_err {x : ℝ} (hx : x ≥ exp 22) :
     1.001 * sqrt x ≤ 0.005 * x / log x := by
@@ -214,25 +224,25 @@ private lemma sqrt_err {x : ℝ} (hx : x ≥ exp 22) :
   nlinarith [pow_le_pow_left₀ (by linarith) (log_ge_22 hx) 7, sqrt_nonneg x, sq_sqrt hx_pos.le]
 
 private lemma cbrt_err {x : ℝ} (hx : x ≥ exp 22) :
-    1.78 * x ^ (1 / 3 : ℝ) ≤ 0.001 * x / log x := by
+    1.78 * x ^ (1 / 3 : ℝ) ≤ 0.0005 * x / log x := by
   have hx_pos : (0 : ℝ) < x := lt_of_lt_of_le (by positivity) hx
   have hlog := log_nonneg <| by linarith [add_one_le_exp 22]
   have h_rpow : x ^ (2 / 3 : ℝ) = exp (2 * log x / 3) := by rw [rpow_def_of_pos hx_pos]; ring_nf
-  have h_taylor : exp (2 * log x / 3) ≥ (2 * log x / 3) ^ 8 / 40320 := by
+  have h_taylor : exp (2 * log x / 3) ≥ (2 * log x / 3) ^ 9 / 362880 := by
     rw [exp_eq_exp_ℝ, NormedSpace.exp_eq_tsum_div] at *
-    refine le_trans ?_ (Summable.sum_le_tsum (Finset.range 9)
+    refine le_trans ?_ (Summable.sum_le_tsum (Finset.range 10)
       (fun _ _ => div_nonneg (pow_nonneg (div_nonneg (mul_nonneg zero_le_two hlog) zero_le_three) _)
       (Nat.cast_nonneg _)) (show Summable _ from summable_pow_div_factorial _))
     norm_num [Finset.sum_range_succ, Nat.factorial]; ring_nf; norm_num
     nlinarith [sq_nonneg (log x ^ 2), sq_nonneg (log x ^ 3), sq_nonneg (log x ^ 4),
-      sq_nonneg (log x ^ 5), sq_nonneg (log x ^ 6), hlog]
-  have h_bound : x ^ (2 / 3 : ℝ) ≥ 1780 * log x := by
+      sq_nonneg (log x ^ 5), sq_nonneg (log x ^ 6), sq_nonneg (log x ^ 7), hlog]
+  have h_bound : x ^ (2 / 3 : ℝ) ≥ 3560 * log x := by
     rw [h_rpow]
     nlinarith [log_exp 22, log_le_log (by positivity) hx,
       pow_nonneg hlog 2, pow_nonneg hlog 3, pow_nonneg hlog 4,
-      pow_nonneg hlog 5, pow_nonneg hlog 6, pow_nonneg hlog 7]
+      pow_nonneg hlog 5, pow_nonneg hlog 6, pow_nonneg hlog 7, pow_nonneg hlog 8]
   have h_13 : x ^ (1 / 3 : ℝ) * x ^ (2 / 3 : ℝ) = x := by norm_num [← rpow_add hx_pos]
-  have h_recombine : x ≥ 1780 * x ^ (1 / 3 : ℝ) * log x := by nlinarith [rpow_pos_of_pos hx_pos (1 / 3 : ℝ)]
+  have h_recombine : x ≥ 3560 * x ^ (1 / 3 : ℝ) * log x := by nlinarith [rpow_pos_of_pos hx_pos (1 / 3 : ℝ)]
   rw [le_div_iff₀ (log_pos <| lt_of_lt_of_le (by norm_num) hx)]
   linarith
 
@@ -245,15 +255,15 @@ theorem theorem_a (x : ℝ) (hx : x ≥ exp 22) :
     |ψ x - x| ≤ 0.006409 * x / log x := by
   calc |ψ x - x|
       ≤ |θ x - x| + (ψ x - θ x) := psi_triangle x
-    _ ≤ 3.7979e-5 * x / (log x) ^ 2 + (1.001 * sqrt x + 1.78 * x ^ (1 / 3 : ℝ)) := by
+    _ ≤ 4.2065e-1 * x / (log x) ^ 3 + (1.001 * sqrt x + 1.78 * x ^ (1 / 3 : ℝ)) := by
         linarith [theta_err hx, psi_theta_err <| lt_of_lt_of_le (exp_pos _) hx]
-    _ ≤ 3.7979e-5 / 22 * x / log x + (0.005 * x / log x + 0.001 * x / log x) := by
+    _ ≤ 0.0009 * x / log x + (0.005 * x / log x + 0.0005 * x / log x) := by
         linarith [theta_err_simpl hx, sqrt_err hx, cbrt_err hx]
     _ ≤ 0.006409 * x / log x := by
         have hxlog : 0 ≤ x / log x :=
           div_nonneg (le_of_lt (lt_of_lt_of_le (exp_pos _) hx)) (le_of_lt (by linarith [log_ge_22 hx]))
-        have : 3.7979e-5 / 22 * x / log x + (0.005 * x / log x + 0.001 * x / log x) =
-               (3.7979e-5 / 22 + 0.005 + 0.001) * (x / log x) := by ring
+        have : 0.0009 * x / log x + (0.005 * x / log x + 0.0005 * x / log x) =
+               (0.0009 + 0.005 + 0.0005) * (x / log x) := by ring
         rw [this, show 0.006409 * x / log x = 0.006409 * (x / log x) from by ring]
         apply mul_le_mul_of_nonneg_right _ hxlog
         norm_num


### PR DESCRIPTION
- update BKLNW.thm_1b_table to require x ≥ exp b, to match the original paper 
- repair all affected downstream theorems in Ramanujan.lean, Dusart.lean, and TMEEMT.lean
 - downstream theorem statements unchanged