### PR TITLE
BKLNW: align thm_14 and thm_16 statements and definitions with the papers

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
@@ -413,15 +413,15 @@ theorem bklnw_thm_15 (I : Inputs)
   \exp\left(\frac{10 - 16 \sigma}{3}
   \left( \frac{\log x_0}{R}
   \right)^{1/2} \right)
-  \left( \frac{\log x_0}{R}
+  \left( \sqrt{ \frac{\log x_0}{R} }
   \right)^{5 - 2 \sigma}
   \right)^{-1}. $$
   -/)]
 noncomputable def Inputs.k (I : Inputs)
     (σ x₀ : ℝ) : ℝ :=
   (exp ((10 - 16 * σ) / 3 *
-      (log x₀ / I.R) ^ (1 / 2)) *
-    (log x₀ / I.R) ^ (5 - 2 * σ)) ^ (-1 : ℝ)
+      (log x₀ / I.R) ^ (1 / 2 : ℝ)) *
+    sqrt (log x₀ / I.R) ^ (5 - 2 * σ)) ^ (-1 : ℝ)
 
 @[blueprint
   "bklnw-eq_A_17"
@@ -434,7 +434,7 @@ noncomputable def Inputs.k (I : Inputs)
   -/)]
 noncomputable def Inputs.c3 (I : Inputs)
     (σ x₀ : ℝ) : ℝ :=
-  2 * exp (-2 * (log x₀ / I.R) ^ (1 / 2)) *
+  2 * exp (-2 * (log x₀ / I.R) ^ (1 / 2 : ℝ)) *
     (log x₀) ^ 2 * I.k σ x₀
 
 @[blueprint
@@ -463,21 +463,21 @@ noncomputable def Inputs.c4 (I : Inputs)
 noncomputable def Inputs.c5 (I : Inputs)
     (σ x₀ : ℝ) : ℝ :=
   8.01 * I.ZDB.c₂ σ *
-    exp (-2 * (log x₀ / I.R) ^ (1 / 2)) *
+    exp (-2 * (log x₀ / I.R) ^ (1 / 2 : ℝ)) *
     (log x₀ / I.R) * I.k σ x₀
 
 @[blueprint
   "bklnw-eq_A_20"
   (title := "Equation (A.20)")
   (statement := /-- We define
-  $$ A(\sigma, x_0) = 2.0025 \cdot 25^{-2 \sigma}
+  $$ A(\sigma, x_0) = 2.0025 \cdot 2^{5 - 2 \sigma}
   \cdot c_1(\sigma) + c_3(\sigma, x_0)
   + c_4(\sigma, x_0)
   + c_5(\sigma, x_0). $$
   -/)]
 noncomputable def Inputs.A (I : Inputs)
     (σ x₀ : ℝ) : ℝ :=
-  2.0025 * 25 ^ (-2 * σ) * I.ZDB.c₁ σ +
+  2.0025 * 2 ^ (5 - 2 * σ) * I.ZDB.c₁ σ +
     I.c3 σ x₀ + I.c4 σ x₀ + I.c5 σ x₀
 
 @[blueprint
@@ -788,16 +788,16 @@ theorem bklnw_thm_16 (ε c x₀ α : ℝ)
     (hc : 3 ≤ c)
     (hx₀ : 100 ≤ x₀)
     (hα : 0 ≤ α ∧ α < 1)
-    (hB0 : (ε * rexp (-ε) * x₀ * |ν c ε α|) /
-      (2 * (μ c ε α)) > 1)
+    (hB0 : 2 * max (μ c 1 α) 0 <
+      ε * rexp (-ε) * x₀ * |ν c 1 α|)
     (hRH : riemannZeta.RH_up_to (c / ε))
     (x : ℝ)
     (hx : x ≥ rexp (ε * α) * x₀) :
     let E₁ :=
       rexp (2 * ε) * log (rexp ε * x₀) *
-        (2 * ε * |ν c ε α| /
+        (2 * ε * |ν c 1 α| /
           log ((ε * rexp (-ε) * x₀ *
-            |ν c ε α|) / (2 * (μ c ε α))) +
+            |ν c 1 α|) / (2 * max (μ c 1 α) 0)) +
         2.01 * ε / sqrt x₀ +
         log (log (2 * x₀ ^ 2)) /
           (2 * x₀)) +

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
@@ -694,21 +694,38 @@ noncomputable def ℓ (c ε ξ : ℝ) : ℝ :=
     sin (sqrt ((ξ * ε) ^ 2 - c ^ 2)) /
     sqrt ((ξ * ε) ^ 2 - c ^ 2)
 
-open Complex in
+/-- The modified Bessel function of the first kind of order zero,
+$I_0(x) = \sum_{m \geq 0} (x/2)^{2m}/(m!)^2$, introduced for the closed form of the
+Logan kernel transform below (not yet in Mathlib). -/
+noncomputable def besselI0 (x : ℝ) : ℝ :=
+  ∑' m : ℕ, (x / 2) ^ (2 * m) / ((m.factorial : ℝ)) ^ 2
+
 @[blueprint
   "logan-function-ft"
   (title := "Fourier transform of Logan's function")
-  (statement := /-- We define
-  $$ \eta_{c,\varepsilon}(\xi)
+  (statement := /-- The Fourier transform
+  $\eta_{c,\varepsilon}(\xi)
   = \frac{1}{2\pi} \int_{\R} e^{-it\xi}
-  ℓ_{c,\varepsilon}(t) \, dt. $$ -/)
+  ℓ_{c,\varepsilon}(t) \, dt$
+  of Logan's kernel, in closed form: the kernel
+  is band-limited, so the transform is supported
+  in $[-\varepsilon, \varepsilon]$, where
+  $$ \eta_{c,\varepsilon}(\xi)
+  = \frac{c}{2 \varepsilon \sinh c}\,
+  I_0\!\left(c \sqrt{1 - (\xi/\varepsilon)^2}\right) $$
+  with $I_0$ the modified Bessel function of
+  order zero (\cite[p.~2490]{Buthe2}). The
+  closed form is taken as the definition; the
+  Fourier identity is a proof obligation of
+  Theorem 16. -/)
   (latexEnv := "definition")]
 noncomputable def η (c ε ξ : ℝ) : ℝ :=
-  (1 / (2 * π)) *
-    (∫ t : ℝ, exp (-I * t * ξ) * ℓ c ε t).re
+  if |ξ| ≤ ε then
+    c / (2 * ε * sinh c) * besselI0 (c * sqrt (1 - (ξ / ε) ^ 2))
+  else 0
 
 noncomputable def pre_μ (c ε t : ℝ) : ℝ :=
-  -∫ τ in Set.Ici t, η c ε τ
+  -∫ τ in Set.Iic t, η c ε τ
 
 @[blueprint
   "buthe-mu-def"
@@ -718,7 +735,7 @@ noncomputable def pre_μ (c ε t : ℝ) : ℝ :=
   \begin{align*}
   \mu_{c,\varepsilon}(t) &=
   \begin{cases}
-  -\int_t^{\infty} \eta_{c,\varepsilon}(\tau)
+  -\int_{-\infty}^{t} \eta_{c,\varepsilon}(\tau)
   d\tau & t < 0, \\
   -\mu_{c,\varepsilon}(-t) & t > 0, \\
   0 & t = 0,


### PR DESCRIPTION
While preparing certificates for the appendix legs, several of the A.16-A.20 definitions and the thm_14/thm_16 statements turned out to differ from the papers they encode.

On the thm_14 side: the first term of A(σ, x₀) had 2^(5−2σ) transcribed as 25^(−2σ) (the blueprint text carried the same transcription), and in Inputs.k, c3, c5 the literal ^ (1 / 2) elaborates as a natural-number power ^ 0, so k lost its √(log x₀ / R) inside the exponential and c3/c5 carried a constant exp(−2); k's power base was also missing its square root. These are fixed with explicit (1/2 : ℝ) exponents and the paper's constants.

On the thm_16 side: hB0's denominator now uses the positive part max (μ c 1 α) 0, matching Büthe's 2(μ_c)₊(α), and the μ/ν normalizations are evaluated at ε = 1 as in the paper (the previous form passed ε, which evaluates Büthe's functions at the argument α/ε with a spurious ε factor). Separately, the previous η was defined as a Bochner integral of Logan's kernel, which is not Lebesgue integrable, so the integral evaluates to 0 and μ and ν degenerate; η is now Büthe's closed form on [−ε, ε], with I₀ introduced as an explicit power series since mathlib has no Bessel-I, and the Fourier identity stated as a proof obligation of the theorem.

These are statement and definition repairs only: the affected theorems are sorried leaves with no consumers in the repo, and the full build is green on the branch. Each item is checked against the source tex (BKLNW for thm_14, Büthe for thm_16). I may be misreading an intended convention somewhere, but these are the discrepancies I'm seeing.

Tool Usage:

Lean was developed using Claude Code CLI (Fable 5, Adaptive Thinking, primarily High mode). Everything is kernel-checked, and I reviewed and assembled the final branch.
