### PR TITLE
Define `\mathlibok` and `\notready` in blueprint print preamble

### DIFF
--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -16,6 +16,8 @@
 \newcommand{\proves}[1]{}
 \newcommand{\lean}[1]{}
 \newcommand{\leanok}{}
+\newcommand{\mathlibok}{}
+\newcommand{\notready}{}
 \newcommand{\uses}[1]{}
 \newcommand{\discussion}[1]{}
 


### PR DESCRIPTION
`print.tex` was missing `\mathlibok` and `\notready`. Left undefined, they break `leanblueprint pdf` with an "Undefined control sequence" error. The web build already handles both via the leanblueprint plastex plugin.