### PR TITLE
fix: close E₁Λ.bounded sorry in Mertens.lean

### DIFF
--- a/PrimeNumberTheoremAnd/Mertens.lean
+++ b/PrimeNumberTheoremAnd/Mertens.lean
@@ -376,7 +376,9 @@ theorem E₁Λ.bounded' : ∃ c > 0, ∀ x ≥ 1, |E₁Λ x| ≤ c := by
   "Mertens-first-error-mangoldt"
   (discussion := 1309)]
 theorem E₁Λ.bounded : E₁Λ =O[atTop] (fun _ ↦ (1:ℝ)) := by
-    sorry
+  simp only [isBigO_iff, norm_eq_abs, norm_one, mul_one,
+    eventually_atTop, ge_iff_le]
+  exact ⟨log 4 + 4, 1, fun _ hx ↦ sum_mangoldt_div_eq_log hx⟩
 
 theorem one_eq_o_log : (fun _ ↦ (1:ℝ)) =o[atTop] (fun x ↦ log x) := by
     simp only [isLittleO_one_left_iff, norm_eq_abs]


### PR DESCRIPTION
## Summary

Replaces the `sorry` in `E₁Λ.bounded` (Mertens.lean:379) with a 3-line proof.

## Proof

```lean
theorem E₁Λ.bounded : E₁Λ =O[atTop] (fun _ ↦ (1:ℝ)) := by
  simp only [isBigO_iff, norm_eq_abs, norm_one, mul_one,
    eventually_atTop, ge_iff_le]
  exact ⟨log 4 + 4, 1, fun _ hx ↦ sum_mangoldt_div_eq_log hx⟩
```

## Key lemma used

`sum_mangoldt_div_eq_log` (Mertens.lean:366–368, already proved without sorry):
```lean
theorem sum_mangoldt_div_eq_log {x : ℝ} (hx : 1 ≤ x) :
    |∑ d ∈ Ioc 0 ⌊ x ⌋₊, (Λ d) / d - log x| ≤ log 4 + 4 := by
  grind [E₁Λ.le hx, E₁Λ.ge hx, log_nonneg]
```

Since `E₁Λ` is a `noncomputable abbrev`, `|E₁Λ x| ≤ log 4 + 4` is definitionally equal to the LHS above. This gives `E₁Λ =O[atTop] (fun _ ↦ 1)` by taking constant `log 4 + 4` and scale `N = 1`.

## Axiom check

`#print axioms E₁Λ.bounded` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).

## Note

`E₁.le` (line 486) remains sorry; this PR does not touch it. The proof here uses only `E₁Λ.le` and `E₁Λ.ge` (both proved), not `E₁.le`.