### PR TITLE
fix: state n ≥ 55 in Rosser1941 p_n_upper blueprint

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -936,7 +936,7 @@ theorem p_n_lower (n : ℕ) (hn : n ≥ 55) :
 @[blueprint
   "thm:rosser1941-pn-upper"
   (title := "Rosser 1941, upper bound on $p_n$")
-  (statement := /-- For $n \geq 1$, we have $p_n < n(\log n + \log\log n + 2)$. -/)
+  (statement := /-- For $n \geq 55$, we have $p_n < n(\log n + \log\log n + 2)$. -/)
   (latexEnv := "theorem")]
 theorem p_n_upper (n : ℕ) (hn : n ≥ 55) :
     nth_prime' n < n * (log n + log (log n) + 2) := by sorry


### PR DESCRIPTION
Fixes #1185

## Bug
The `@blueprint` for `p_n_upper` stated the bound for `n ≥ 1`, but the Lean theorem requires `n ≥ 55` and the inequality fails at `n = 1` (`nth_prime' 1 = 2`, RHS equals 2).

## Root cause
The blueprint text was not updated when the Lean hypothesis was strengthened to match Rosser 1941 / TME-EMT Theorem 29b.

## Why this fix is correct
Cross-checking with Rosser 1941 and the TME-EMT wiki shows `n ≥ 55` is the valid range; the Lean side already uses this threshold.

## Test plan
- [ ] Blueprint build (if applicable)

Made with [Cursor](https://cursor.com)