### PR TITLE
BKLNW: state the Table 10 safety margin explicitly in the blueprint statement

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_table10_dispatch.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_table10_dispatch.lean
@@ -16,7 +16,11 @@ set_option maxRecDepth 100000 in
 @[blueprint
   "bklnw-table-10-verification"
   (title := "BKLNW Table 10 verification")
-  (statement := /--  Verification of the entries of Table 10. -/)
+  (statement := /--  Verification of the entries of Table 10, up to the safety margin
+  $m = 1.002001$: each row $(b, B_1, \ldots, B_5)$ of the (unabridged) Table 10 satisfies
+  $$B^{\mathrm{exact}}_k(b, \mathrm{next}(b)) \le B_k \cdot m \qquad (k = 1, \ldots, 5),$$
+  where $m$ is the Table 8 margin $1.001$ composed with a further factor $1.001$,
+  accounting for the final-digit rounding of the printed values. -/)
   (proof := /-- Enumerate the 287 rows of `table_10`, split into the five `k` cases,
   and discharge each case using the generated row margin and next-row certificates. -/)
   (latexEnv := "proposition")


### PR DESCRIPTION
Follow-up to the review comment on #1517: the blueprint statement of the Table 10 verification now states the safety margin explicitly (m = 1.002001, the Table 8 margin composed with a further 1.001 for the final-digit rounding of the printed values). No changes to any Lean statement or proof.
