### PR TITLE
fix: align Dusart1999.pi_inequality blueprint threshold

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -159,7 +159,7 @@ Some results from \cite{Dusart1999}-/
 @[blueprint
   "thm:dusart1999-pi"
   (title := "Dusart 1999, $\\pi$ inequality")
-  (statement := /-- For $x \geq 17$, we have $\pi(x) > \frac{x}{\log x - 1}$. -/)
+  (statement := /-- For $x \geq 5393$, we have $\pi(x) > \frac{x}{\log x - 1}$. -/)
   (latexEnv := "theorem")]
 theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
     pi x ≥ x / (log x - 1) :=


### PR DESCRIPTION
## Summary

The Lean theorem `pi_inequality` already requires `x ≥ 5393` (via `Dusart.corollary_5_3_a`), but the `@blueprint` statement still claimed `x ≥ 17`. At `x = 17`, `π(17) = 7` while `17/(log 17 - 1) ≈ 9.27`, so the old blueprint text was false.

## Root cause

Issue #1182 corrected the Lean signature, but the blueprint statement was not updated to match.

## Fix

Update the blueprint threshold from 17 to 5393 so it matches the theorem hypothesis.

Closes #1182

Made with [Cursor](https://cursor.com)