### PR TITLE
fix: close derivativeBound sorry in DerivativeBound.lean

### DIFF
--- a/PrimeNumberTheoremAnd/DerivativeBound.lean
+++ b/PrimeNumberTheoremAnd/DerivativeBound.lean
@@ -22,6 +22,13 @@ import Mathlib.Analysis.Analytic.Within
 import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.Analysis.Complex.AbsMax
 import PrimeNumberTheoremAnd.BorelCaratheodory
+import Mathlib.Analysis.Complex.Liouville
+import Mathlib.Analysis.Calculus.DiffContOnCl
+import Mathlib.Analysis.Analytic.Composition
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Comp
+
+open Complex Metric Real
 
 @[blueprint "DerivativeBound"
   (title := "DerivativeBound")
@@ -53,4 +60,67 @@ theorem derivativeBound {R M r r' : ℝ} {z : ℂ} {f : ℂ → ℂ}
     (analytic_f : AnalyticOn ℂ f (Metric.closedBall 0 R)) (f_zero_at_zero : f 0 = 0)
     (re_f_le_M : ∀ z ∈ Metric.closedBall 0 R, (f z).re ≤ M) (pos_r : 0 < r)
     (z_in_r : z ∈ Metric.closedBall 0 r) (r_le_r' : r < r') (r'_le_R : r' < R) :
-    ‖(deriv f) z‖ ≤ 2 * M * (r')^2 / ((R - r') * (r' - r)^2) := by sorry
+    ‖(deriv f) z‖ ≤ 2 * M * (r')^2 / ((R - r') * (r' - r)^2) := by
+  have pos_r' : (0 : ℝ) < r' := lt_trans pos_r r_le_r'
+  have pos_rr : (0 : ℝ) < r' - r := sub_pos.mpr r_le_r'
+  have pos_Rr' : (0 : ℝ) < R - r' := sub_pos.mpr r'_le_R
+  have M_nonneg : (0 : ℝ) ≤ M := by
+    have h0 := re_f_le_M 0 (mem_closedBall_self (by linarith))
+    simp only [f_zero_at_zero, Complex.zero_re] at h0; exact h0
+  have hz_norm : ‖z‖ ≤ r := by rwa [mem_closedBall, dist_zero_right] at z_in_r
+  set h := fun w : ℂ => f (z + w) with h_def
+  have translate_into_R : ∀ w ∈ ball 0 (R - r), z + w ∈ closedBall 0 R := by
+    intro w hw
+    rw [mem_closedBall, dist_zero_right]
+    have hw_norm : ‖w‖ < R - r := by rwa [mem_ball, dist_zero_right] at hw
+    calc ‖z + w‖ ≤ ‖z‖ + ‖w‖ := norm_add_le _ _
+      _ < r + (R - r) := by linarith
+      _ = R := by ring
+  have h_analytic : AnalyticOn ℂ h (ball 0 (R - r)) :=
+    analytic_f.comp (analyticOn_const.add analyticOn_id)
+      (fun w hw => translate_into_R w hw)
+  have h_diffContOnCl : DiffContOnCl ℂ h (ball 0 (r' - r)) :=
+    h_analytic.differentiableOn.diffContOnCl_ball
+      (closedBall_subset_ball (by linarith))
+  have h_hasDerivAt : HasDerivAt h (deriv f z) 0 := by
+    have z_in_ball_R : z ∈ ball 0 R := by rw [mem_ball, dist_zero_right]; linarith
+    have hfz : HasDerivAt f (deriv f z) z :=
+      (analytic_f.analyticAt (closedBall_mem_nhds_of_mem z_in_ball_R)).differentiableAt.hasDerivAt
+    have hadd : HasDerivAt (fun w : ℂ => z + w) 1 0 := (hasDerivAt_id (0 : ℂ)).const_add z
+    have hfz' : HasDerivAt f (deriv f z) (z + 0) := by simpa using hfz
+    simpa using hfz'.comp 0 hadd
+  have h_deriv_eq : deriv h 0 = deriv f z := h_hasDerivAt.deriv
+  have sphere_in_r' : ∀ w ∈ sphere 0 (r' - r), z + w ∈ closedBall 0 r' := by
+    intro w hw
+    rw [mem_closedBall, dist_zero_right]
+    have hw_norm : ‖w‖ = r' - r := by rwa [mem_sphere, dist_zero_right] at hw
+    calc ‖z + w‖ ≤ ‖z‖ + ‖w‖ := norm_add_le _ _
+      _ ≤ r + (r' - r) := by linarith [hw_norm.le]
+      _ = r' := by ring
+  have main_bound : ∀ M' : ℝ, 0 < M' →
+      (∀ w ∈ closedBall 0 R, (f w).re ≤ M') →
+      ‖deriv h 0‖ ≤ 2 * M' * r' / ((R - r') * (r' - r)) := fun M' hM'pos hM'le => by
+    have sphere_bound : ∀ w ∈ sphere 0 (r' - r), ‖h w‖ ≤ 2 * M' * r' / (R - r') := by
+      intro w hw; show ‖f (z + w)‖ ≤ 2 * M' * r' / (R - r')
+      exact borelCaratheodory_closedBall
+        (by linarith) analytic_f f_zero_at_zero hM'pos hM'le r'_le_R (sphere_in_r' w hw)
+    have cauchy := norm_deriv_le_of_forall_mem_sphere_norm_le pos_rr h_diffContOnCl sphere_bound
+    rw [div_div] at cauchy; linarith
+  rw [← h_deriv_eq]
+  rcases lt_or_eq_of_le M_nonneg with hMpos | rfl
+  · calc ‖deriv h 0‖
+        ≤ 2 * M * r' / ((R - r') * (r' - r)) := main_bound M hMpos re_f_le_M
+      _ ≤ 2 * M * r' ^ 2 / ((R - r') * (r' - r) ^ 2) := by
+          have key : 2 * M * r' ^ 2 / ((R - r') * (r' - r) ^ 2) =
+                     2 * M * r' / ((R - r') * (r' - r)) * (r' / (r' - r)) := by field_simp
+          rw [key]; apply le_mul_of_one_le_right (by positivity)
+          have hrr : r' / (r' - r) - 1 = r / (r' - r) := by field_simp; ring
+          linarith [div_nonneg pos_r.le pos_rr.le]
+  · simp only [mul_zero, zero_mul, zero_div]
+    apply le_of_forall_pos_le_add; intro δ hδ
+    set M' := δ * (R - r') * (r' - r) / (2 * r') with M'_def
+    have hM'pos : 0 < M' := by positivity
+    have hbound := main_bound M' hM'pos (fun w hw => (re_f_le_M w hw).trans hM'pos.le)
+    have heq : 2 * M' * r' / ((R - r') * (r' - r)) = δ := by
+      simp only [M'_def]; field_simp
+    linarith [heq ▸ hbound]

--- a/PrimeNumberTheoremAnd/DerivativeBound.lean
+++ b/PrimeNumberTheoremAnd/DerivativeBound.lean
@@ -74,7 +74,7 @@ theorem derivativeBound {R M r r' : ℝ} {z : ℂ} {f : ℂ → ℂ}
     rw [mem_closedBall, dist_zero_right]
     have hw_norm : ‖w‖ < R - r := by rwa [mem_ball, dist_zero_right] at hw
     calc ‖z + w‖ ≤ ‖z‖ + ‖w‖ := norm_add_le _ _
-      _ < r + (R - r) := by linarith
+      _ ≤ r + (R - r) := by linarith [hw_norm.le]
       _ = R := by ring
   have h_analytic : AnalyticOn ℂ h (ball 0 (R - r)) :=
     analytic_f.comp (analyticOn_const.add analyticOn_id)
@@ -101,7 +101,7 @@ theorem derivativeBound {R M r r' : ℝ} {z : ℂ} {f : ℂ → ℂ}
       (∀ w ∈ closedBall 0 R, (f w).re ≤ M') →
       ‖deriv h 0‖ ≤ 2 * M' * r' / ((R - r') * (r' - r)) := fun M' hM'pos hM'le => by
     have sphere_bound : ∀ w ∈ sphere 0 (r' - r), ‖h w‖ ≤ 2 * M' * r' / (R - r') := by
-      intro w hw; show ‖f (z + w)‖ ≤ 2 * M' * r' / (R - r')
+      intro w hw; change ‖f (z + w)‖ ≤ 2 * M' * r' / (R - r')
       exact borelCaratheodory_closedBall
         (by linarith) analytic_f f_zero_at_zero hM'pos hM'le r'_le_R (sphere_in_r' w hw)
     have cauchy := norm_deriv_le_of_forall_mem_sphere_norm_le pos_rr h_diffContOnCl sphere_bound
@@ -124,3 +124,4 @@ theorem derivativeBound {R M r r' : ℝ} {z : ℂ} {f : ℂ → ℂ}
     have heq : 2 * M' * r' / ((R - r') * (r' - r)) = δ := by
       simp only [M'_def]; field_simp
     linarith [heq ▸ hbound]
+


### PR DESCRIPTION
## Summary

Closes the `by sorry` in `PrimeNumberTheoremAnd/DerivativeBound.lean`.

## Proof strategy

Uses shift trick h(w) = f(z+w) to reduce to bounding the derivative at the center of a ball:
1. h analytic on ball 0 (R−r) via `AnalyticOn.comp` with translation
2. h DiffContOnCl on ball 0 (r'−r) via `diffContOnCl_ball`
3. HasDerivAt h (deriv f z) 0 via chain rule (h' = f'(z+0)·1)
4. On sphere 0 (r'−r): ‖f(z+w)‖ ≤ 2Mr'/(R−r') by `borelCaratheodory_closedBall`
5. ‖deriv h 0‖ ≤ bound/(r'−r) by `norm_deriv_le_of_forall_mem_sphere_norm_le`
6. Arithmetic: 2Mr'/((R−r')(r'−r)) ≤ 2M(r')²/((R−r')(r'−r)²) since r'/(r'−r) ≥ 1
7. M=0 edge case via `le_of_forall_pos_le_add` with M' = δ(R−r')(r'−r)/(2r')

## New imports added

- `Mathlib.Analysis.Complex.Liouville` (for `norm_deriv_le_of_forall_mem_sphere_norm_le`)
- `Mathlib.Analysis.Calculus.DiffContOnCl`
- `Mathlib.Analysis.Analytic.Composition` (for `AnalyticOn.comp`)
- `Mathlib.Analysis.Calculus.Deriv.Add` (for `HasDerivAt.const_add`)
- `Mathlib.Analysis.Calculus.Deriv.Comp` (for `HasDerivAt.comp`)

## Build evidence

Proof verified in separate experiment file `D100_DerivativeBound_gate_c.lean` (same statement, same proof, same PNTA package version v4.29.0):
```
info: 'D100Experiment.d100_derivativeBound_primary' depends on axioms: [propext, Classical.choice, Quot.sound]
```