### PR TITLE
fix: require Re(s) > 2 in LSeries_totient_eq

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1471,7 +1471,7 @@ lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouvil
 L(\varphi, s) = \prod_{p} \left(1 + \varphi(p)p^{-s} + \varphi(p^2)p^{-2s} + \ldots\right) = \prod_{p} \left(1 - p^{-s  +1}\right)^{-1} \left(1 - p^{-s}\right) = \frac{\zeta(s-1)}{\zeta(s)}.
 \]
   -/)]
-lemma LSeries_totient_eq {s : ℂ} (hs : 1 < s.re) :
+lemma LSeries_totient_eq {s : ℂ} (hs : 2 < s.re) :
     LSeries (↗totient) s = riemannZeta (s - 1) / riemannZeta s := by
   sorry
 


### PR DESCRIPTION
## Summary

`LSeries_totient_eq` stated the Euler product identity with hypothesis `1 < Re(s)`, but the Dirichlet series is only absolutely summable for `Re(s) > 2`.

## Root cause

The convergence region was copied from the IK identity without matching the absolute-summability threshold.

## Why this fix is correct

For `Re(s) ∈ (1, 2]`, terms are bounded by `n^{1-Re(s)}`, which is not absolutely summable. The identity requires `2 < s.re`, matching the standard convergence region for this L-series.

Complements #1468 (blueprint text).

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1`