### PR TITLE
fix: close 3 IwaniecKowalskiCh1 sorrys (divisors_mul_injective, isCompletelyMultiplicative_liouville, liouville_eq_moebius_on_squarefree)

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -72,7 +72,26 @@ lemma IsCompletelyAdditive.isAdditive [AddZeroClass R] {f : ArithmeticFunction R
   -/)]
 lemma unique_divisor_decomposition {a b d : ℕ} (hab : Coprime a b) (hd : d ∣ a * b) :
     ∃! p : ℕ × ℕ, p.1 ∣ a ∧ p.2 ∣ b ∧ p.1 * p.2 = d := by
-  sorry -- UPSTREAMED TO MATHLIB #36495
+  refine ⟨(d.gcd a, d.gcd b), ⟨?_, ?_, ?_⟩, ?_⟩
+  · exact Nat.gcd_dvd_right d a
+  · exact Nat.gcd_dvd_right d b
+  · exact (Nat.gcd_mul_gcd_eq_iff_dvd_mul_of_coprime hab).mpr hd
+  · rintro ⟨q₁, q₂⟩ ⟨hq₁a, hq₂b, hq⟩
+    simp only [Prod.mk.injEq]
+    constructor
+    · apply Nat.dvd_antisymm
+      · exact Nat.dvd_gcd (hq ▸ Nat.dvd_mul_right q₁ q₂) hq₁a
+      · have hgda_dvd_q1q2 : d.gcd a ∣ q₁ * q₂ := hq ▸ Nat.gcd_dvd_left d a
+        have hcoprime_gda_q2 : Nat.Coprime (d.gcd a) q₂ :=
+          Nat.Coprime.of_dvd_right hq₂b (Nat.Coprime.of_dvd_left (Nat.gcd_dvd_right d a) hab)
+        exact hcoprime_gda_q2.dvd_of_dvd_mul_right hgda_dvd_q1q2
+    · apply Nat.dvd_antisymm
+      · exact Nat.dvd_gcd (hq ▸ Nat.dvd_mul_left q₂ q₁) hq₂b
+      · have hgdb_dvd_q1q2 : d.gcd b ∣ q₁ * q₂ := hq ▸ Nat.gcd_dvd_left d b
+        have hcoprime_gdb_q1 : Nat.Coprime (d.gcd b) q₁ :=
+          Nat.Coprime.of_dvd_right hq₁a (Nat.Coprime.of_dvd_right (Nat.gcd_dvd_right d b) hab).symm
+        rw [mul_comm] at hgdb_dvd_q1q2
+        exact hcoprime_gdb_q1.dvd_of_dvd_mul_right hgdb_dvd_q1q2
 
 /-- If `f` is a multiplicative arithmetic function, then for coprime `a` and `b`, we have $\sum_{d | ab} f(d) = (\sum_{d | a} f(d)) \cdot (\sum_{d | b} f(d))$. -/
 @[blueprint
@@ -91,7 +110,8 @@ theorem sum_divisors_mul_of_coprime {R : Type*} [CommRing R]
     {f : ArithmeticFunction R} (hf : f.IsMultiplicative)
     {a b : ℕ} (hab : Coprime a b) (ha : a ≠ 0) (hb : b ≠ 0) :
     ∑ d ∈ (a * b).divisors, f d = (∑ d ∈ a.divisors, f d) * (∑ d ∈ b.divisors, f d) := by
-  sorry -- UPSTREAMED TO MATHLIB #36495
+  simp only [← coe_mul_zeta_apply]
+  exact (hf.mul isMultiplicative_zeta.natCast).map_mul_of_coprime hab
 
 /-- If `g` is a multiplicative arithmetic function, then for any $n \neq 0$,
     $\sum_{d | n} \mu(d) \cdot g(d) = \prod_{p | n} (1 - g(p))$. -/

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -833,8 +833,23 @@ lemma pow_divisors_mul {m n k : ℕ} (hmn : Nat.Coprime m n) :
   -/)]
 lemma divisors_mul_injective {m n : ℕ} (hmn : m.Coprime n) :
     Set.InjOn (fun p : ℕ × ℕ => p.1 * p.2) (m.divisors ×ˢ n.divisors) := by
-  /-- comes from mathlib PR #36495 -/
-  sorry
+  intro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
+  simp only [Finset.coe_product, Set.mem_prod, Finset.mem_coe, Nat.mem_divisors] at h₁ h₂
+  obtain ⟨⟨ha₁, hm⟩, hb₁, _⟩ := h₁
+  obtain ⟨⟨ha₂, _⟩, hb₂, _⟩ := h₂
+  simp only at heq
+  have hcop_a₁_b₂ : Nat.Coprime a₁ b₂ :=
+    (hmn.coprime_dvd_left ha₁).coprime_dvd_right hb₂
+  have hcop_a₂_b₁ : Nat.Coprime a₂ b₁ :=
+    (hmn.coprime_dvd_left ha₂).coprime_dvd_right hb₁
+  have ha₁_dvd_a₂ : a₁ ∣ a₂ :=
+    hcop_a₁_b₂.dvd_of_dvd_mul_right (heq ▸ dvd_mul_right a₁ b₁)
+  have ha₂_dvd_a₁ : a₂ ∣ a₁ :=
+    hcop_a₂_b₁.dvd_of_dvd_mul_right (heq.symm ▸ dvd_mul_right a₂ b₂)
+  have ha : a₁ = a₂ := Nat.dvd_antisymm ha₁_dvd_a₂ ha₂_dvd_a₁
+  have ha₁_ne : a₁ ≠ 0 := ne_zero_of_dvd_ne_zero hm ha₁
+  have hb : b₁ = b₂ := Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero ha₁_ne) (ha ▸ heq)
+  exact Prod.ext ha hb
 
 @[blueprint
   "pow_divisors_mul_injective"
@@ -1001,8 +1016,27 @@ The Liouville function is completely multiplicative. -/
   (proof := /--
   The Liouville function $\lambda(n)$ is defined as $(-1)^{\Omega(n)}$, where $\Omega(n)$ counts the total number of prime factors of $n$ with multiplicity. To show that $\lambda$ is completely multiplicative, we need to verify that $\lambda(1) = 1$ and that $\lambda(ab) = \lambda(a)\lambda(b)$ for all natural numbers $a$ and $b$.
   -/)]
+private theorem liouville_mul_eq' (m n : ℕ) :
+    liouville (m * n) = liouville m * liouville n := by
+  show (if m * n = 0 then (0 : ℤ) else (-1 : ℤ) ^ Ω (m * n)) =
+       (if m = 0 then (0 : ℤ) else (-1 : ℤ) ^ Ω m) *
+       (if n = 0 then (0 : ℤ) else (-1 : ℤ) ^ Ω n)
+  by_cases hm : m = 0
+  · simp [hm]
+  · by_cases hn : n = 0
+    · simp [hn]
+    · have hmn : m * n ≠ 0 := mul_ne_zero hm hn
+      simp only [hm, hn, hmn, ↓reduceIte]
+      rw [cardFactors_mul hm hn, pow_add]
+
 lemma isCompletelyMultiplicative_liouville : IsCompletelyMultiplicative (liouville : ArithmeticFunction ℤ) := by
-  sorry
+  refine ⟨?_, fun m n => ?_⟩
+  · simp only [intCoe_apply]
+    norm_cast
+    show (if (1 : ℕ) = 0 then (0 : ℤ) else (-1 : ℤ) ^ Ω 1) = 1
+    simp [cardFactors_one]
+  · simp only [intCoe_apply]
+    exact_mod_cast liouville_mul_eq' m n
 
 /--
 The Dirichlet series of the Liouville function is `ζ(2s)/ζ(s)`. -/
@@ -1029,7 +1063,9 @@ lemma LSeries_liouville_eq {s : ℂ} (hs : 1 < s.re) :
   The Liouville function $\lambda(n)$ is defined as $(-1)^{\Omega(n)}$, where $\Omega(n)$ counts the total number of prime factors of $n$ with multiplicity. The Möbius function $\mu(n)$ is defined as $0$ if $n$ has a squared prime factor, and otherwise it is $(-1)^{\omega(n)}$, where $\omega(n)$ counts the number of distinct prime factors of $n$. For square-free numbers, we have $\Omega(n) = \omega(n)$, since there are no repeated prime factors. Therefore, for square-free numbers, we have $\lambda(n) = (-1)^{\omega(n)} = \mu(n)$, which shows that the Liouville function agrees with the Möbius function on square-free numbers.
   -/)]
 lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouville n = μ n := by
-  sorry
+  show (if n = 0 then (0 : ℤ) else (-1 : ℤ) ^ Ω n) = μ n
+  rw [if_neg hn.ne_zero]
+  exact (moebius_apply_of_squarefree hn).symm
 
 /-- Euler totient series: `∑ φ(n) n^-s = ζ(s-1)/ζ(s)`. -/
 @[blueprint


### PR DESCRIPTION
Closes 3 sorrys in `IwaniecKowalskiCh1.lean`:

1. `divisors_mul_injective`: injectivity of (a,b)↦a·b on m.divisors ×ˢ n.divisors for coprime m,n. Uses `Coprime.coprime_dvd_left/right` + `Nat.dvd_antisymm`.
2. `isCompletelyMultiplicative_liouville`: liouville is completely multiplicative. Uses `intCoe_apply` + `exact_mod_cast`.
3. `liouville_eq_moebius_on_squarefree`: liouville agrees with μ on squarefree n. Direct from `moebius_apply_of_squarefree`.

All proofs axiom-clean: `[propext, Classical.choice, Quot.sound]` only.

Depends on: PR #1419 (fix/ik-sum-divisors-coprime-sorry)