### PR TITLE
feat(DerivativeBound): prove the sorry in derivativeBound

### DIFF
--- a/PrimeNumberTheoremAnd/DerivativeBound.lean
+++ b/PrimeNumberTheoremAnd/DerivativeBound.lean
@@ -22,6 +22,7 @@ import Mathlib.Analysis.Analytic.Within
 import Mathlib.Analysis.Normed.Group.Basic
 import Mathlib.Analysis.Complex.AbsMax
 import PrimeNumberTheoremAnd.BorelCaratheodory
+import PrimeNumberTheoremAnd.StrongPNT
 
 @[blueprint "DerivativeBound"
   (title := "DerivativeBound")
@@ -53,4 +54,40 @@ theorem derivativeBound {R M r r' : ℝ} {z : ℂ} {f : ℂ → ℂ}
     (analytic_f : AnalyticOn ℂ f (Metric.closedBall 0 R)) (f_zero_at_zero : f 0 = 0)
     (re_f_le_M : ∀ z ∈ Metric.closedBall 0 R, (f z).re ≤ M) (pos_r : 0 < r)
     (z_in_r : z ∈ Metric.closedBall 0 r) (r_le_r' : r < r') (r'_le_R : r' < R) :
-    ‖(deriv f) z‖ ≤ 2 * M * (r')^2 / ((R - r') * (r' - r)^2) := by sorry
+    ‖(deriv f) z‖ ≤ 2 * M * (r')^2 / ((R - r') * (r' - r)^2) := by
+  have Rpos : 0 < R := lt_trans pos_r (lt_trans r_le_r' r'_le_R)
+  have analytic_f' : AnalyticOn ℂ f (Metric.ball 0 R) :=
+    analytic_f.mono Metric.ball_subset_closedBall
+  have re_f_le_M' : ∀ z ∈ Metric.ball 0 R, (f z).re ≤ M := fun z hz =>
+    re_f_le_M z (Metric.ball_subset_closedBall hz)
+  have Mnn : 0 ≤ M := by
+    have h0 : (0 : ℂ) ∈ Metric.closedBall (0 : ℂ) R := by
+      simp [Metric.mem_closedBall, Rpos.le]
+    have := re_f_le_M 0 h0
+    rw [f_zero_at_zero] at this
+    simpa using this
+  by_cases hM : M = 0
+  · subst hM
+    have hRr' : 0 < R - r' := by linarith
+    have hrr' : 0 < r' - r := by linarith
+    have hr'_pos : 0 < r' := lt_of_lt_of_le pos_r r_le_r'.le
+    rw [show (2 * (0:ℝ) * (r')^2 / ((R - r') * (r' - r)^2)) = 0 from by ring]
+    refine le_of_forall_pos_le_add (fun ε hε => ?_)
+    rw [zero_add]
+    set K : ℝ := 2 * (r')^2 / ((R - r') * (r' - r)^2) with hK_def
+    have hKpos : 0 < K := by positivity
+    have εK_pos : 0 < ε / K := div_pos hε hKpos
+    have re_f_eK : ∀ z ∈ Metric.ball 0 R, (f z).re ≤ ε / K := fun z hz =>
+      le_trans (re_f_le_M' z hz) εK_pos.le
+    have hDB := DerivativeBound εK_pos pos_r r_le_r' r'_le_R
+      analytic_f' f_zero_at_zero re_f_eK z_in_r
+    have hKε : 2 * (ε / K) * (r')^2 / ((R - r') * (r' - r)^2) = ε := by
+      have h1 : (R - r') ≠ 0 := hRr'.ne'
+      have h2 : (r' - r) ≠ 0 := hrr'.ne'
+      have h3 : K ≠ 0 := hKpos.ne'
+      simp only [hK_def] at h3 ⊢
+      field_simp at h3 ⊢
+    linarith
+  · have Mpos : 0 < M := lt_of_le_of_ne Mnn (Ne.symm hM)
+    exact DerivativeBound Mpos pos_r r_le_r' r'_le_R
+      analytic_f' f_zero_at_zero re_f_le_M' z_in_r


### PR DESCRIPTION
## Summary

This PR completes the proof of `derivativeBound` in `PrimeNumberTheoremAnd/DerivativeBound.lean`, which was previously a `sorry`.

## Strategy

The closed-ball version proved here is reduced to the existing ball-version `DerivativeBound` already established in `StrongPNT.lean`:

1. **Restrict to open ball**: `analytic_f.mono Metric.ball_subset_closedBall` gives analyticity on `ball 0 R`; the real-part bound transfers identically.
2. **Derive `0 le M`**: evaluate `re_f_le_M` at `0` (using `f 0 = 0`).
3. **Case `0 < M`**: directly apply the ball-version `DerivativeBound`.
4. **Case `M = 0`** (the boundary case): for any `eps > 0`, set `M' = eps / K` where `K` is the geometric constant. Apply the ball version with `M = M'`, obtain `norm (deriv f z) <= eps`, and conclude with `le_of_forall_pos_le_add`.

## Verification

```
Built PrimeNumberTheoremAnd.DerivativeBound (22s)
Build completed successfully (3458 jobs).
```

Zero `sorry` warnings, no new axioms.

## Concern: new import dependency

This patch introduces:
```lean
import PrimeNumberTheoremAnd.StrongPNT
```

because `DerivativeBound` and `cauchy_formula_deriv` currently live there. If reviewers prefer to avoid this cross-file dependency, I am happy to either:

- inline the ~30-line ball-version proof here, or
- move the canonical statement of `DerivativeBound` out of `StrongPNT.lean` into this file and have `StrongPNT.lean` import it instead.

Please advise.