### PR TITLE
feat(BKLNW): prove `bklnw_corollary_9_1_explicit`

### DIFF
--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1772,7 +1772,7 @@ theorem bklnw_corollary_9_1 (k : ℕ) (v c C b : ℝ) (hvcc : (100, v, c, C) ∈
 theorem bklnw_table_12_verification (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k := by
   sorry
 
-private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
+private lemma mem_table_from_buthe_and_bounds_of_mem_table_12 (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
     ((100 : ℝ), M, c, C) ∈ table_from_buthe ∧
     exp b ≤ M ∧ (10000 : ℝ) ≤ exp b ∧ (10 : ℝ) ≤ b ∧ 0 < b ∧
@@ -1824,7 +1824,7 @@ private lemma exp_two_k_le_exp_ten (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
   have : (k : ℝ) ≤ 5 := by exact_mod_cast (Finset.mem_Icc.mp hk).2
   linarith
 
-private lemma Cb_ref_le_dispatch (Cb Cb_ref : ℕ → ℝ)
+private lemma le_of_le_of_mem_Icc_one_five (Cb Cb_ref : ℕ → ℝ)
     (h1 : Cb_ref 1 ≤ Cb 1) (h2 : Cb_ref 2 ≤ Cb 2) (h3 : Cb_ref 3 ≤ Cb 3)
     (h4 : Cb_ref 4 ≤ Cb 4) (h5 : Cb_ref 5 ≤ Cb 5)
     (k : ℕ) (hk : k ∈ Finset.Icc 1 5) : Cb_ref k ≤ Cb k := by
@@ -1874,15 +1874,15 @@ private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     norm_num at hM
   )
   all_goals try (
-    refine Cb_ref_le_dispatch Cb bklnw_Cb_row6 ?_ ?_ ?_ ?_ ?_ k hk <;>
+    refine le_of_le_of_mem_Icc_one_five Cb bklnw_Cb_row6 ?_ ?_ ?_ ?_ ?_ k hk <;>
       simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row6] <;> norm_num
   )
   all_goals try (
-    refine Cb_ref_le_dispatch Cb bklnw_Cb_row14 ?_ ?_ ?_ ?_ ?_ k hk <;>
+    refine le_of_le_of_mem_Icc_one_five Cb bklnw_Cb_row14 ?_ ?_ ?_ ?_ ?_ k hk <;>
       simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row14] <;> norm_num
   )
 
-lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
+lemma C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
   C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by
   have h_row6_mem : (log (5 * 10 ^ 10), bklnw_Cb_row6 1, bklnw_Cb_row6 2, bklnw_Cb_row6 3, bklnw_Cb_row6 4, bklnw_Cb_row6 5, 0.88, 0.86, 32 * 10 ^ 12) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
@@ -1893,7 +1893,7 @@ lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2,
   have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) bklnw_Cb_row6 h_row6_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).1 hM5)
 
-private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
+private lemma C_bk_le_Cb_of_M_ne_ten_pow_nineteen (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
     (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM : M ≠ 10 ^ 19) :
     C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k := by
@@ -1915,7 +1915,7 @@ private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
 theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
   ∀ x ∈ Set.Ico (exp b) (10 ^ 19), ∀ k ∈ Finset.Icc 1 5, θ x - x ≥ - Cb k * x / (log x)^k := by
   obtain ⟨h_buthe, h_expb_le_M, h_10000_le_expb, h_ten_le_b, h_b_pos, h_M_vals⟩ :=
-    table_12_basic_props b c C M Cb h
+    mem_table_from_buthe_and_bounds_of_mem_table_12 b c C M Cb h
   have h_expb_lb : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
       max (10000 : ℝ) (exp (2 * (k : ℝ))) ≤ exp b := fun k hk =>
     max_le_iff.mpr ⟨h_10000_le_expb,
@@ -1954,7 +1954,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
             pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
             (by linarith [h_cor_9_1_row6 x hx_in_Icc6])
-            (bklnw_case1_helper b c C M Cb h k hk hM5)
+            (C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten b c C M Cb h k hk hM5)
         · have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
             rw [Real.exp_log (by norm_num)]
             exact ⟨(not_le.mp hx32).le, hx.2.le⟩
@@ -1969,7 +1969,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
             pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
             (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
-            (bklnw_row14_le b c C M Cb h k hk (by rw [hM5]; norm_num))
+            (C_bk_le_Cb_of_M_ne_ten_pow_nineteen b c C M Cb h k hk (by rw [hM5]; norm_num))
       · have h_M_eq : M = 32 * 10 ^ 12 := by
           rcases h_M_vals with rfl | rfl | rfl
           · exact absurd rfl hM5
@@ -1990,7 +1990,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
           pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
         exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
           (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
-          (bklnw_row14_le b c C M Cb h k hk hM)
+          (C_bk_le_Cb_of_M_ne_ten_pow_nineteen b c C M Cb h k hk hM)
 
 
 blueprint_comment /--

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1869,11 +1869,19 @@ private lemma table_12_M_eq_32e12 (b c C M : ℝ) (Cb : ℕ → ℝ)
     try contradiction
     try (revert hM5; norm_num)
     try (revert hM; norm_num)
-    try rfl
 
 private lemma table_12_b_pos (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : 0 < b :=
   (table_12_basic_props b c C M Cb h).2.2.2.2
+
+-- For k ∈ {1,...,5}, pointwise bounds at each index suffice to pick the bound at k
+private lemma Cb_ref_le_dispatch (Cb Cb_ref : ℕ → ℝ)
+    (h1 : Cb_ref 1 ≤ Cb 1) (h2 : Cb_ref 2 ≤ Cb 2) (h3 : Cb_ref 3 ≤ Cb 3)
+    (h4 : Cb_ref 4 ≤ Cb 4) (h5 : Cb_ref 5 ≤ Cb 5)
+    (k : ℕ) (hk : k ∈ Finset.Icc 1 5) : Cb_ref k ≤ Cb k := by
+  have : k = 1 ∨ k = 2 ∨ k = 3 ∨ k = 4 ∨ k = 5 := by
+    simp only [Finset.mem_Icc] at hk; omega
+  rcases this with rfl | rfl | rfl | rfl | rfl <;> assumption
 
 lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
   C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by
@@ -1913,13 +1921,8 @@ lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2,
       try contradiction
       try (revert hM5; norm_num)
     all_goals
-      have hk_cases : k = 1 ∨ k = 2 ∨ k = 3 ∨ k = 4 ∨ k = 5 := by
-        simp only [Finset.mem_Icc] at hk
-        omega
-      rcases hk_cases with rfl | rfl | rfl | rfl | rfl
-      all_goals
-        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_6]
-        norm_num
+      refine Cb_ref_le_dispatch Cb Cb_6 ?_ ?_ ?_ ?_ ?_ k hk <;>
+        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_6] <;> norm_num
   exact le_trans h_ver h_Cb_le'
 
 -- Rows in table_12 with M ≠ 10^19 all have Cb values ≥ row 14's Cb values
@@ -1963,13 +1966,8 @@ private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
       try contradiction
       try (revert hM; norm_num)
     all_goals
-      have hk_cases : k = 1 ∨ k = 2 ∨ k = 3 ∨ k = 4 ∨ k = 5 := by
-        simp only [Finset.mem_Icc] at hk
-        omega
-      rcases hk_cases with rfl | rfl | rfl | rfl | rfl
-      all_goals
-        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_14]
-        norm_num
+      refine Cb_ref_le_dispatch Cb Cb_14 ?_ ?_ ?_ ?_ ?_ k hk <;>
+        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_14] <;> norm_num
   exact le_trans h_ver h_Cb_le'
 
 @[blueprint

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1778,23 +1778,9 @@ private lemma mem_table_from_buthe_and_bounds_of_mem_table_12 (b c C M : ℝ) (C
     exp b ≤ M ∧ (10000 : ℝ) ≤ exp b ∧ (10 : ℝ) ≤ b ∧ 0 < b ∧
     (M = 5 * 10 ^ 10 ∨ M = 32 * 10 ^ 12 ∨ M = 10 ^ 19) := by
   simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h
-  -- union of all_goals closers from the six individual lemmas
+  casesm* _ ∨ _
   all_goals try contradiction
+  all_goals try rcases h with ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩
   all_goals try refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   all_goals try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
   all_goals try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
@@ -1832,19 +1818,18 @@ private lemma le_of_le_of_mem_Icc_one_five (Cb Cb_ref : ℕ → ℝ)
     simp only [Finset.mem_Icc] at hk; omega
   rcases this with rfl | rfl | rfl | rfl | rfl <;> assumption
 
-private def bklnw_Cb_row6 : ℕ → ℝ := fun j ↦
-  if j = 1 then 2.01560e-4
-  else if j = 2 then 4.96540e-3
-  else if j = 3 then 1.22330e-1
-  else if j = 4 then 3.01350e0
-  else 7.42380e1
+noncomputable def table_12_row_Cb (row_idx : Fin BKLNW.table_12.length) (k : ℕ) : ℝ :=
+  match BKLNW.table_12.get row_idx with
+  | (_, Cb1, Cb2, Cb3, Cb4, Cb5, _, _, _) =>
+    if k = 1 then Cb1
+    else if k = 2 then Cb2
+    else if k = 3 then Cb3
+    else if k = 4 then Cb4
+    else Cb5
 
-private def bklnw_Cb_row14 : ℕ → ℝ := fun j ↦
-  if j = 1 then 1.02600e-5
-  else if j = 2 then 3.19040e-4
-  else if j = 3 then 9.92090e-3
-  else if j = 4 then 3.08510e-1
-  else 9.59360e0
+private noncomputable def bklnw_Cb_row6 (k : ℕ) : ℝ := table_12_row_Cb ⟨5, by decide⟩ k
+
+private noncomputable def bklnw_Cb_row14 (k : ℕ) : ℝ := table_12_row_Cb ⟨13, by decide⟩ k
 
 private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
@@ -1852,44 +1837,31 @@ private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     (M = 5 * 10 ^ 10 → bklnw_Cb_row6 k ≤ Cb k) ∧
     (M ≠ 10 ^ 19 → bklnw_Cb_row14 k ≤ Cb k) := by
   simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-    h_false
+  casesm* _ ∨ _
   all_goals try contradiction
+  all_goals try rcases h with ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩
   all_goals try refine ⟨?_, ?_⟩
   all_goals try (
     intro hM
     norm_num at hM
+    try contradiction
   )
   all_goals try (
     refine le_of_le_of_mem_Icc_one_five Cb bklnw_Cb_row6 ?_ ?_ ?_ ?_ ?_ k hk <;>
-      simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row6] <;> norm_num
+      (unfold bklnw_Cb_row6 table_12_row_Cb; simp only [table_12, List.get, hCb1, hCb2, hCb3, hCb4, hCb5]; norm_num)
   )
   all_goals try (
     refine le_of_le_of_mem_Icc_one_five Cb bklnw_Cb_row14 ?_ ?_ ?_ ?_ ?_ k hk <;>
-      simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row14] <;> norm_num
+      (unfold bklnw_Cb_row14 table_12_row_Cb; simp only [table_12, List.get, hCb1, hCb2, hCb3, hCb4, hCb5]; norm_num)
   )
 
 lemma C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
   C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by
   have h_row6_mem : (log (5 * 10 ^ 10), bklnw_Cb_row6 1, bklnw_Cb_row6 2, bklnw_Cb_row6 3, bklnw_Cb_row6 4, bklnw_Cb_row6 5, 0.88, 0.86, 32 * 10 ^ 12) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    right; right; right; right; right
-    left
-    simp [bklnw_Cb_row6]
-    constructor <;> norm_num
+    unfold bklnw_Cb_row6 table_12_row_Cb
+    simp only [table_12, List.get]
+    repeat (first | (left; constructor <;> (first | rfl | norm_num); done) | right)
   have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) bklnw_Cb_row6 h_row6_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).1 hM5)
 
@@ -1899,10 +1871,9 @@ private lemma C_bk_le_Cb_of_M_ne_ten_pow_nineteen (b c C M : ℝ) (Cb : ℕ → 
     C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k := by
   have h_row14_mem : (log (32 * 10 ^ 12), bklnw_Cb_row14 1, bklnw_Cb_row14 2, bklnw_Cb_row14 3, bklnw_Cb_row14 4, bklnw_Cb_row14 5, 0.94, 0.94, 10 ^ 19) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    right; right; right; right; right; right; right; right; right; right; right; right; right
-    left
-    simp [bklnw_Cb_row14]
-    constructor <;> norm_num
+    unfold bklnw_Cb_row14 table_12_row_Cb
+    simp only [table_12, List.get]
+    repeat (first | (left; constructor <;> (first | rfl | norm_num); done) | right)
   have h_ver := bklnw_table_12_verification (log (32 * 10 ^ 12)) 0.94 0.94 (10 ^ 19) bklnw_Cb_row14 h_row14_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).2 hM)
 

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1811,29 +1811,6 @@ private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
   -- all_goals try (apply Or.inr; apply Or.inr; simp; done)
   all_goals try norm_num
 
-private lemma table_12_mem_buthe (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
-    ((100 : ℝ), M, c, C) ∈ table_from_buthe :=
-  (table_12_basic_props b c C M Cb h).1
-
-private lemma table_12_expb_le_M (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : exp b ≤ M :=
-  (table_12_basic_props b c C M Cb h).2.1
-
-private lemma table_12_10000_le_expb (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
-    (10000 : ℝ) ≤ exp b :=
-  (table_12_basic_props b c C M Cb h).2.2.1
-
-private lemma table_12_ten_le_b (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : (10 : ℝ) ≤ b :=
-  (table_12_basic_props b c C M Cb h).2.2.2.1
-
-private lemma table_12_M_vals (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
-    M = 5 * 10 ^ 10 ∨ M = 32 * 10 ^ 12 ∨ M = 10 ^ 19 :=
-  (table_12_basic_props b c C M Cb h).2.2.2.2.2
-
 -- Transfers a C_bk analytical bound to the tabulated Cb bound in the final inequality
 private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
     (hx_pos : 0 < x) (h_log_pos : 0 < log x ^ k)
@@ -1853,19 +1830,6 @@ private lemma exp_two_k_le_exp_ten (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
   have : (k : ℝ) ≤ 5 := by exact_mod_cast (Finset.mem_Icc.mp hk).2
   linarith
 
--- The only M values in table_12 are 5e10, 32e12, 10^19; ruling out two forces the third
-private lemma table_12_M_eq_32e12 (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
-    (hM : M ≠ 10 ^ 19) (hM5 : M ≠ 5 * 10 ^ 10) :
-    M = 32 * 10 ^ 12 := by
-  rcases table_12_M_vals b c C M Cb h with rfl | rfl | rfl
-  · exact absurd rfl hM5
-  · rfl
-  · exact absurd rfl hM
-
-private lemma table_12_b_pos (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : 0 < b :=
-  (table_12_basic_props b c C M Cb h).2.2.2.2.1
 
 -- For k ∈ {1,...,5}, pointwise bounds at each index suffice to pick the bound at k
 private lemma Cb_ref_le_dispatch (Cb Cb_ref : ℕ → ℝ)
@@ -1964,101 +1928,71 @@ private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
   (latexEnv := "corollary")]
 theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
   ∀ x ∈ Set.Ico (exp b) (10 ^ 19), ∀ k ∈ Finset.Icc 1 5, θ x - x ≥ - Cb k * x / (log x)^k := by
-  -- Step 1. Every row of table_12 satisfies (100, M, c, C) ∈ table_from_buthe.
-  have h_buthe : ((100 : ℝ), M, c, C) ∈ table_from_buthe := table_12_mem_buthe b c C M Cb h
-  -- Step 2. Every row has e^b ≤ M.
-  have h_expb_le_M : exp b ≤ M := table_12_expb_le_M b c C M Cb h
-  -- Step 3. Every row has max(10000, exp(2k)) ≤ exp(b) for all k ∈ {1,...,5}.
+  obtain ⟨h_buthe, h_expb_le_M, h_10000_le_expb, h_ten_le_b, h_b_pos, h_M_vals⟩ :=
+    table_12_basic_props b c C M Cb h
   have h_expb_lb : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
-      max (10000 : ℝ) (exp (2 * (k : ℝ))) ≤ exp b := fun k hk => by
-    rw [max_le_iff]
-    exact ⟨table_12_10000_le_expb b c C M Cb h,
-           le_trans (exp_two_k_le_exp_ten k hk)
-                    (Real.exp_le_exp.mpr (table_12_ten_le_b b c C M Cb h))⟩
-  -- Step 4. Apply bklnw_corollary_9_1 to get the ≥ bound on [exp b, M].
-  -- This is the key application: θ x ≥ x - C_bk b c C c₀ k * x / (log x)^k for x ∈ [exp b, M].
+      max (10000 : ℝ) (exp (2 * (k : ℝ))) ≤ exp b := fun k hk =>
+    max_le_iff.mpr ⟨h_10000_le_expb,
+                    le_trans (exp_two_k_le_exp_ten k hk) (Real.exp_le_exp.mpr h_ten_le_b)⟩
   have h_cor_9_1 : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
       ∀ x ∈ Set.Icc (exp b) M,
-      θ x ≥ x - C_bk b c C RS_prime.c₀ k * x / (log x) ^ k := by
-    intro k hk
-    exact bklnw_corollary_9_1 k M c C b h_buthe ⟨h_expb_lb k hk, h_expb_le_M⟩
-  -- Step 5. Table 12 verification: the tabulated values Cb k upper-bound C_bk analytically.
-  -- Proof: apply bklnw_table_12_verification h k hk (which is itself sorry-ed).
+      θ x ≥ x - C_bk b c C RS_prime.c₀ k * x / (log x) ^ k :=
+    fun k hk => bklnw_corollary_9_1 k M c C b h_buthe ⟨h_expb_lb k hk, h_expb_le_M⟩
   have h_Cb_le : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k :=
     bklnw_table_12_verification b c C M Cb h
-  -- Step 6. Split on whether x ≤ M or x > M.
-  -- For x ≤ M, the target x ∈ Set.Icc (exp b) M is satisfied.
-  -- For x > M, either M = 10^19 (which leads to a contradiction since x < 10^19),
-  -- or M < 10^19
   intro x hx k hk
   rcases le_or_gt x M with hx_le | hx_gt
   · have hx_in_Icc : x ∈ Set.Icc (exp b) M := ⟨hx.1, hx_le⟩
     have hx_pos : (0 : ℝ) < x := (exp_pos b).trans_le hx_in_Icc.1
     have h_log_pos : (0 : ℝ) < (log x) ^ k := by
       apply pow_pos
-      have hb_pos : (0 : ℝ) < b := table_12_b_pos b c C M Cb h
-      calc 0 < b := hb_pos
+      calc 0 < b := h_b_pos
         _ = log (exp b) := (Real.log_exp b).symm
         _ ≤ log x := Real.log_le_log (exp_pos b) hx_in_Icc.1
-    have h_theta_ge := h_cor_9_1 k hk x hx_in_Icc
-    have h_cbk_le := h_Cb_le k hk
-    exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos (by linarith [h_theta_ge]) h_cbk_le
+    exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
+      (by linarith [h_cor_9_1 k hk x hx_in_Icc]) (h_Cb_le k hk)
   · by_cases hM : M = 10 ^ 19
-    · subst hM
-      linarith [hx.2, hx_gt]
+    · subst hM; linarith [hx.2, hx_gt]
     · by_cases hM5 : M = 5 * 10 ^ 10
       · by_cases hx32 : x ≤ 32 * 10 ^ 12
         · -- Case 1: M = 5e10, x ∈ (5e10, 32e12]
-          -- We apply bklnw_corollary_9_1 to row 6 (b = log 5e10, M = 32e12).
           have hx_in_Icc6 : x ∈ Set.Icc (exp (log (5 * 10 ^ 10))) (32 * 10 ^ 12) := by
-            rw [Real.exp_log (by norm_num)]
-            exact ⟨by linarith, hx32⟩
+            rw [Real.exp_log (by norm_num)]; exact ⟨by linarith, hx32⟩
           have h_cor_9_1_row6 := bklnw_corollary_9_1 k (32 * 10 ^ 12) 0.88 0.86 (log (5 * 10 ^ 10))
             (by simp [table_from_buthe]) (by
               rw [Real.exp_log (by norm_num)]
               simp only [max_le_iff]
               refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
-              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
-              norm_num)
-          have h_theta_ge_row6 := h_cor_9_1_row6 x hx_in_Icc6
-          have h_theta_ge_rw : θ x - x ≥ - (C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k * x / log x ^ k) := by linarith [h_theta_ge_row6]
+              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
           have hx_pos : (0 : ℝ) < x := by linarith
-          have h_log_pos : (0 : ℝ) < log x ^ k := by
-            apply pow_pos
-            have : 1 < x := by linarith
-            exact Real.log_pos this
-          have h_const_le : C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k :=
-            bklnw_case1_helper b c C M Cb h k hk hM5
-          exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
+          have h_log_pos : (0 : ℝ) < log x ^ k :=
+            pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
+          exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
+            (by linarith [h_cor_9_1_row6 x hx_in_Icc6])
+            (bklnw_case1_helper b c C M Cb h k hk hM5)
         · -- Case 2: M = 5e10, x ∈ (32e12, 10^19)
-          -- We apply bklnw_corollary_9_1 to row 14 (b = log 32e12, M = 10^19).
-          have hx_gt32 : x > 32 * 10 ^ 12 := not_le.mp hx32
           have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
             rw [Real.exp_log (by norm_num)]
-            exact ⟨hx_gt32.le, hx.2.le⟩
+            exact ⟨(not_le.mp hx32).le, hx.2.le⟩
           have h_cor_9_1_row14 := bklnw_corollary_9_1 k (10 ^ 19) 0.94 0.94 (log (32 * 10 ^ 12))
             (by simp [table_from_buthe]) (by
               rw [Real.exp_log (by norm_num)]
               simp only [max_le_iff]
               refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
-              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
-              norm_num)
-          have h_theta_ge_row14 := h_cor_9_1_row14 x hx_in_Icc14
-          have h_theta_ge_rw : θ x - x ≥ - (C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k * x / log x ^ k) := by linarith [h_theta_ge_row14]
+              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
           have hx_pos : (0 : ℝ) < x := by linarith
-          have h_log_pos : (0 : ℝ) < log x ^ k := by
-            apply pow_pos
-            have : 1 < x := by linarith
-            exact Real.log_pos this
-          have h_const_le : C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k :=
-            bklnw_row14_le b c C M Cb h k hk (by rw [hM5]; norm_num)
-          exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
+          have h_log_pos : (0 : ℝ) < log x ^ k :=
+            pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
+          exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
+            (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
+            (bklnw_row14_le b c C M Cb h k hk (by rw [hM5]; norm_num))
       · -- Case 3: M = 32e12 (since M ≠ 10^19 and M ≠ 5e10)
-        -- We apply bklnw_corollary_9_1 to row 14 (b = log 32e12, M = 10^19).
-        have h_M_eq : M = 32 * 10 ^ 12 := table_12_M_eq_32e12 b c C M Cb h hM hM5
-        have hx_gt32 : x > 32 * 10 ^ 12 := by
-          rw [← h_M_eq]
-          exact hx_gt
+        have h_M_eq : M = 32 * 10 ^ 12 := by
+          rcases h_M_vals with rfl | rfl | rfl
+          · exact absurd rfl hM5
+          · rfl
+          · exact absurd rfl hM
+        have hx_gt32 : x > 32 * 10 ^ 12 := h_M_eq ▸ hx_gt
         have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
           rw [Real.exp_log (by norm_num)]
           exact ⟨hx_gt32.le, hx.2.le⟩
@@ -2067,18 +2001,13 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
             rw [Real.exp_log (by norm_num)]
             simp only [max_le_iff]
             refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
-            grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
-            norm_num)
-        have h_theta_ge_row14 := h_cor_9_1_row14 x hx_in_Icc14
-        have h_theta_ge_rw : θ x - x ≥ - (C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k * x / log x ^ k) := by linarith [h_theta_ge_row14]
+            grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
         have hx_pos : (0 : ℝ) < x := by linarith
-        have h_log_pos : (0 : ℝ) < log x ^ k := by
-          apply pow_pos
-          have : 1 < x := by linarith
-          exact Real.log_pos this
-        have h_const_le : C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k :=
-          bklnw_row14_le b c C M Cb h k hk hM
-        exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
+        have h_log_pos : (0 : ℝ) < log x ^ k :=
+          pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
+        exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
+          (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
+          (bklnw_row14_le b c C M Cb h k hk hM)
 
 
 blueprint_comment /--

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1818,6 +1818,10 @@ private lemma le_of_le_of_mem_Icc_one_five (Cb Cb_ref : ℕ → ℝ)
     simp only [Finset.mem_Icc] at hk; omega
   rcases this with rfl | rfl | rfl | rfl | rfl <;> assumption
 
+noncomputable def table_12_row_b (row_idx : Fin BKLNW.table_12.length) : ℝ :=
+  match BKLNW.table_12.get row_idx with
+  | (b, _, _, _, _, _, _, _, _) => b
+
 noncomputable def table_12_row_Cb (row_idx : Fin BKLNW.table_12.length) (k : ℕ) : ℝ :=
   match BKLNW.table_12.get row_idx with
   | (_, Cb1, Cb2, Cb3, Cb4, Cb5, _, _, _) =>
@@ -1827,9 +1831,47 @@ noncomputable def table_12_row_Cb (row_idx : Fin BKLNW.table_12.length) (k : ℕ
     else if k = 4 then Cb4
     else Cb5
 
-private noncomputable def bklnw_Cb_row6 (k : ℕ) : ℝ := table_12_row_Cb ⟨5, by decide⟩ k
+noncomputable def table_12_row_c (row_idx : Fin BKLNW.table_12.length) : ℝ :=
+  match BKLNW.table_12.get row_idx with
+  | (_, _, _, _, _, _, c, _, _) => c
 
+noncomputable def table_12_row_C (row_idx : Fin BKLNW.table_12.length) : ℝ :=
+  match BKLNW.table_12.get row_idx with
+  | (_, _, _, _, _, _, _, C, _) => C
+
+noncomputable def table_12_row_M (row_idx : Fin BKLNW.table_12.length) : ℝ :=
+  match BKLNW.table_12.get row_idx with
+  | (_, _, _, _, _, _, _, _, M) => M
+
+private noncomputable def bklnw_b_row6 : ℝ := table_12_row_b ⟨5, by decide⟩
+private noncomputable def bklnw_Cb_row6 (k : ℕ) : ℝ := table_12_row_Cb ⟨5, by decide⟩ k
+private noncomputable def bklnw_c_row6 : ℝ := table_12_row_c ⟨5, by decide⟩
+private noncomputable def bklnw_C_row6 : ℝ := table_12_row_C ⟨5, by decide⟩
+private noncomputable def bklnw_M_row6 : ℝ := table_12_row_M ⟨5, by decide⟩
+
+private noncomputable def bklnw_b_row14 : ℝ := table_12_row_b ⟨13, by decide⟩
 private noncomputable def bklnw_Cb_row14 (k : ℕ) : ℝ := table_12_row_Cb ⟨13, by decide⟩ k
+private noncomputable def bklnw_c_row14 : ℝ := table_12_row_c ⟨13, by decide⟩
+private noncomputable def bklnw_C_row14 : ℝ := table_12_row_C ⟨13, by decide⟩
+private noncomputable def bklnw_M_row14 : ℝ := table_12_row_M ⟨13, by decide⟩
+
+private lemma bklnw_b_row6_eq : bklnw_b_row6 = log (5 * 10 ^ 10) := by
+  unfold bklnw_b_row6 table_12_row_b; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_c_row6_eq : bklnw_c_row6 = 0.88 := by
+  unfold bklnw_c_row6 table_12_row_c; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_C_row6_eq : bklnw_C_row6 = 0.86 := by
+  unfold bklnw_C_row6 table_12_row_C; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_M_row6_eq : bklnw_M_row6 = 32 * 10 ^ 12 := by
+  unfold bklnw_M_row6 table_12_row_M; simp only [table_12, List.get]; try norm_num
+
+private lemma bklnw_b_row14_eq : bklnw_b_row14 = log (32 * 10 ^ 12) := by
+  unfold bklnw_b_row14 table_12_row_b; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_c_row14_eq : bklnw_c_row14 = 0.94 := by
+  unfold bklnw_c_row14 table_12_row_c; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_C_row14_eq : bklnw_C_row14 = 0.94 := by
+  unfold bklnw_C_row14 table_12_row_C; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_M_row14_eq : bklnw_M_row14 = 10 ^ 19 := by
+  unfold bklnw_M_row14 table_12_row_M; simp only [table_12, List.get]; try norm_num
 
 private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
@@ -1856,25 +1898,25 @@ private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
   )
 
 lemma C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
-  C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by
-  have h_row6_mem : (log (5 * 10 ^ 10), bklnw_Cb_row6 1, bklnw_Cb_row6 2, bklnw_Cb_row6 3, bklnw_Cb_row6 4, bklnw_Cb_row6 5, 0.88, 0.86, 32 * 10 ^ 12) ∈ table_12 := by
+  C_bk bklnw_b_row6 bklnw_c_row6 bklnw_C_row6 RS_prime.c₀ k ≤ Cb k := by
+  have h_row6_mem : (bklnw_b_row6, bklnw_Cb_row6 1, bklnw_Cb_row6 2, bklnw_Cb_row6 3, bklnw_Cb_row6 4, bklnw_Cb_row6 5, bklnw_c_row6, bklnw_C_row6, bklnw_M_row6) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    unfold bklnw_Cb_row6 table_12_row_Cb
+    unfold bklnw_b_row6 bklnw_Cb_row6 bklnw_c_row6 bklnw_C_row6 bklnw_M_row6 table_12_row_b table_12_row_Cb table_12_row_c table_12_row_C table_12_row_M
     simp only [table_12, List.get]
     repeat (first | (left; constructor <;> (first | rfl | norm_num); done) | right)
-  have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) bklnw_Cb_row6 h_row6_mem k hk
+  have h_ver := bklnw_table_12_verification bklnw_b_row6 bklnw_c_row6 bklnw_C_row6 bklnw_M_row6 bklnw_Cb_row6 h_row6_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).1 hM5)
 
 private lemma C_bk_le_Cb_of_M_ne_ten_pow_nineteen (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
     (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM : M ≠ 10 ^ 19) :
-    C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k := by
-  have h_row14_mem : (log (32 * 10 ^ 12), bklnw_Cb_row14 1, bklnw_Cb_row14 2, bklnw_Cb_row14 3, bklnw_Cb_row14 4, bklnw_Cb_row14 5, 0.94, 0.94, 10 ^ 19) ∈ table_12 := by
+    C_bk bklnw_b_row14 bklnw_c_row14 bklnw_C_row14 RS_prime.c₀ k ≤ Cb k := by
+  have h_row14_mem : (bklnw_b_row14, bklnw_Cb_row14 1, bklnw_Cb_row14 2, bklnw_Cb_row14 3, bklnw_Cb_row14 4, bklnw_Cb_row14 5, bklnw_c_row14, bklnw_C_row14, bklnw_M_row14) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    unfold bklnw_Cb_row14 table_12_row_Cb
+    unfold bklnw_b_row14 bklnw_Cb_row14 bklnw_c_row14 bklnw_C_row14 bklnw_M_row14 table_12_row_b table_12_row_Cb table_12_row_c table_12_row_C table_12_row_M
     simp only [table_12, List.get]
     repeat (first | (left; constructor <;> (first | rfl | norm_num); done) | right)
-  have h_ver := bklnw_table_12_verification (log (32 * 10 ^ 12)) 0.94 0.94 (10 ^ 19) bklnw_Cb_row14 h_row14_mem k hk
+  have h_ver := bklnw_table_12_verification bklnw_b_row14 bklnw_c_row14 bklnw_C_row14 bklnw_M_row14 bklnw_Cb_row14 h_row14_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).2 hM)
 
 @[blueprint
@@ -1911,51 +1953,61 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
   · by_cases hM : M = 10 ^ 19
     · subst hM; linarith [hx.2, hx_gt]
     · by_cases hM5 : M = 5 * 10 ^ 10
-      · by_cases hx32 : x ≤ 32 * 10 ^ 12
-        · have hx_in_Icc6 : x ∈ Set.Icc (exp (log (5 * 10 ^ 10))) (32 * 10 ^ 12) := by
+      · by_cases hx32 : x ≤ bklnw_M_row6
+        · have hx_in_Icc6 : x ∈ Set.Icc (exp bklnw_b_row6) bklnw_M_row6 := by
+            rw [bklnw_b_row6_eq, bklnw_M_row6_eq] at *
             rw [Real.exp_log (by norm_num)]; exact ⟨by linarith, hx32⟩
-          have h_cor_9_1_row6 := bklnw_corollary_9_1 k (32 * 10 ^ 12) 0.88 0.86 (log (5 * 10 ^ 10))
-            (by simp [table_from_buthe]) (by
-              rw [Real.exp_log (by norm_num)]
-              simp only [max_le_iff]
-              refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
-              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
+          have h_cor_9_1_row6 := bklnw_corollary_9_1 k bklnw_M_row6 bklnw_c_row6 bklnw_C_row6 bklnw_b_row6
+            (by rw [bklnw_M_row6_eq, bklnw_c_row6_eq, bklnw_C_row6_eq]
+                simp [table_from_buthe])
+            (by rw [bklnw_M_row6_eq, bklnw_b_row6_eq]
+                rw [Real.exp_log (by norm_num)]
+                simp only [max_le_iff]
+                refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
+                grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
           have hx_pos : (0 : ℝ) < x := by linarith
           have h_log_pos : (0 : ℝ) < log x ^ k :=
             pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
             (by linarith [h_cor_9_1_row6 x hx_in_Icc6])
             (C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten b c C M Cb h k hk hM5)
-        · have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
+        · have hx_in_Icc14 : x ∈ Set.Icc (exp bklnw_b_row14) bklnw_M_row14 := by
+            rw [bklnw_b_row14_eq, bklnw_M_row6_eq, bklnw_M_row14_eq] at *
             rw [Real.exp_log (by norm_num)]
             exact ⟨(not_le.mp hx32).le, hx.2.le⟩
-          have h_cor_9_1_row14 := bklnw_corollary_9_1 k (10 ^ 19) 0.94 0.94 (log (32 * 10 ^ 12))
-            (by simp [table_from_buthe]) (by
-              rw [Real.exp_log (by norm_num)]
-              simp only [max_le_iff]
-              refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
-              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
+          have h_cor_9_1_row14 := bklnw_corollary_9_1 k bklnw_M_row14 bklnw_c_row14 bklnw_C_row14 bklnw_b_row14
+            (by rw [bklnw_M_row14_eq, bklnw_c_row14_eq, bklnw_C_row14_eq]
+                simp [table_from_buthe])
+            (by rw [bklnw_M_row14_eq, bklnw_b_row14_eq]
+                rw [Real.exp_log (by norm_num)]
+                simp only [max_le_iff]
+                refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
+                grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
           have hx_pos : (0 : ℝ) < x := by linarith
           have h_log_pos : (0 : ℝ) < log x ^ k :=
             pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
             (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
             (C_bk_le_Cb_of_M_ne_ten_pow_nineteen b c C M Cb h k hk (by rw [hM5]; norm_num))
-      · have h_M_eq : M = 32 * 10 ^ 12 := by
+      · have h_M_eq : M = bklnw_M_row6 := by
+          rw [bklnw_M_row6_eq]
           rcases h_M_vals with rfl | rfl | rfl
           · exact absurd rfl hM5
           · rfl
           · exact absurd rfl hM
-        have hx_gt32 : x > 32 * 10 ^ 12 := h_M_eq ▸ hx_gt
-        have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
+        have hx_gt32 : x > bklnw_M_row6 := h_M_eq ▸ hx_gt
+        have hx_in_Icc14 : x ∈ Set.Icc (exp bklnw_b_row14) bklnw_M_row14 := by
+          rw [bklnw_b_row14_eq, bklnw_M_row6_eq, bklnw_M_row14_eq] at *
           rw [Real.exp_log (by norm_num)]
           exact ⟨hx_gt32.le, hx.2.le⟩
-        have h_cor_9_1_row14 := bklnw_corollary_9_1 k (10 ^ 19) 0.94 0.94 (log (32 * 10 ^ 12))
-          (by simp [table_from_buthe]) (by
-            rw [Real.exp_log (by norm_num)]
-            simp only [max_le_iff]
-            refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
-            grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
+        have h_cor_9_1_row14 := bklnw_corollary_9_1 k bklnw_M_row14 bklnw_c_row14 bklnw_C_row14 bklnw_b_row14
+          (by rw [bklnw_M_row14_eq, bklnw_c_row14_eq, bklnw_C_row14_eq]
+              simp [table_from_buthe])
+          (by rw [bklnw_M_row14_eq, bklnw_b_row14_eq]
+              rw [Real.exp_log (by norm_num)]
+              simp only [max_le_iff]
+              refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
+              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
         have hx_pos : (0 : ℝ) < x := by linarith
         have h_log_pos : (0 : ℝ) < log x ^ k :=
           pow_pos (Real.log_pos (by linarith : (1 : ℝ) < x)) k

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1772,11 +1772,12 @@ theorem bklnw_corollary_9_1 (k : ℕ) (v c C b : ℝ) (hvcc : (100, v, c, C) ∈
 theorem bklnw_table_12_verification (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k := by
   sorry
 
--- Bundles five basic properties of table_12 rows, avoiding six separate 26-case dispatches
+-- Bundles six basic properties of table_12 rows, avoiding separate 26-case dispatches
 private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
     ((100 : ℝ), M, c, C) ∈ table_from_buthe ∧
-    exp b ≤ M ∧ (10000 : ℝ) ≤ exp b ∧ (10 : ℝ) ≤ b ∧ 0 < b := by
+    exp b ≤ M ∧ (10000 : ℝ) ≤ exp b ∧ (10 : ℝ) ≤ b ∧ 0 < b ∧
+    (M = 5 * 10 ^ 10 ∨ M = 32 * 10 ^ 12 ∨ M = 10 ^ 19) := by
   simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
   rcases h with
     ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
@@ -1793,9 +1794,9 @@ private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
     ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
     ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
     h
-  -- union of all_goals closers from the five individual lemmas
+  -- union of all_goals closers from the six individual lemmas
   all_goals try contradiction
-  all_goals try refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  all_goals try refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
   all_goals try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
   all_goals try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
                             Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
@@ -1805,6 +1806,9 @@ private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
   all_goals try (rw [Real.le_log_iff_exp_le (by norm_num)]
                  grw [← exp_one_rpow 10, Real.exp_one_lt_d9])
   all_goals try (apply Real.log_pos; norm_num)
+  all_goals try exact Or.inl (by norm_num)
+  all_goals try exact Or.inr (Or.inl (by norm_num))
+  all_goals try exact Or.inr (Or.inr (by norm_num))
   all_goals try norm_num
 
 private lemma table_12_mem_buthe (b c C M : ℝ) (Cb : ℕ → ℝ)
@@ -1824,6 +1828,11 @@ private lemma table_12_10000_le_expb (b c C M : ℝ) (Cb : ℕ → ℝ)
 private lemma table_12_ten_le_b (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : (10 : ℝ) ≤ b :=
   (table_12_basic_props b c C M Cb h).2.2.2.1
+
+private lemma table_12_M_vals (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
+    M = 5 * 10 ^ 10 ∨ M = 32 * 10 ^ 12 ∨ M = 10 ^ 19 :=
+  (table_12_basic_props b c C M Cb h).2.2.2.2.2
 
 -- Transfers a C_bk analytical bound to the tabulated Cb bound in the final inequality
 private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
@@ -1849,30 +1858,14 @@ private lemma table_12_M_eq_32e12 (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
     (hM : M ≠ 10 ^ 19) (hM5 : M ≠ 5 * 10 ^ 10) :
     M = 32 * 10 ^ 12 := by
-  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h_false
-  all_goals
-    try contradiction
-    try (revert hM5; norm_num)
-    try (revert hM; norm_num)
+  rcases table_12_M_vals b c C M Cb h with rfl | rfl | rfl
+  · exact absurd rfl hM5
+  · rfl
+  · exact absurd rfl hM
 
 private lemma table_12_b_pos (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : 0 < b :=
-  (table_12_basic_props b c C M Cb h).2.2.2.2
+  (table_12_basic_props b c C M Cb h).2.2.2.2.1
 
 -- For k ∈ {1,...,5}, pointwise bounds at each index suffice to pick the bound at k
 private lemma Cb_ref_le_dispatch (Cb Cb_ref : ℕ → ℝ)

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1772,7 +1772,6 @@ theorem bklnw_corollary_9_1 (k : ℕ) (v c C b : ℝ) (hvcc : (100, v, c, C) ∈
 theorem bklnw_table_12_verification (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k := by
   sorry
 
--- Bundles six basic properties of table_12 rows, avoiding separate 26-case dispatches
 private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
     ((100 : ℝ), M, c, C) ∈ table_from_buthe ∧
@@ -1806,12 +1805,8 @@ private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
   all_goals try (rw [Real.le_log_iff_exp_le (by norm_num)]
                  grw [← exp_one_rpow 10, Real.exp_one_lt_d9])
   all_goals try (apply Real.log_pos; norm_num)
-  -- all_goals try (apply Or.inl; simp; done)
-  -- all_goals try (apply Or.inr; apply Or.inl; simp; done)
-  -- all_goals try (apply Or.inr; apply Or.inr; simp; done)
   all_goals try norm_num
 
--- Transfers a C_bk analytical bound to the tabulated Cb bound in the final inequality
 private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
     (hx_pos : 0 < x) (h_log_pos : 0 < log x ^ k)
     (h_theta : θ x - x ≥ -(cbk * x / log x ^ k))
@@ -1823,15 +1818,12 @@ private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
         apply div_le_div_of_nonneg_right _ (le_of_lt h_log_pos)
         exact mul_le_mul_of_nonneg_right (neg_le_neg h_le) hx_pos.le
 
--- For k ∈ {1,...,5}, we have 2k ≤ 10, so exp(2k) ≤ exp(10)
 private lemma exp_two_k_le_exp_ten (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
     exp (2 * (k : ℝ)) ≤ exp 10 := by
   apply Real.exp_le_exp.mpr
   have : (k : ℝ) ≤ 5 := by exact_mod_cast (Finset.mem_Icc.mp hk).2
   linarith
 
-
--- For k ∈ {1,...,5}, pointwise bounds at each index suffice to pick the bound at k
 private lemma Cb_ref_le_dispatch (Cb Cb_ref : ℕ → ℝ)
     (h1 : Cb_ref 1 ≤ Cb 1) (h2 : Cb_ref 2 ≤ Cb 2) (h3 : Cb_ref 3 ≤ Cb 3)
     (h4 : Cb_ref 4 ≤ Cb 4) (h5 : Cb_ref 5 ≤ Cb 5)
@@ -1854,8 +1846,6 @@ private def bklnw_Cb_row14 : ℕ → ℝ := fun j ↦
   else if j = 4 then 3.08510e-1
   else 9.59360e0
 
--- Bundles the two Cb bounds needed by bklnw_case1_helper and bklnw_row14_le,
--- avoiding two separate 26-case dispatches on table_12.
 private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
     (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
@@ -1879,17 +1869,14 @@ private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     h_false
   all_goals try contradiction
   all_goals try refine ⟨?_, ?_⟩
-  -- Introduce and simplify implication hypotheses for all goals
   all_goals try (
     intro hM
     norm_num at hM
   )
-  -- Solve non-vacuous first component goals (row 6)
   all_goals try (
     refine Cb_ref_le_dispatch Cb bklnw_Cb_row6 ?_ ?_ ?_ ?_ ?_ k hk <;>
       simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row6] <;> norm_num
   )
-  -- Solve non-vacuous second component goals (row 14)
   all_goals try (
     refine Cb_ref_le_dispatch Cb bklnw_Cb_row14 ?_ ?_ ?_ ?_ ?_ k hk <;>
       simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row14] <;> norm_num
@@ -1906,7 +1893,6 @@ lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2,
   have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) bklnw_Cb_row6 h_row6_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).1 hM5)
 
--- Rows in table_12 with M ≠ 10^19 all have Cb values ≥ row 14's Cb values
 private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
     (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM : M ≠ 10 ^ 19) :
@@ -1955,8 +1941,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
     · subst hM; linarith [hx.2, hx_gt]
     · by_cases hM5 : M = 5 * 10 ^ 10
       · by_cases hx32 : x ≤ 32 * 10 ^ 12
-        · -- Case 1: M = 5e10, x ∈ (5e10, 32e12]
-          have hx_in_Icc6 : x ∈ Set.Icc (exp (log (5 * 10 ^ 10))) (32 * 10 ^ 12) := by
+        · have hx_in_Icc6 : x ∈ Set.Icc (exp (log (5 * 10 ^ 10))) (32 * 10 ^ 12) := by
             rw [Real.exp_log (by norm_num)]; exact ⟨by linarith, hx32⟩
           have h_cor_9_1_row6 := bklnw_corollary_9_1 k (32 * 10 ^ 12) 0.88 0.86 (log (5 * 10 ^ 10))
             (by simp [table_from_buthe]) (by
@@ -1970,8 +1955,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
             (by linarith [h_cor_9_1_row6 x hx_in_Icc6])
             (bklnw_case1_helper b c C M Cb h k hk hM5)
-        · -- Case 2: M = 5e10, x ∈ (32e12, 10^19)
-          have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
+        · have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
             rw [Real.exp_log (by norm_num)]
             exact ⟨(not_le.mp hx32).le, hx.2.le⟩
           have h_cor_9_1_row14 := bklnw_corollary_9_1 k (10 ^ 19) 0.94 0.94 (log (32 * 10 ^ 12))
@@ -1986,8 +1970,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos
             (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
             (bklnw_row14_le b c C M Cb h k hk (by rw [hM5]; norm_num))
-      · -- Case 3: M = 32e12 (since M ≠ 10^19 and M ≠ 5e10)
-        have h_M_eq : M = 32 * 10 ^ 12 := by
+      · have h_M_eq : M = 32 * 10 ^ 12 := by
           rcases h_M_vals with rfl | rfl | rfl
           · exact absurd rfl hM5
           · rfl

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1806,9 +1806,9 @@ private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
   all_goals try (rw [Real.le_log_iff_exp_le (by norm_num)]
                  grw [← exp_one_rpow 10, Real.exp_one_lt_d9])
   all_goals try (apply Real.log_pos; norm_num)
-  all_goals try exact Or.inl (by norm_num)
-  all_goals try exact Or.inr (Or.inl (by norm_num))
-  all_goals try exact Or.inr (Or.inr (by norm_num))
+  -- all_goals try (apply Or.inl; simp; done)
+  -- all_goals try (apply Or.inr; apply Or.inl; simp; done)
+  -- all_goals try (apply Or.inr; apply Or.inr; simp; done)
   all_goals try norm_num
 
 private lemma table_12_mem_buthe (b c C M : ℝ) (Cb : ℕ → ℝ)

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1772,15 +1772,396 @@ theorem bklnw_corollary_9_1 (k : ℕ) (v c C b : ℝ) (hvcc : (100, v, c, C) ∈
 theorem bklnw_table_12_verification (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k := by
   sorry
 
+-- Transfers a C_bk analytical bound to the tabulated Cb bound in the final inequality
+private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
+    (hx_pos : 0 < x) (h_log_pos : 0 < log x ^ k)
+    (h_theta : θ x - x ≥ -(cbk * x / log x ^ k))
+    (h_le : cbk ≤ cb) :
+    θ x - x ≥ -cb * x / log x ^ k :=
+  calc θ x - x ≥ -(cbk * x / log x ^ k) := h_theta
+    _ = -cbk * x / log x ^ k := by ring
+    _ ≥ -cb * x / log x ^ k := by
+        apply div_le_div_of_nonneg_right _ (le_of_lt h_log_pos)
+        exact mul_le_mul_of_nonneg_right (neg_le_neg h_le) hx_pos.le
+
+-- For k ∈ {1,...,5}, we have 2k ≤ 10, so exp(2k) ≤ exp(10)
+private lemma exp_two_k_le_exp_ten (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
+    exp (2 * (k : ℝ)) ≤ exp 10 := by
+  apply Real.exp_le_exp.mpr
+  have : (k : ℝ) ≤ 5 := by exact_mod_cast (Finset.mem_Icc.mp hk).2
+  linarith
+
+-- Every b-value in table_12 is positive (smallest is log(5e10) ≈ 24.6)
+private lemma table_12_b_pos (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : 0 < b := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h
+  all_goals
+    try contradiction
+    try (apply Real.log_pos; norm_num)
+    try norm_num
+
+lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
+  C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by
+  let Cb_6 : ℕ → ℝ := fun j ↦
+    if j = 1 then 2.01560e-4
+    else if j = 2 then 4.96540e-3
+    else if j = 3 then 1.22330e-1
+    else if j = 4 then 3.01350e0
+    else 7.42380e1
+  have h_row6_mem : (log (5 * 10 ^ 10), Cb_6 1, Cb_6 2, Cb_6 3, Cb_6 4, Cb_6 5, 0.88, 0.86, 32 * 10 ^ 12) ∈ table_12 := by
+    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
+    right; right; right; right; right
+    left
+    dsimp [Cb_6]
+    simp
+    constructor <;> norm_num
+  have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) Cb_6 h_row6_mem k hk
+  have h_Cb_le' : Cb_6 k ≤ Cb k := by
+    have h_simp := h
+    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h_simp
+    rcases h_simp with
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      h_false
+    all_goals
+      try contradiction
+      try (revert hM5; norm_num)
+    all_goals
+      have hk_cases : k = 1 ∨ k = 2 ∨ k = 3 ∨ k = 4 ∨ k = 5 := by
+        simp only [Finset.mem_Icc] at hk
+        omega
+      rcases hk_cases with rfl | rfl | rfl | rfl | rfl
+      all_goals
+        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_6]
+        norm_num
+  exact le_trans h_ver h_Cb_le'
+
+-- Rows in table_12 with M ≠ 10^19 all have Cb values ≥ row 14's Cb values
+private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
+    (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM : M ≠ 10 ^ 19) :
+    C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k := by
+  let Cb_14 : ℕ → ℝ := fun j ↦
+    if j = 1 then 1.02600e-5
+    else if j = 2 then 3.19040e-4
+    else if j = 3 then 9.92090e-3
+    else if j = 4 then 3.08510e-1
+    else 9.59360e0
+  have h_row14_mem : (log (32 * 10 ^ 12), Cb_14 1, Cb_14 2, Cb_14 3, Cb_14 4, Cb_14 5, 0.94, 0.94, 10 ^ 19) ∈ table_12 := by
+    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
+    right; right; right; right; right; right; right; right; right; right; right; right; right
+    left
+    dsimp [Cb_14]
+    simp
+    constructor <;> norm_num
+  have h_ver := bklnw_table_12_verification (log (32 * 10 ^ 12)) 0.94 0.94 (10 ^ 19) Cb_14 h_row14_mem k hk
+  have h_Cb_le' : Cb_14 k ≤ Cb k := by
+    have h_simp := h
+    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h_simp
+    rcases h_simp with
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+      h_false
+    all_goals
+      try contradiction
+      try (revert hM; norm_num)
+    all_goals
+      have hk_cases : k = 1 ∨ k = 2 ∨ k = 3 ∨ k = 4 ∨ k = 5 := by
+        simp only [Finset.mem_Icc] at hk
+        omega
+      rcases hk_cases with rfl | rfl | rfl | rfl | rfl
+      all_goals
+        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_14]
+        norm_num
+  exact le_trans h_ver h_Cb_le'
+
 @[blueprint
   "bklnw-corollary-9-1-explicit"
   (title := "BKLNW Corollary 9.1 explicit version")
-  (statement := /--  We have $\theta(x) - x > - C_{b,k} x / \log k$ for all $k=1,\dots, 5$, $e^b \leq x < 10^{19}$, and $C_{b,k}$ from Table 12. -/)
+  (statement := /--  We have $\theta(x) - x \geq - C_{b,k} x / \log k$ for all $k=1,\dots, 5$, $e^b \leq x < 10^{19}$, and $C_{b,k}$ from Table 12. -/)
   (proof := /-- Insert the above table into the previous corollary. -/)
   (latexEnv := "corollary")]
 theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
-  ∀ x ∈ Set.Ico (exp b) (10 ^ 19), ∀ k ∈ Finset.Icc 1 5, θ x - x > - Cb k * x / (log x)^k := by
-  sorry
+  ∀ x ∈ Set.Ico (exp b) (10 ^ 19), ∀ k ∈ Finset.Icc 1 5, θ x - x ≥ - Cb k * x / (log x)^k := by
+  -- Step 1. Every row of table_12 satisfies (100, M, c, C) ∈ table_from_buthe.
+  -- Proof: case-split on all 26 rows via `simp [BKLNW.table_12, table_from_buthe]` + `rcases`.
+  have h_buthe : ((100 : ℝ), M, c, C) ∈ table_from_buthe := by
+    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+    rcases h with
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      h
+    all_goals
+      try contradiction
+      try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
+      try norm_num
+  -- Step 2. Every row has e^b ≤ M (the last column is the Buthe range upper bound).
+  -- Proof: same case-split as Step 1; each row has b ≤ log M, so exp b ≤ M.
+  have h_expb_le_M : exp b ≤ M := by
+    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+    rcases h with
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+      h
+    all_goals
+      try contradiction
+      try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
+                     Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
+      try grw [← exp_one_rpow, Real.exp_one_lt_d9]
+      try norm_num
+  -- Step 3. Every row has max(10000, exp(2k)) ≤ exp(b) for all k ∈ {1,...,5}.
+  -- Proof: each row has b ≥ 20 ≥ 10 ≥ 2k for k ≤ 5, and exp(20) ≥ 10000. Case-split on rows.
+  have h_expb_lb : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
+      max (10000 : ℝ) (exp (2 * (k : ℝ))) ≤ exp b := by
+    intro k hk
+    simp only [Finset.mem_Icc] at hk
+    have hk5 : (k : ℝ) ≤ 5 := by norm_cast; exact hk.2
+    rw [max_le_iff]
+    constructor
+    · simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+      rcases h with
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        h
+      all_goals
+        try contradiction
+        try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
+                       Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
+        try (
+          rw [← exp_one_rpow]
+          refine le_trans ?_ (rpow_le_rpow (by norm_num) exp_one_gt_d9.le (by norm_num))
+        )
+        try norm_num
+    · apply Real.exp_le_exp.mpr
+      simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+      rcases h with
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+        h
+      all_goals
+        try contradiction
+        try (
+          rw [Real.le_log_iff_exp_le (by norm_num)]
+          refine le_trans (exp_two_k_le_exp_ten k (Finset.mem_Icc.mpr hk)) ?_
+          grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
+        )
+        try linarith
+        try norm_num
+  -- Step 4. Apply bklnw_corollary_9_1 to get the ≥ bound on [exp b, M].
+  -- This is the key application: θ x ≥ x - C_bk b c C c₀ k * x / (log x)^k for x ∈ [exp b, M].
+  have h_cor_9_1 : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
+      ∀ x ∈ Set.Icc (exp b) M,
+      θ x ≥ x - C_bk b c C RS_prime.c₀ k * x / (log x) ^ k := by
+    intro k hk
+    exact bklnw_corollary_9_1 k M c C b h_buthe ⟨h_expb_lb k hk, h_expb_le_M⟩
+  -- Step 5. Table 12 verification: the tabulated values Cb k upper-bound C_bk analytically.
+  -- Proof: apply bklnw_table_12_verification h k hk (which is itself sorry-ed).
+  have h_Cb_le : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k :=
+    bklnw_table_12_verification b c C M Cb h
+  -- Step 6. Split on whether x ≤ M or x > M.
+  -- For x ≤ M, the target x ∈ Set.Icc (exp b) M is satisfied.
+  -- For x > M, either M = 10^19 (which leads to a contradiction since x < 10^19),
+  -- or M < 10^19
+  intro x hx k hk
+  rcases le_or_gt x M with hx_le | hx_gt
+  · have hx_in_Icc : x ∈ Set.Icc (exp b) M := ⟨hx.1, hx_le⟩
+    have hx_pos : (0 : ℝ) < x := (exp_pos b).trans_le hx_in_Icc.1
+    have h_log_pos : (0 : ℝ) < (log x) ^ k := by
+      apply pow_pos
+      have hb_pos : (0 : ℝ) < b := table_12_b_pos b c C M Cb h
+      calc 0 < b := hb_pos
+        _ = log (exp b) := (Real.log_exp b).symm
+        _ ≤ log x := Real.log_le_log (exp_pos b) hx_in_Icc.1
+    have h_theta_ge := h_cor_9_1 k hk x hx_in_Icc
+    have h_cbk_le := h_Cb_le k hk
+    exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos (by linarith [h_theta_ge]) h_cbk_le
+  · by_cases hM : M = 10 ^ 19
+    · subst hM
+      linarith [hx.2, hx_gt]
+    · by_cases hM5 : M = 5 * 10 ^ 10
+      · by_cases hx32 : x ≤ 32 * 10 ^ 12
+        · -- Case 1: M = 5e10, x ∈ (5e10, 32e12]
+          -- We apply bklnw_corollary_9_1 to row 6 (b = log 5e10, M = 32e12).
+          have hx_in_Icc6 : x ∈ Set.Icc (exp (log (5 * 10 ^ 10))) (32 * 10 ^ 12) := by
+            rw [Real.exp_log (by norm_num)]
+            exact ⟨by linarith, hx32⟩
+          have h_cor_9_1_row6 := bklnw_corollary_9_1 k (32 * 10 ^ 12) 0.88 0.86 (log (5 * 10 ^ 10))
+            (by simp [table_from_buthe]) (by
+              rw [Real.exp_log (by norm_num)]
+              simp only [max_le_iff]
+              refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
+              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
+              norm_num)
+          have h_theta_ge_row6 := h_cor_9_1_row6 x hx_in_Icc6
+          have h_theta_ge_rw : θ x - x ≥ - (C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k * x / log x ^ k) := by linarith [h_theta_ge_row6]
+          have hx_pos : (0 : ℝ) < x := by linarith
+          have h_log_pos : (0 : ℝ) < log x ^ k := by
+            apply pow_pos
+            have : 1 < x := by linarith
+            exact Real.log_pos this
+          have h_const_le : C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k :=
+            bklnw_case1_helper b c C M Cb h k hk hM5
+          exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
+        · -- Case 2: M = 5e10, x ∈ (32e12, 10^19)
+          -- We apply bklnw_corollary_9_1 to row 14 (b = log 32e12, M = 10^19).
+          have hx_gt32 : x > 32 * 10 ^ 12 := not_le.mp hx32
+          have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
+            rw [Real.exp_log (by norm_num)]
+            exact ⟨hx_gt32.le, hx.2.le⟩
+          have h_cor_9_1_row14 := bklnw_corollary_9_1 k (10 ^ 19) 0.94 0.94 (log (32 * 10 ^ 12))
+            (by simp [table_from_buthe]) (by
+              rw [Real.exp_log (by norm_num)]
+              simp only [max_le_iff]
+              refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
+              grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
+              norm_num)
+          have h_theta_ge_row14 := h_cor_9_1_row14 x hx_in_Icc14
+          have h_theta_ge_rw : θ x - x ≥ - (C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k * x / log x ^ k) := by linarith [h_theta_ge_row14]
+          have hx_pos : (0 : ℝ) < x := by linarith
+          have h_log_pos : (0 : ℝ) < log x ^ k := by
+            apply pow_pos
+            have : 1 < x := by linarith
+            exact Real.log_pos this
+          have h_const_le : C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k :=
+            bklnw_row14_le b c C M Cb h k hk (by rw [hM5]; norm_num)
+          exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
+      · -- Case 3: M = 32e12 (since M ≠ 10^19 and M ≠ 5e10)
+        -- We apply bklnw_corollary_9_1 to row 14 (b = log 32e12, M = 10^19).
+        have h_M_eq : M = 32 * 10 ^ 12 := by
+          -- M must be 32e12
+          simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+          rcases h with
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+            h_false
+          all_goals
+            try contradiction
+            try (revert hM5; norm_num)
+            try (revert hM; norm_num)
+            try rfl
+        have hx_gt32 : x > 32 * 10 ^ 12 := by
+          rw [← h_M_eq]
+          exact hx_gt
+        have hx_in_Icc14 : x ∈ Set.Icc (exp (log (32 * 10 ^ 12))) (10 ^ 19) := by
+          rw [Real.exp_log (by norm_num)]
+          exact ⟨hx_gt32.le, hx.2.le⟩
+        have h_cor_9_1_row14 := bklnw_corollary_9_1 k (10 ^ 19) 0.94 0.94 (log (32 * 10 ^ 12))
+          (by simp [table_from_buthe]) (by
+            rw [Real.exp_log (by norm_num)]
+            simp only [max_le_iff]
+            refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
+            grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
+            norm_num)
+        have h_theta_ge_row14 := h_cor_9_1_row14 x hx_in_Icc14
+        have h_theta_ge_rw : θ x - x ≥ - (C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k * x / log x ^ k) := by linarith [h_theta_ge_row14]
+        have hx_pos : (0 : ℝ) < x := by linarith
+        have h_log_pos : (0 : ℝ) < log x ^ k := by
+          apply pow_pos
+          have : 1 < x := by linarith
+          exact Real.log_pos this
+        have h_const_le : C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k :=
+          bklnw_row14_le b c C M Cb h k hk hM
+        exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
 
 
 blueprint_comment /--

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1883,92 +1883,85 @@ private lemma Cb_ref_le_dispatch (Cb Cb_ref : ℕ → ℝ)
     simp only [Finset.mem_Icc] at hk; omega
   rcases this with rfl | rfl | rfl | rfl | rfl <;> assumption
 
+private def bklnw_Cb_row6 : ℕ → ℝ := fun j ↦
+  if j = 1 then 2.01560e-4
+  else if j = 2 then 4.96540e-3
+  else if j = 3 then 1.22330e-1
+  else if j = 4 then 3.01350e0
+  else 7.42380e1
+
+private def bklnw_Cb_row14 : ℕ → ℝ := fun j ↦
+  if j = 1 then 1.02600e-5
+  else if j = 2 then 3.19040e-4
+  else if j = 3 then 9.92090e-3
+  else if j = 4 then 3.08510e-1
+  else 9.59360e0
+
+-- Bundles the two Cb bounds needed by bklnw_case1_helper and bklnw_row14_le,
+-- avoiding two separate 26-case dispatches on table_12.
+private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
+    (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
+    (M = 5 * 10 ^ 10 → bklnw_Cb_row6 k ≤ Cb k) ∧
+    (M ≠ 10 ^ 19 → bklnw_Cb_row14 k ≤ Cb k) := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
+    h_false
+  all_goals try contradiction
+  all_goals try refine ⟨?_, ?_⟩
+  -- Introduce and simplify implication hypotheses for all goals
+  all_goals try (
+    intro hM
+    norm_num at hM
+  )
+  -- Solve non-vacuous first component goals (row 6)
+  all_goals try (
+    refine Cb_ref_le_dispatch Cb bklnw_Cb_row6 ?_ ?_ ?_ ?_ ?_ k hk <;>
+      simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row6] <;> norm_num
+  )
+  -- Solve non-vacuous second component goals (row 14)
+  all_goals try (
+    refine Cb_ref_le_dispatch Cb bklnw_Cb_row14 ?_ ?_ ?_ ?_ ?_ k hk <;>
+      simp only [hCb1, hCb2, hCb3, hCb4, hCb5, bklnw_Cb_row14] <;> norm_num
+  )
+
 lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
   C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by
-  let Cb_6 : ℕ → ℝ := fun j ↦
-    if j = 1 then 2.01560e-4
-    else if j = 2 then 4.96540e-3
-    else if j = 3 then 1.22330e-1
-    else if j = 4 then 3.01350e0
-    else 7.42380e1
-  have h_row6_mem : (log (5 * 10 ^ 10), Cb_6 1, Cb_6 2, Cb_6 3, Cb_6 4, Cb_6 5, 0.88, 0.86, 32 * 10 ^ 12) ∈ table_12 := by
+  have h_row6_mem : (log (5 * 10 ^ 10), bklnw_Cb_row6 1, bklnw_Cb_row6 2, bklnw_Cb_row6 3, bklnw_Cb_row6 4, bklnw_Cb_row6 5, 0.88, 0.86, 32 * 10 ^ 12) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
     right; right; right; right; right
     left
-    dsimp [Cb_6]
-    simp
+    simp [bklnw_Cb_row6]
     constructor <;> norm_num
-  have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) Cb_6 h_row6_mem k hk
-  have h_Cb_le' : Cb_6 k ≤ Cb k := by
-    have h_simp := h
-    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h_simp
-    rcases h_simp with
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      h_false
-    all_goals
-      try contradiction
-      try (revert hM5; norm_num)
-    all_goals
-      refine Cb_ref_le_dispatch Cb Cb_6 ?_ ?_ ?_ ?_ ?_ k hk <;>
-        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_6] <;> norm_num
-  exact le_trans h_ver h_Cb_le'
+  have h_ver := bklnw_table_12_verification (log (5 * 10 ^ 10)) 0.88 0.86 (32 * 10 ^ 12) bklnw_Cb_row6 h_row6_mem k hk
+  exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).1 hM5)
 
 -- Rows in table_12 with M ≠ 10^19 all have Cb values ≥ row 14's Cb values
 private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
     (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM : M ≠ 10 ^ 19) :
     C_bk (log (32 * 10 ^ 12)) 0.94 0.94 RS_prime.c₀ k ≤ Cb k := by
-  let Cb_14 : ℕ → ℝ := fun j ↦
-    if j = 1 then 1.02600e-5
-    else if j = 2 then 3.19040e-4
-    else if j = 3 then 9.92090e-3
-    else if j = 4 then 3.08510e-1
-    else 9.59360e0
-  have h_row14_mem : (log (32 * 10 ^ 12), Cb_14 1, Cb_14 2, Cb_14 3, Cb_14 4, Cb_14 5, 0.94, 0.94, 10 ^ 19) ∈ table_12 := by
+  have h_row14_mem : (log (32 * 10 ^ 12), bklnw_Cb_row14 1, bklnw_Cb_row14 2, bklnw_Cb_row14 3, bklnw_Cb_row14 4, bklnw_Cb_row14 5, 0.94, 0.94, 10 ^ 19) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
     right; right; right; right; right; right; right; right; right; right; right; right; right
     left
-    dsimp [Cb_14]
-    simp
+    simp [bklnw_Cb_row14]
     constructor <;> norm_num
-  have h_ver := bklnw_table_12_verification (log (32 * 10 ^ 12)) 0.94 0.94 (10 ^ 19) Cb_14 h_row14_mem k hk
-  have h_Cb_le' : Cb_14 k ≤ Cb k := by
-    have h_simp := h
-    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h_simp
-    rcases h_simp with
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ | ⟨rfl, hCb1, hCb2, hCb3, hCb4, hCb5, rfl, rfl, rfl⟩ |
-      h_false
-    all_goals
-      try contradiction
-      try (revert hM; norm_num)
-    all_goals
-      refine Cb_ref_le_dispatch Cb Cb_14 ?_ ?_ ?_ ?_ ?_ k hk <;>
-        simp only [hCb1, hCb2, hCb3, hCb4, hCb5, Cb_14] <;> norm_num
-  exact le_trans h_ver h_Cb_le'
+  have h_ver := bklnw_table_12_verification (log (32 * 10 ^ 12)) 0.94 0.94 (10 ^ 19) bklnw_Cb_row14 h_row14_mem k hk
+  exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).2 hM)
 
 @[blueprint
   "bklnw-corollary-9-1-explicit"

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1772,6 +1772,112 @@ theorem bklnw_corollary_9_1 (k : ℕ) (v c C b : ℝ) (hvcc : (100, v, c, C) ∈
 theorem bklnw_table_12_verification (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k := by
   sorry
 
+-- Every row of table_12 lies in table_from_buthe (same (c, C, M) parameters)
+private lemma table_12_mem_buthe (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
+    ((100 : ℝ), M, c, C) ∈ table_from_buthe := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h
+  all_goals
+    try contradiction
+    try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
+    try norm_num
+
+-- Every row of table_12 satisfies exp b ≤ M (the b column is log of the range's lower bound)
+private lemma table_12_expb_le_M (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : exp b ≤ M := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h
+  all_goals
+    try contradiction
+    try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
+                   Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
+    try grw [← exp_one_rpow, Real.exp_one_lt_d9]
+    try norm_num
+
+-- Every row of table_12 satisfies 10000 ≤ exp b (b ≥ log(5e10) ≈ 24.6 so exp b ≥ 5e10 ≫ 10000)
+private lemma table_12_10000_le_expb (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
+    (10000 : ℝ) ≤ exp b := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h
+  all_goals
+    try contradiction
+    try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
+                   Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
+    try (
+      rw [← exp_one_rpow]
+      refine le_trans ?_ (rpow_le_rpow (by norm_num) exp_one_gt_d9.le (by norm_num))
+    )
+    try norm_num
+
+-- Every row of table_12 satisfies 10 ≤ b (minimum b is 20 or log(5e10) ≈ 24.6)
+private lemma table_12_ten_le_b (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : (10 : ℝ) ≤ b := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h
+  all_goals
+    try contradiction
+    try (rw [Real.le_log_iff_exp_le (by norm_num)];
+         grw [← exp_one_rpow 10, Real.exp_one_lt_d9])
+    try norm_num
+
 -- Transfers a C_bk analytical bound to the tabulated Cb bound in the final inequality
 private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
     (hx_pos : 0 < x) (h_log_pos : 0 < log x ^ k)
@@ -1790,6 +1896,33 @@ private lemma exp_two_k_le_exp_ten (k : ℕ) (hk : k ∈ Finset.Icc 1 5) :
   apply Real.exp_le_exp.mpr
   have : (k : ℝ) ≤ 5 := by exact_mod_cast (Finset.mem_Icc.mp hk).2
   linarith
+
+-- The only M values in table_12 are 5e10, 32e12, 10^19; ruling out two forces the third
+private lemma table_12_M_eq_32e12 (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
+    (hM : M ≠ 10 ^ 19) (hM5 : M ≠ 5 * 10 ^ 10) :
+    M = 32 * 10 ^ 12 := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h_false
+  all_goals
+    try contradiction
+    try (revert hM5; norm_num)
+    try (revert hM; norm_num)
+    try rfl
 
 -- Every b-value in table_12 is positive (smallest is log(5e10) ≈ 24.6)
 private lemma table_12_b_pos (b c C M : ℝ) (Cb : ℕ → ℝ)
@@ -1921,113 +2054,16 @@ private lemma bklnw_row14_le (b c C M : ℝ) (Cb : ℕ → ℝ)
 theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
   ∀ x ∈ Set.Ico (exp b) (10 ^ 19), ∀ k ∈ Finset.Icc 1 5, θ x - x ≥ - Cb k * x / (log x)^k := by
   -- Step 1. Every row of table_12 satisfies (100, M, c, C) ∈ table_from_buthe.
-  -- Proof: case-split on all 26 rows via `simp [BKLNW.table_12, table_from_buthe]` + `rcases`.
-  have h_buthe : ((100 : ℝ), M, c, C) ∈ table_from_buthe := by
-    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-    rcases h with
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      h
-    all_goals
-      try contradiction
-      try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-      try norm_num
-  -- Step 2. Every row has e^b ≤ M (the last column is the Buthe range upper bound).
-  -- Proof: same case-split as Step 1; each row has b ≤ log M, so exp b ≤ M.
-  have h_expb_le_M : exp b ≤ M := by
-    simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-    rcases h with
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-      h
-    all_goals
-      try contradiction
-      try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
-                     Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
-      try grw [← exp_one_rpow, Real.exp_one_lt_d9]
-      try norm_num
+  have h_buthe : ((100 : ℝ), M, c, C) ∈ table_from_buthe := table_12_mem_buthe b c C M Cb h
+  -- Step 2. Every row has e^b ≤ M.
+  have h_expb_le_M : exp b ≤ M := table_12_expb_le_M b c C M Cb h
   -- Step 3. Every row has max(10000, exp(2k)) ≤ exp(b) for all k ∈ {1,...,5}.
-  -- Proof: each row has b ≥ 20 ≥ 10 ≥ 2k for k ≤ 5, and exp(20) ≥ 10000. Case-split on rows.
   have h_expb_lb : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
-      max (10000 : ℝ) (exp (2 * (k : ℝ))) ≤ exp b := by
-    intro k hk
-    simp only [Finset.mem_Icc] at hk
-    have hk5 : (k : ℝ) ≤ 5 := by norm_cast; exact hk.2
+      max (10000 : ℝ) (exp (2 * (k : ℝ))) ≤ exp b := fun k hk => by
     rw [max_le_iff]
-    constructor
-    · simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-      rcases h with
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        h
-      all_goals
-        try contradiction
-        try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
-                       Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
-        try (
-          rw [← exp_one_rpow]
-          refine le_trans ?_ (rpow_le_rpow (by norm_num) exp_one_gt_d9.le (by norm_num))
-        )
-        try norm_num
-    · apply Real.exp_le_exp.mpr
-      simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-      rcases h with
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-        h
-      all_goals
-        try contradiction
-        try (
-          rw [Real.le_log_iff_exp_le (by norm_num)]
-          refine le_trans (exp_two_k_le_exp_ten k (Finset.mem_Icc.mpr hk)) ?_
-          grw [← exp_one_rpow 10, Real.exp_one_lt_d9]
-        )
-        try linarith
-        try norm_num
+    exact ⟨table_12_10000_le_expb b c C M Cb h,
+           le_trans (exp_two_k_le_exp_ten k hk)
+                    (Real.exp_le_exp.mpr (table_12_ten_le_b b c C M Cb h))⟩
   -- Step 4. Apply bklnw_corollary_9_1 to get the ≥ bound on [exp b, M].
   -- This is the key application: θ x ≥ x - C_bk b c C c₀ k * x / (log x)^k for x ∈ [exp b, M].
   have h_cor_9_1 : ∀ k : ℕ, k ∈ Finset.Icc 1 5 →
@@ -2108,37 +2144,7 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
           exact theta_sub_ge_of_cbk_le x _ _ k hx_pos h_log_pos h_theta_ge_rw h_const_le
       · -- Case 3: M = 32e12 (since M ≠ 10^19 and M ≠ 5e10)
         -- We apply bklnw_corollary_9_1 to row 14 (b = log 32e12, M = 10^19).
-        have h_M_eq : M = 32 * 10 ^ 12 := by
-          -- M must be 32e12
-          simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-          rcases h with
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-            h_false
-          all_goals
-            try contradiction
-            try (revert hM5; norm_num)
-            try (revert hM; norm_num)
-            try rfl
+        have h_M_eq : M = 32 * 10 ^ 12 := table_12_M_eq_32e12 b c C M Cb h hM hM5
         have hx_gt32 : x > 32 * 10 ^ 12 := by
           rw [← h_M_eq]
           exact hx_gt

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1858,23 +1858,22 @@ private noncomputable def bklnw_M_row14 : ℝ := table_12_row_M ⟨13, by decide
 local macro "eval_table_12" : tactic =>
   `(tactic| (
     simp only [
-      bklnw_b_row6, bklnw_c_row6, bklnw_C_row6, bklnw_M_row6,
-      bklnw_b_row14, bklnw_c_row14, bklnw_C_row14, bklnw_M_row14,
-      table_12_row_b, table_12_row_c, table_12_row_C, table_12_row_M,
+      bklnw_b_row6, bklnw_Cb_row6, bklnw_c_row6, bklnw_C_row6, bklnw_M_row6,
+      bklnw_b_row14, bklnw_Cb_row14, bklnw_c_row14, bklnw_C_row14, bklnw_M_row14,
+      table_12_row_b, table_12_row_Cb, table_12_row_c, table_12_row_C, table_12_row_M,
       table_12, List.get
     ]
-    try norm_num
   ))
 
-private lemma bklnw_b_row6_eq : bklnw_b_row6 = log (5 * 10 ^ 10) := by eval_table_12
-private lemma bklnw_c_row6_eq : bklnw_c_row6 = 0.88 := by eval_table_12
-private lemma bklnw_C_row6_eq : bklnw_C_row6 = 0.86 := by eval_table_12
-private lemma bklnw_M_row6_eq : bklnw_M_row6 = 32 * 10 ^ 12 := by eval_table_12
-
-private lemma bklnw_b_row14_eq : bklnw_b_row14 = log (32 * 10 ^ 12) := by eval_table_12
-private lemma bklnw_c_row14_eq : bklnw_c_row14 = 0.94 := by eval_table_12
-private lemma bklnw_C_row14_eq : bklnw_C_row14 = 0.94 := by eval_table_12
-private lemma bklnw_M_row14_eq : bklnw_M_row14 = 10 ^ 19 := by eval_table_12
+local macro "eval_table_12_at_all" : tactic =>
+  `(tactic| (
+    simp only [
+      bklnw_b_row6, bklnw_Cb_row6, bklnw_c_row6, bklnw_C_row6, bklnw_M_row6,
+      bklnw_b_row14, bklnw_Cb_row14, bklnw_c_row14, bklnw_C_row14, bklnw_M_row14,
+      table_12_row_b, table_12_row_Cb, table_12_row_c, table_12_row_C, table_12_row_M,
+      table_12, List.get
+    ] at *
+  ))
 
 private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)
@@ -1904,9 +1903,7 @@ lemma C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten (b c C M : ℝ) (Cb : ℕ → ℝ)
   C_bk bklnw_b_row6 bklnw_c_row6 bklnw_C_row6 RS_prime.c₀ k ≤ Cb k := by
   have h_row6_mem : (bklnw_b_row6, bklnw_Cb_row6 1, bklnw_Cb_row6 2, bklnw_Cb_row6 3, bklnw_Cb_row6 4, bklnw_Cb_row6 5, bklnw_c_row6, bklnw_C_row6, bklnw_M_row6) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    unfold bklnw_b_row6 bklnw_Cb_row6 bklnw_c_row6 bklnw_C_row6 bklnw_M_row6 table_12_row_b table_12_row_Cb table_12_row_c table_12_row_C table_12_row_M
-    simp only [table_12, List.get]
-    repeat (first | (left; constructor <;> (first | rfl | norm_num); done) | right)
+    eval_table_12; norm_num
   have h_ver := bklnw_table_12_verification bklnw_b_row6 bklnw_c_row6 bklnw_C_row6 bklnw_M_row6 bklnw_Cb_row6 h_row6_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).1 hM5)
 
@@ -1916,9 +1913,7 @@ private lemma C_bk_le_Cb_of_M_ne_ten_pow_nineteen (b c C M : ℝ) (Cb : ℕ → 
     C_bk bklnw_b_row14 bklnw_c_row14 bklnw_C_row14 RS_prime.c₀ k ≤ Cb k := by
   have h_row14_mem : (bklnw_b_row14, bklnw_Cb_row14 1, bklnw_Cb_row14 2, bklnw_Cb_row14 3, bklnw_Cb_row14 4, bklnw_Cb_row14 5, bklnw_c_row14, bklnw_C_row14, bklnw_M_row14) ∈ table_12 := by
     simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    unfold bklnw_b_row14 bklnw_Cb_row14 bklnw_c_row14 bklnw_C_row14 bklnw_M_row14 table_12_row_b table_12_row_Cb table_12_row_c table_12_row_C table_12_row_M
-    simp only [table_12, List.get]
-    repeat (first | (left; constructor <;> (first | rfl | norm_num); done) | right)
+    eval_table_12; norm_num
   have h_ver := bklnw_table_12_verification bklnw_b_row14 bklnw_c_row14 bklnw_C_row14 bklnw_M_row14 bklnw_Cb_row14 h_row14_mem k hk
   exact le_trans h_ver ((table_12_Cb_bounds b c C M Cb h k hk).2 hM)
 
@@ -1958,14 +1953,13 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
     · by_cases hM5 : M = 5 * 10 ^ 10
       · by_cases hx32 : x ≤ bklnw_M_row6
         · have hx_in_Icc6 : x ∈ Set.Icc (exp bklnw_b_row6) bklnw_M_row6 := by
-            rw [bklnw_b_row6_eq, bklnw_M_row6_eq] at *
+            eval_table_12_at_all
             rw [Real.exp_log (by norm_num)]; exact ⟨by linarith, hx32⟩
           have h_cor_9_1_row6 := bklnw_corollary_9_1 k bklnw_M_row6 bklnw_c_row6 bklnw_C_row6 bklnw_b_row6
-            (by rw [bklnw_M_row6_eq, bklnw_c_row6_eq, bklnw_C_row6_eq]
-                simp [table_from_buthe])
-            (by rw [bklnw_M_row6_eq, bklnw_b_row6_eq]
+            (by eval_table_12; simp [table_from_buthe]; norm_num)
+            (by eval_table_12
                 rw [Real.exp_log (by norm_num)]
-                simp only [max_le_iff]
+                try simp only [max_le_iff]
                 refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
                 grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
           have hx_pos : (0 : ℝ) < x := by linarith
@@ -1975,15 +1969,14 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
             (by linarith [h_cor_9_1_row6 x hx_in_Icc6])
             (C_bk_le_Cb_of_M_eq_five_mul_ten_pow_ten b c C M Cb h k hk hM5)
         · have hx_in_Icc14 : x ∈ Set.Icc (exp bklnw_b_row14) bklnw_M_row14 := by
-            rw [bklnw_b_row14_eq, bklnw_M_row6_eq, bklnw_M_row14_eq] at *
+            eval_table_12_at_all
             rw [Real.exp_log (by norm_num)]
-            exact ⟨(not_le.mp hx32).le, hx.2.le⟩
+            exact ⟨(not_le.mp hx32).le, by linarith [hx.2]⟩
           have h_cor_9_1_row14 := bklnw_corollary_9_1 k bklnw_M_row14 bklnw_c_row14 bklnw_C_row14 bklnw_b_row14
-            (by rw [bklnw_M_row14_eq, bklnw_c_row14_eq, bklnw_C_row14_eq]
-                simp [table_from_buthe])
-            (by rw [bklnw_M_row14_eq, bklnw_b_row14_eq]
+            (by eval_table_12; simp [table_from_buthe]; norm_num)
+            (by eval_table_12
                 rw [Real.exp_log (by norm_num)]
-                simp only [max_le_iff]
+                try simp only [max_le_iff]
                 refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
                 grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
           have hx_pos : (0 : ℝ) < x := by linarith
@@ -1993,22 +1986,21 @@ theorem bklnw_corollary_9_1_explicit (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b,
             (by linarith [h_cor_9_1_row14 x hx_in_Icc14])
             (C_bk_le_Cb_of_M_ne_ten_pow_nineteen b c C M Cb h k hk (by rw [hM5]; norm_num))
       · have h_M_eq : M = bklnw_M_row6 := by
-          rw [bklnw_M_row6_eq]
+          eval_table_12
           rcases h_M_vals with rfl | rfl | rfl
           · exact absurd rfl hM5
-          · rfl
+          · norm_num
           · exact absurd rfl hM
         have hx_gt32 : x > bklnw_M_row6 := h_M_eq ▸ hx_gt
         have hx_in_Icc14 : x ∈ Set.Icc (exp bklnw_b_row14) bklnw_M_row14 := by
-          rw [bklnw_b_row14_eq, bklnw_M_row6_eq, bklnw_M_row14_eq] at *
+          eval_table_12_at_all
           rw [Real.exp_log (by norm_num)]
-          exact ⟨hx_gt32.le, hx.2.le⟩
+          exact ⟨hx_gt32.le, by linarith [hx.2]⟩
         have h_cor_9_1_row14 := bklnw_corollary_9_1 k bklnw_M_row14 bklnw_c_row14 bklnw_C_row14 bklnw_b_row14
-          (by rw [bklnw_M_row14_eq, bklnw_c_row14_eq, bklnw_C_row14_eq]
-              simp [table_from_buthe])
-          (by rw [bklnw_M_row14_eq, bklnw_b_row14_eq]
+          (by eval_table_12; simp [table_from_buthe]; norm_num)
+          (by eval_table_12
               rw [Real.exp_log (by norm_num)]
-              simp only [max_le_iff]
+              try simp only [max_le_iff]
               refine ⟨⟨by norm_num, le_trans (exp_two_k_le_exp_ten k hk) ?_⟩, by norm_num⟩
               grw [← exp_one_rpow 10, Real.exp_one_lt_d9]; norm_num)
         have hx_pos : (0 : ℝ) < x := by linarith

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1772,111 +1772,58 @@ theorem bklnw_corollary_9_1 (k : ℕ) (v c C b : ℝ) (hvcc : (100, v, c, C) ∈
 theorem bklnw_table_12_verification (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : ∀ k ∈ Finset.Icc 1 5, C_bk b c C RS_prime.c₀ k ≤ Cb k := by
   sorry
 
--- Every row of table_12 lies in table_from_buthe (same (c, C, M) parameters)
+-- Bundles five basic properties of table_12 rows, avoiding six separate 26-case dispatches
+private lemma table_12_basic_props (b c C M : ℝ) (Cb : ℕ → ℝ)
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
+    ((100 : ℝ), M, c, C) ∈ table_from_buthe ∧
+    exp b ≤ M ∧ (10000 : ℝ) ≤ exp b ∧ (10 : ℝ) ≤ b ∧ 0 < b := by
+  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
+  rcases h with
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
+    h
+  -- union of all_goals closers from the five individual lemmas
+  all_goals try contradiction
+  all_goals try refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  all_goals try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
+  all_goals try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
+                            Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
+  all_goals try grw [← exp_one_rpow, Real.exp_one_lt_d9]
+  all_goals try (rw [← exp_one_rpow]
+                 refine le_trans ?_ (rpow_le_rpow (by norm_num) exp_one_gt_d9.le (by norm_num)))
+  all_goals try (rw [Real.le_log_iff_exp_le (by norm_num)]
+                 grw [← exp_one_rpow 10, Real.exp_one_lt_d9])
+  all_goals try (apply Real.log_pos; norm_num)
+  all_goals try norm_num
+
 private lemma table_12_mem_buthe (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
-    ((100 : ℝ), M, c, C) ∈ table_from_buthe := by
-  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨-, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h
-  all_goals
-    try contradiction
-    try simp only [table_from_buthe, List.mem_cons, List.not_mem_nil, Prod.mk.injEq]
-    try norm_num
+    ((100 : ℝ), M, c, C) ∈ table_from_buthe :=
+  (table_12_basic_props b c C M Cb h).1
 
--- Every row of table_12 satisfies exp b ≤ M (the b column is log of the range's lower bound)
 private lemma table_12_expb_le_M (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : exp b ≤ M := by
-  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h
-  all_goals
-    try contradiction
-    try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
-                   Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
-    try grw [← exp_one_rpow, Real.exp_one_lt_d9]
-    try norm_num
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : exp b ≤ M :=
+  (table_12_basic_props b c C M Cb h).2.1
 
--- Every row of table_12 satisfies 10000 ≤ exp b (b ≥ log(5e10) ≈ 24.6 so exp b ≥ 5e10 ≫ 10000)
 private lemma table_12_10000_le_expb (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) :
-    (10000 : ℝ) ≤ exp b := by
-  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h
-  all_goals
-    try contradiction
-    try simp only [Real.exp_log (show (0 : ℝ) < 5e10 by norm_num),
-                   Real.exp_log (show (0 : ℝ) < 32e12 by norm_num)]
-    try (
-      rw [← exp_one_rpow]
-      refine le_trans ?_ (rpow_le_rpow (by norm_num) exp_one_gt_d9.le (by norm_num))
-    )
-    try norm_num
+    (10000 : ℝ) ≤ exp b :=
+  (table_12_basic_props b c C M Cb h).2.2.1
 
--- Every row of table_12 satisfies 10 ≤ b (minimum b is 20 or log(5e10) ≈ 24.6)
 private lemma table_12_ten_le_b (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : (10 : ℝ) ≤ b := by
-  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h
-  all_goals
-    try contradiction
-    try (rw [Real.le_log_iff_exp_le (by norm_num)];
-         grw [← exp_one_rpow 10, Real.exp_one_lt_d9])
-    try norm_num
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : (10 : ℝ) ≤ b :=
+  (table_12_basic_props b c C M Cb h).2.2.2.1
 
 -- Transfers a C_bk analytical bound to the tabulated Cb bound in the final inequality
 private lemma theta_sub_ge_of_cbk_le (x cbk cb : ℝ) (k : ℕ)
@@ -1924,29 +1871,9 @@ private lemma table_12_M_eq_32e12 (b c C M : ℝ) (Cb : ℕ → ℝ)
     try (revert hM; norm_num)
     try rfl
 
--- Every b-value in table_12 is positive (smallest is log(5e10) ≈ 24.6)
 private lemma table_12_b_pos (b c C M : ℝ) (Cb : ℕ → ℝ)
-    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : 0 < b := by
-  simp only [table_12, List.mem_cons, List.not_mem_nil, Prod.mk.injEq] at h
-  rcases h with
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ | ⟨rfl, -, -, -, -, -, rfl, rfl, rfl⟩ |
-    h
-  all_goals
-    try contradiction
-    try (apply Real.log_pos; norm_num)
-    try norm_num
+    (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) : 0 < b :=
+  (table_12_basic_props b c C M Cb h).2.2.2.2
 
 lemma bklnw_case1_helper (b c C M : ℝ) (Cb : ℕ → ℝ) (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12) (k : ℕ) (hk : k ∈ Finset.Icc 1 5) (hM5 : M = 5 * 10 ^ 10) :
   C_bk (log (5 * 10 ^ 10)) 0.88 0.86 RS_prime.c₀ k ≤ Cb k := by

--- a/PrimeNumberTheoremAnd/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/BKLNW.lean
@@ -1855,23 +1855,26 @@ private noncomputable def bklnw_c_row14 : ℝ := table_12_row_c ⟨13, by decide
 private noncomputable def bklnw_C_row14 : ℝ := table_12_row_C ⟨13, by decide⟩
 private noncomputable def bklnw_M_row14 : ℝ := table_12_row_M ⟨13, by decide⟩
 
-private lemma bklnw_b_row6_eq : bklnw_b_row6 = log (5 * 10 ^ 10) := by
-  unfold bklnw_b_row6 table_12_row_b; simp only [table_12, List.get]; try norm_num
-private lemma bklnw_c_row6_eq : bklnw_c_row6 = 0.88 := by
-  unfold bklnw_c_row6 table_12_row_c; simp only [table_12, List.get]; try norm_num
-private lemma bklnw_C_row6_eq : bklnw_C_row6 = 0.86 := by
-  unfold bklnw_C_row6 table_12_row_C; simp only [table_12, List.get]; try norm_num
-private lemma bklnw_M_row6_eq : bklnw_M_row6 = 32 * 10 ^ 12 := by
-  unfold bklnw_M_row6 table_12_row_M; simp only [table_12, List.get]; try norm_num
+local macro "eval_table_12" : tactic =>
+  `(tactic| (
+    simp only [
+      bklnw_b_row6, bklnw_c_row6, bklnw_C_row6, bklnw_M_row6,
+      bklnw_b_row14, bklnw_c_row14, bklnw_C_row14, bklnw_M_row14,
+      table_12_row_b, table_12_row_c, table_12_row_C, table_12_row_M,
+      table_12, List.get
+    ]
+    try norm_num
+  ))
 
-private lemma bklnw_b_row14_eq : bklnw_b_row14 = log (32 * 10 ^ 12) := by
-  unfold bklnw_b_row14 table_12_row_b; simp only [table_12, List.get]; try norm_num
-private lemma bklnw_c_row14_eq : bklnw_c_row14 = 0.94 := by
-  unfold bklnw_c_row14 table_12_row_c; simp only [table_12, List.get]; try norm_num
-private lemma bklnw_C_row14_eq : bklnw_C_row14 = 0.94 := by
-  unfold bklnw_C_row14 table_12_row_C; simp only [table_12, List.get]; try norm_num
-private lemma bklnw_M_row14_eq : bklnw_M_row14 = 10 ^ 19 := by
-  unfold bklnw_M_row14 table_12_row_M; simp only [table_12, List.get]; try norm_num
+private lemma bklnw_b_row6_eq : bklnw_b_row6 = log (5 * 10 ^ 10) := by eval_table_12
+private lemma bklnw_c_row6_eq : bklnw_c_row6 = 0.88 := by eval_table_12
+private lemma bklnw_C_row6_eq : bklnw_C_row6 = 0.86 := by eval_table_12
+private lemma bklnw_M_row6_eq : bklnw_M_row6 = 32 * 10 ^ 12 := by eval_table_12
+
+private lemma bklnw_b_row14_eq : bklnw_b_row14 = log (32 * 10 ^ 12) := by eval_table_12
+private lemma bklnw_c_row14_eq : bklnw_c_row14 = 0.94 := by eval_table_12
+private lemma bklnw_C_row14_eq : bklnw_C_row14 = 0.94 := by eval_table_12
+private lemma bklnw_M_row14_eq : bklnw_M_row14 = 10 ^ 19 := by eval_table_12
 
 private lemma table_12_Cb_bounds (b c C M : ℝ) (Cb : ℕ → ℝ)
     (h : (b, Cb 1, Cb 2, Cb 3, Cb 4, Cb 5, c, C, M) ∈ BKLNW.table_12)


### PR DESCRIPTION
Co-authored with Gemini 3 and Claude.

Notes:
- Changed strict inequality `θ x - x > - Cb k * x / (log x)^k` to non-strict in both blueprint and lean statement. See [discussion](https://leanprover.zulipchat.com/#narrow/channel/423402-PrimeNumberTheorem.2B/topic/Starting.20on.20BKLNW/near/596203538)

Closes #1264