### PR TITLE
IK Ch1: close 5 algebraic sorries (Liouville + divisor decomposition)

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -296,7 +296,11 @@ theorem d_isMultiplicative (k : ℕ) : (d k).IsMultiplicative := by
 /- MOVE HELPER LEMMA ESLEWHERE?? Not used in this file, but seems potentially useful? -/
 theorem Nat.sum_divisorsAntidiagonal_prime_pow {α : Type u_1} [AddCommMonoid α] [HMul α α α] {k p : ℕ} {f : ℕ × ℕ → α} (h : Nat.Prime p) :
 ∑ x ∈ (p ^ k).divisorsAntidiagonal, f x = ∑ n ∈ Finset.range (k + 1), f (p ^ n, p ^ (k - n)) := by
-  sorry
+  rw [Nat.sum_divisorsAntidiagonal (fun a b => f (a, b)), sum_divisors_prime_pow h]
+  refine Finset.sum_congr rfl ?_
+  intro i hi
+  have hik : i ≤ k := by rw [Finset.mem_range] at hi; omega
+  rw [Nat.pow_div hik h.pos]
 
 /-- Explicit formula: `d k (p^a) = (a + k - 1).choose (k - 1) for prime p` for `k ≥ 1`. -/
 @[blueprint

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -982,7 +982,20 @@ The Liouville function is completely multiplicative. -/
   The Liouville function $\lambda(n)$ is defined as $(-1)^{\Omega(n)}$, where $\Omega(n)$ counts the total number of prime factors of $n$ with multiplicity. To show that $\lambda$ is completely multiplicative, we need to verify that $\lambda(1) = 1$ and that $\lambda(ab) = \lambda(a)\lambda(b)$ for all natural numbers $a$ and $b$.
   -/)]
 lemma isCompletelyMultiplicative_liouville : IsCompletelyMultiplicative (liouville : ArithmeticFunction ℤ) := by
-  sorry
+  refine ⟨?_, fun a b => ?_⟩
+  · show ((liouville 1 : ℤ) : ℝ) = 1
+    simp [liouville, toArithmeticFunction]
+  · show ((liouville (a * b) : ℤ) : ℝ)
+          = ((liouville a : ℤ) : ℝ) * ((liouville b : ℤ) : ℝ)
+    rcases eq_or_ne a 0 with ha | ha
+    · simp [ha, liouville, toArithmeticFunction]
+    rcases eq_or_ne b 0 with hb | hb
+    · simp [hb, liouville, toArithmeticFunction]
+    have hab : a * b ≠ 0 := mul_ne_zero ha hb
+    simp only [liouville, toArithmeticFunction, ArithmeticFunction.coe_mk,
+               ha, hb, hab, if_false]
+    rw [cardFactors_mul ha hb, pow_add]
+    push_cast; ring
 
 /--
 The Dirichlet series of the Liouville function is `ζ(2s)/ζ(s)`. -/

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -91,7 +91,8 @@ theorem sum_divisors_mul_of_coprime {R : Type*} [CommRing R]
     {f : ArithmeticFunction R} (hf : f.IsMultiplicative)
     {a b : ℕ} (hab : Coprime a b) (ha : a ≠ 0) (hb : b ≠ 0) :
     ∑ d ∈ (a * b).divisors, f d = (∑ d ∈ a.divisors, f d) * (∑ d ∈ b.divisors, f d) := by
-  sorry -- UPSTREAMED TO MATHLIB #36495
+  simp only [← coe_mul_zeta_apply]
+  exact (hf.mul isMultiplicative_zeta.natCast).map_mul_of_coprime hab
 
 /-- If `g` is a multiplicative arithmetic function, then for any $n \neq 0$,
     $\sum_{d | n} \mu(d) \cdot g(d) = \prod_{p | n} (1 - g(p))$. -/
@@ -817,8 +818,26 @@ lemma pow_divisors_mul {m n k : ℕ} (hmn : Nat.Coprime m n) :
   -/)]
 lemma divisors_mul_injective {m n : ℕ} (hmn : m.Coprime n) :
     Set.InjOn (fun p : ℕ × ℕ => p.1 * p.2) (m.divisors ×ˢ n.divisors) := by
-  /-- comes from mathlib PR #36495 -/
-  sorry
+  intro ⟨a₁, b₁⟩ hab₁ ⟨a₂, b₂⟩ hab₂ heq
+  simp only [Set.mem_prod, Finset.mem_coe, Nat.mem_divisors] at hab₁ hab₂
+  obtain ⟨⟨ha₁, hm⟩, ⟨hb₁, _⟩⟩ := hab₁
+  obtain ⟨⟨ha₂, _⟩, ⟨hb₂, _⟩⟩ := hab₂
+  simp only at heq  -- normalize the fun application: a₁ * b₁ = a₂ * b₂
+  have ha₁_cop_b₂ : a₁.Coprime b₂ := (hmn.coprime_dvd_left ha₁).coprime_dvd_right hb₂
+  have ha₂_cop_b₁ : a₂.Coprime b₁ := (hmn.coprime_dvd_left ha₂).coprime_dvd_right hb₁
+  have h_a₁_dvd : a₁ ∣ a₂ * b₂ := heq ▸ dvd_mul_right a₁ b₁
+  have h_a₂_dvd : a₂ ∣ a₁ * b₁ := heq.symm ▸ dvd_mul_right a₂ b₂
+  have h₁ : a₁ ∣ a₂ := ha₁_cop_b₂.dvd_of_dvd_mul_right h_a₁_dvd
+  have h₂ : a₂ ∣ a₁ := ha₂_cop_b₁.dvd_of_dvd_mul_right h_a₂_dvd
+  have heq_a : a₁ = a₂ := Nat.dvd_antisymm h₁ h₂
+  have ha_pos : 0 < a₁ := by
+    rcases Nat.eq_zero_or_pos a₁ with h0 | hp
+    · exact absurd (h0 ▸ ha₁) (by simpa using hm)
+    · exact hp
+  have heq_b : b₁ = b₂ := by
+    have : a₁ * b₁ = a₁ * b₂ := by rw [heq, heq_a]
+    exact Nat.eq_of_mul_eq_mul_left ha_pos this
+  simp [heq_a, heq_b]
 
 @[blueprint
   "pow_divisors_mul_injective"

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1022,7 +1022,9 @@ lemma LSeries_liouville_eq {s : ℂ} (hs : 1 < s.re) :
   The Liouville function $\lambda(n)$ is defined as $(-1)^{\Omega(n)}$, where $\Omega(n)$ counts the total number of prime factors of $n$ with multiplicity. The Möbius function $\mu(n)$ is defined as $0$ if $n$ has a squared prime factor, and otherwise it is $(-1)^{\omega(n)}$, where $\omega(n)$ counts the number of distinct prime factors of $n$. For square-free numbers, we have $\Omega(n) = \omega(n)$, since there are no repeated prime factors. Therefore, for square-free numbers, we have $\lambda(n) = (-1)^{\omega(n)} = \mu(n)$, which shows that the Liouville function agrees with the Möbius function on square-free numbers.
   -/)]
 lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouville n = μ n := by
-  sorry
+  have hn0 : n ≠ 0 := hn.ne_zero
+  rw [moebius_apply_of_squarefree hn]
+  simp [liouville, toArithmeticFunction, hn0]
 
 /-- Euler totient series: `∑ φ(n) n^-s = ζ(s-1)/ζ(s)`. -/
 @[blueprint


### PR DESCRIPTION
## Summary

Closes 5 algebraic / definitional sorries in `PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean`. All proofs kernel-check against the current Lean toolchain (4.28.0) + mathlib snapshot pinned in `lake-manifest.json`. No new dependencies; no other files touched.

| Commit | Lemma closed | Approach |
|---|---|---|
| `9dbd8e1` | `isCompletelyMultiplicative_liouville` | Definitional: `λ(n) = (-1)^Ω(n)` + `cardFactors_mul` + `pow_add`. Cases on `a = 0` / `b = 0` for the `toArithmeticFunction` zero-padding. |
| `f444f75` | `liouville_eq_moebius_on_squarefree` | Both equal `(-1)^Ω(n)` on squarefree `n`; via `moebius_apply_of_squarefree` + `Squarefree.ne_zero`. |
| `92533d0` | `Nat.sum_divisorsAntidiagonal_prime_pow` | Composes `Nat.sum_divisorsAntidiagonal` + `sum_divisors_prime_pow` + `Nat.pow_div` to rewrite `∑_{x ∈ (p^k).divisorsAntidiagonal} f x` as `∑_{n ∈ range (k+1)} f (p^n, p^(k-n))`. |
| `55c00f3` | `sum_divisors_mul_of_coprime` | Rewrite both sides as `(f * ζ)(·)` via `coe_mul_zeta_apply`; multiplicativity of `f * ζ` (product of multiplicatives) closes the goal via `IsMultiplicative.map_mul_of_coprime`. |
| `55c00f3` | `divisors_mul_injective` | From `a₁·b₁ = a₂·b₂` with `aᵢ ∣ m`, `bᵢ ∣ n`, `m.Coprime n`: mutual divisibility via `Nat.Coprime.dvd_of_dvd_mul_right` gives `a₁ = a₂`; then `b₁ = b₂` by cancellation. |

IK Ch1 sorry count: **13 → 8**.

## Verification

- `lake env lean PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean` produces 8 `declaration uses sorry` warnings (down from 13) and **zero errors**.
- The 5 closed lemmas no longer appear in the warning list.

## Disclosure

These proofs were drafted with help from an AI coding assistant (Claude). Each was verified by the Lean kernel against PNT+'s own toolchain before commit. No proofs use `sorry`, `admit`, or `--no-verify`. The two `liouville` lemmas (`isCompletelyMultiplicative_liouville`, `liouville_eq_moebius_on_squarefree`) needed cases on the `toArithmeticFunction` zero-padding which I worked through manually after the first attempts didn't account for it.

I'm happy to split into separate PRs per commit if that's preferred for review.

## Test plan

- [x] `lake env lean PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean` — compiles, 8 sorry warnings, 0 errors
- [x] No proof uses sorry / admit
- [x] No imports added
- [x] No other files modified