### PR TITLE
fix: state Re(s) > 2 in LSeries_totient_eq blueprint

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1460,7 +1460,7 @@ lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouvil
 @[blueprint
   "LSeries_totient_eq"
   (title := "LSeries totient eq")
-  (statement := /-- Euler totient series: $\sum_{n=1}^{\infty} \varphi(n) n^{-s} = \zeta(s-1)/\zeta(s)$.
+  (statement := /-- Euler totient series: $\sum_{n=1}^{\infty} \varphi(n) n^{-s} = \zeta(s-1)/\zeta(s)$ for $\Re(s) > 2$.
   \begin{verbatim}
   This is IK (1.35).
   \end{verbatim}


### PR DESCRIPTION
## Summary

The `@blueprint` statement for `LSeries_totient_eq` gave the Euler product identity with no convergence hypothesis, while the series is absolutely summable only for `Re(s) > 2`.

## Root cause

The blueprint text was copied from the IK identity without the convergence region. The Lean side is corrected in #1467 (`2 < s.re`); the blueprint still needed to match.

## Why this fix is correct

For `Re(s) ∈ (1, 2]`, `φ(n) ≤ n` gives terms bounded by `n^{1-Re(s)}`, which is not absolutely summable. The identity holds only where the Dirichlet series converges absolutely, i.e. `Re(s) > 2`.

Complements #1467.

## Test plan
- [ ] Blueprint build (if applicable)