### PR TITLE
  BKLNW: elementary lemmas for the eta, mu and Bessel I0 layer

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
@@ -933,6 +933,149 @@ lemma ν_eq_zero_of_lt_neg {c ε : ℝ} (hε : 0 < ε) {t : ℝ} (ht : t < -ε) 
   refine MeasureTheory.setIntegral_eq_zero_of_forall_eq_zero fun τ hτ ↦ ?_
   exact μ_eq_zero_of_lt_neg hε (lt_of_le_of_lt hτ ht)
 
+open MeasureTheory in
+/-- A bounded function vanishing outside `[-ε, ε]` has all its `Iic`-integrals bounded
+by `M * (2ε)`. -/
+private lemma abs_setIntegral_Iic_le {f : ℝ → ℝ} {ε M : ℝ} (hε : 0 < ε) (hM : 0 ≤ M)
+    (hf_bound : ∀ x, |f x| ≤ M) (hf_zero : ∀ x, ε < |x| → f x = 0) (u : ℝ) :
+    |∫ x in Set.Iic u, f x| ≤ M * (2 * ε) := by
+  have heq : ∫ x in Set.Iic u, f x = ∫ x in Set.Iic u ∩ Set.Icc (-ε) ε, f x := by
+    refine MeasureTheory.setIntegral_eq_of_subset_of_forall_diff_eq_zero measurableSet_Iic
+      Set.inter_subset_left fun x hx ↦ ?_
+    refine hf_zero x ?_
+    have h3 : x ∉ Set.Icc (-ε) ε := fun hmem ↦ hx.2 ⟨hx.1, hmem⟩
+    rw [Set.mem_Icc, ← abs_le] at h3
+    exact not_le.mp h3
+  have hvol : (volume (Set.Iic u ∩ Set.Icc (-ε) ε)).toReal ≤ 2 * ε := by
+    have h2 : volume (Set.Icc (-ε : ℝ) ε) = ENNReal.ofReal (2 * ε) := by
+      rw [Real.volume_Icc]
+      ring_nf
+    calc (volume (Set.Iic u ∩ Set.Icc (-ε) ε)).toReal
+        ≤ (volume (Set.Icc (-ε : ℝ) ε)).toReal :=
+          ENNReal.toReal_mono (by rw [h2]; exact ENNReal.ofReal_ne_top)
+            (measure_mono Set.inter_subset_right)
+      _ = 2 * ε := by rw [h2, ENNReal.toReal_ofReal (by linarith)]
+  have hfin : volume (Set.Iic u ∩ Set.Icc (-ε) ε) < ⊤ :=
+    lt_of_le_of_lt (measure_mono Set.inter_subset_right)
+      (by rw [Real.volume_Icc]; exact ENNReal.ofReal_lt_top)
+  have hnorm := MeasureTheory.norm_setIntegral_le_of_norm_le_const (μ := volume) (C := M)
+    (f := f) hfin (fun x _ ↦ by simpa using hf_bound x)
+  rw [heq, ← Real.norm_eq_abs]
+  calc ‖∫ x in Set.Iic u ∩ Set.Icc (-ε) ε, f x‖
+      ≤ M * (volume (Set.Iic u ∩ Set.Icc (-ε) ε)).toReal := hnorm
+    _ ≤ M * (2 * ε) := mul_le_mul_of_nonneg_left hvol hM
+
+lemma pre_μ_antitone {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) : Antitone (pre_μ c ε) := by
+  intro s t hst
+  unfold pre_μ
+  rw [neg_le_neg_iff]
+  exact MeasureTheory.setIntegral_mono_set ((integrable_η hc hε).integrableOn)
+    (MeasureTheory.ae_of_all _ fun ξ ↦ η_nonneg hc hε ξ)
+    (Set.Iic_subset_Iic.mpr hst).eventuallyLE
+
+lemma measurable_μ {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) : Measurable (μ c ε) := by
+  unfold μ
+  refine Measurable.ite measurableSet_Iio (pre_μ_antitone hc hε).measurable ?_
+  refine Measurable.ite measurableSet_Ioi ?_ measurable_const
+  exact ((pre_μ_antitone hc hε).measurable.comp measurable_neg).neg
+
+private lemma pre_μ_abs_le {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) (u : ℝ) :
+    |pre_μ c ε u| ≤ c / sinh c * besselI0 c := by
+  have hs : 0 < sinh c := sinh_pos_iff.mpr hc
+  have h := abs_setIntegral_Iic_le (f := η c ε)
+    (M := c / (2 * ε * sinh c) * besselI0 c) hε
+    (mul_nonneg (div_nonneg hc.le (by nlinarith [mul_pos hε hs])) (besselI0_nonneg c))
+    (fun x ↦ by rw [abs_of_nonneg (η_nonneg hc hε x)]; exact η_le hc hε x)
+    (fun x hx ↦ η_eq_zero_of_abs_gt hx) u
+  unfold pre_μ
+  rw [abs_neg]
+  refine h.trans (le_of_eq ?_)
+  field_simp [hε.ne', hs.ne']
+
+lemma μ_abs_le {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) (t : ℝ) :
+    |μ c ε t| ≤ c / sinh c * besselI0 c := by
+  have hs : 0 < sinh c := sinh_pos_iff.mpr hc
+  have hnn : 0 ≤ c / sinh c * besselI0 c :=
+    mul_nonneg (div_nonneg hc.le hs.le) (besselI0_nonneg c)
+  unfold μ
+  split
+  · exact pre_μ_abs_le hc hε t
+  · split
+    · rw [abs_neg]
+      exact pre_μ_abs_le hc hε (-t)
+    · simpa using hnn
+
+lemma integrable_μ {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) :
+    MeasureTheory.Integrable (μ c ε) := by
+  have hsupp : Function.support (μ c ε) ⊆ Set.Icc (-ε) ε := by
+    intro t ht
+    rw [Set.mem_Icc, ← abs_le]
+    by_contra h
+    rcases lt_abs.mp (not_le.mp h) with h1 | h1
+    · exact ht (μ_eq_zero_of_gt hε h1)
+    · exact ht (μ_eq_zero_of_lt_neg hε (by linarith))
+  rw [← MeasureTheory.integrableOn_iff_integrable_of_support_subset hsupp]
+  refine MeasureTheory.Measure.integrableOn_of_bounded
+    (M := c / sinh c * besselI0 c)
+    (by rw [Real.volume_Icc]; exact ENNReal.ofReal_ne_top)
+    ((measurable_μ hc hε).aestronglyMeasurable)
+    (MeasureTheory.ae_of_all _ fun t ↦ ?_)
+  rw [Real.norm_eq_abs]
+  exact μ_abs_le hc hε t
+
+lemma ν_abs_le {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) (t : ℝ) :
+    |ν c ε t| ≤ c / sinh c * besselI0 c * (2 * ε) := by
+  have hs : 0 < sinh c := sinh_pos_iff.mpr hc
+  have hM : 0 ≤ c / sinh c * besselI0 c :=
+    mul_nonneg (div_nonneg hc.le hs.le) (besselI0_nonneg c)
+  unfold ν
+  exact abs_setIntegral_Iic_le hε hM (fun x ↦ μ_abs_le hc hε x)
+    (fun x hx ↦ by
+      rcases lt_abs.mp hx with h1 | h1
+      · exact μ_eq_zero_of_gt hε h1
+      · exact μ_eq_zero_of_lt_neg hε (by linarith)) t
+
+lemma besselI0_partial_le (x : ℝ) (N : ℕ) :
+    ∑ m ∈ Finset.range N, (x / 2) ^ (2 * m) / ((m.factorial : ℝ)) ^ 2 ≤ besselI0 x := by
+  change _ ≤ ∑' m : ℕ, (x / 2) ^ (2 * m) / ((m.factorial : ℝ)) ^ 2
+  exact Summable.sum_le_tsum (Finset.range N)
+    (fun m _ ↦ by rw [pow_mul]; positivity) (besselI0_summable x)
+
+lemma besselI0_sub_partial_le (x : ℝ) (N : ℕ) :
+    besselI0 x - ∑ m ∈ Finset.range N, (x / 2) ^ (2 * m) / ((m.factorial : ℝ)) ^ 2 ≤
+      (x / 2) ^ (2 * N) / ((N.factorial : ℝ)) ^ 2 * besselI0 x := by
+  have hsum := besselI0_summable x
+  have hb : besselI0 x = ∑' m : ℕ, (x / 2) ^ (2 * m) / ((m.factorial : ℝ)) ^ 2 := rfl
+  have hsplit := hsum.sum_add_tsum_nat_add N
+  have hterm : ∀ k : ℕ, (x / 2) ^ (2 * (k + N)) / (((k + N).factorial : ℝ)) ^ 2 ≤
+      (x / 2) ^ (2 * N) / ((N.factorial : ℝ)) ^ 2 *
+        ((x / 2) ^ (2 * k) / ((k.factorial : ℝ)) ^ 2) := by
+    intro k
+    have hfact : (N.factorial : ℝ) * (k.factorial : ℝ) ≤ ((k + N).factorial : ℝ) := by
+      exact_mod_cast Nat.le_of_dvd (k + N).factorial_pos
+        (by simpa [mul_comm] using Nat.factorial_mul_factorial_dvd_factorial_add k N)
+    have hN : (0 : ℝ) < ((N.factorial : ℝ)) ^ 2 :=
+      pow_pos (by exact_mod_cast N.factorial_pos) 2
+    have hk : (0 : ℝ) < ((k.factorial : ℝ)) ^ 2 :=
+      pow_pos (by exact_mod_cast k.factorial_pos) 2
+    have hNk : (0 : ℝ) ≤ (N.factorial : ℝ) * (k.factorial : ℝ) := by positivity
+    rw [show 2 * (k + N) = 2 * N + 2 * k by ring, pow_add, div_mul_div_comm]
+    gcongr (x / 2) ^ (2 * N) * (x / 2) ^ (2 * k) / ?_ <;>
+      first
+        | exact mul_pos hN hk
+        | (rw [pow_mul, pow_mul]; positivity)
+        | nlinarith [hfact, hNk]
+  have htail : (∑' k : ℕ, (x / 2) ^ (2 * (k + N)) / (((k + N).factorial : ℝ)) ^ 2) ≤
+      (x / 2) ^ (2 * N) / ((N.factorial : ℝ)) ^ 2 * besselI0 x := by
+    calc (∑' k : ℕ, (x / 2) ^ (2 * (k + N)) / (((k + N).factorial : ℝ)) ^ 2)
+        ≤ ∑' k : ℕ, (x / 2) ^ (2 * N) / ((N.factorial : ℝ)) ^ 2 *
+            ((x / 2) ^ (2 * k) / ((k.factorial : ℝ)) ^ 2) :=
+          Summable.tsum_le_tsum hterm ((summable_nat_add_iff N).mpr hsum)
+            (hsum.mul_left ((x / 2) ^ (2 * N) / ((N.factorial : ℝ)) ^ 2))
+      _ = (x / 2) ^ (2 * N) / ((N.factorial : ℝ)) ^ 2 * besselI0 x := by
+          rw [tsum_mul_left, ← hb]
+  linarith [hsplit, htail, hb.le, hb.ge]
+
 @[blueprint
   "bklnw-thm_16"
   (title := "Theorem 16")

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
@@ -752,6 +752,83 @@ noncomputable def μ (c ε t : ℝ) : ℝ :=
 noncomputable def ν (c ε t : ℝ) : ℝ :=
   ∫ τ in Set.Iic t, μ c ε τ
 
+/-! ### Elementary properties of the Logan kernel transform
+
+Sign, support, and symmetry facts about `besselI0`, `η` and `μ`, provable directly from
+the closed form. They are the base layer for the monotonicity claims of
+\cite[p.~2492]{Buthe2} and for certified bounds on the `μ` and `ν` values appearing in
+the `hB0` hypothesis of Theorem 16. -/
+
+lemma besselI0_summable (x : ℝ) :
+    Summable (fun m : ℕ ↦ (x / 2) ^ (2 * m) / ((m.factorial : ℝ)) ^ 2) := by
+  refine Summable.of_nonneg_of_le (fun m ↦ by rw [pow_mul]; positivity) (fun m ↦ ?_)
+    (Real.summable_pow_div_factorial (x ^ 2 / 4))
+  have h2 : (x / 2) ^ (2 * m) = (x ^ 2 / 4) ^ m := by
+    rw [pow_mul, div_pow]
+    norm_num
+  rw [h2]
+  gcongr (x ^ 2 / 4) ^ m / ?_
+  exact_mod_cast Nat.le_self_pow (by norm_num) m.factorial
+
+lemma besselI0_nonneg (x : ℝ) : 0 ≤ besselI0 x :=
+  tsum_nonneg fun m ↦ by rw [pow_mul]; positivity
+
+lemma besselI0_one_le (x : ℝ) : 1 ≤ besselI0 x := by
+  have h := (besselI0_summable x).le_tsum 0 fun j _ ↦ by rw [pow_mul]; positivity
+  simpa [Nat.factorial] using h
+
+lemma besselI0_pos (x : ℝ) : 0 < besselI0 x :=
+  lt_of_lt_of_le one_pos (besselI0_one_le x)
+
+lemma besselI0_le_besselI0 {x y : ℝ} (h : |x| ≤ |y|) : besselI0 x ≤ besselI0 y := by
+  refine Summable.tsum_le_tsum (fun m ↦ ?_) (besselI0_summable x) (besselI0_summable y)
+  have hx : (x / 2) ^ (2 * m) = (x ^ 2 / 4) ^ m := by rw [pow_mul, div_pow]; norm_num
+  have hy : (y / 2) ^ (2 * m) = (y ^ 2 / 4) ^ m := by rw [pow_mul, div_pow]; norm_num
+  rw [hx, hy]
+  have hxy : x ^ 2 ≤ y ^ 2 := by
+    nlinarith [sq_abs x, sq_abs y, abs_nonneg x, abs_nonneg y]
+  gcongr
+
+lemma η_nonneg {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) (ξ : ℝ) : 0 ≤ η c ε ξ := by
+  unfold η
+  split
+  · have hs : 0 < sinh c := sinh_pos_iff.mpr hc
+    refine mul_nonneg (div_nonneg hc.le ?_) (besselI0_nonneg _)
+    nlinarith [mul_pos hε hs]
+  · exact le_rfl
+
+lemma η_even (c ε ξ : ℝ) : η c ε (-ξ) = η c ε ξ := by
+  simp [η, abs_neg, neg_div]
+
+lemma η_eq_zero_of_abs_gt {c ε ξ : ℝ} (h : ε < |ξ|) : η c ε ξ = 0 := by
+  simp [η, not_le.mpr h]
+
+lemma μ_zero (c ε : ℝ) : μ c ε 0 = 0 := by
+  simp [μ]
+
+lemma μ_nonneg_of_pos {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) {t : ℝ} (ht : 0 < t) :
+    0 ≤ μ c ε t := by
+  unfold μ
+  rw [if_neg (by linarith : ¬ t < 0), if_pos ht, pre_μ, neg_neg]
+  exact MeasureTheory.setIntegral_nonneg measurableSet_Iic fun ξ _ ↦ η_nonneg hc hε ξ
+
+lemma μ_nonpos_of_neg {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) {t : ℝ} (ht : t < 0) :
+    μ c ε t ≤ 0 := by
+  unfold μ
+  rw [if_pos ht, pre_μ]
+  simp only [neg_nonpos]
+  exact MeasureTheory.setIntegral_nonneg measurableSet_Iic fun ξ _ ↦ η_nonneg hc hε ξ
+
+lemma μ_neg (c ε t : ℝ) : μ c ε (-t) = -μ c ε t := by
+  rcases lt_trichotomy t 0 with ht | rfl | ht
+  · unfold μ
+    rw [if_neg (by linarith : ¬ -t < 0), if_pos (by linarith : -t > 0), neg_neg,
+      if_pos ht]
+  · simp [μ]
+  · unfold μ
+    rw [if_pos (by linarith : -t < 0), if_neg (by linarith : ¬ t < 0), if_pos ht,
+      neg_neg]
+
 @[blueprint
   "bklnw-thm_16"
   (title := "Theorem 16")

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_app.lean
@@ -829,6 +829,110 @@ lemma μ_neg (c ε t : ℝ) : μ c ε (-t) = -μ c ε t := by
     rw [if_pos (by linarith : -t < 0), if_neg (by linarith : ¬ t < 0), if_pos ht,
       neg_neg]
 
+lemma continuous_besselI0 : Continuous besselI0 := by
+  rw [continuous_iff_continuousAt]
+  intro x₀
+  have hmem : Metric.ball (0 : ℝ) (|x₀| + 1) ∈ nhds x₀ := by
+    refine Metric.isOpen_ball.mem_nhds ?_
+    simp only [Metric.mem_ball, Real.dist_eq, sub_zero]
+    linarith [abs_nonneg x₀]
+  refine (continuousOn_tsum
+    (fun m ↦ (((continuous_id.div_const 2).pow (2 * m)).div_const _).continuousOn)
+    (besselI0_summable (|x₀| + 1)) ?_).continuousAt hmem
+  intro m x hx
+  simp only [Metric.mem_ball, Real.dist_eq, sub_zero] at hx
+  have hb : |x / 2| ≤ (|x₀| + 1) / 2 := by
+    rw [abs_div, abs_two]
+    linarith
+  rw [Real.norm_eq_abs, abs_div, abs_pow,
+    abs_of_nonneg (by positivity : (0 : ℝ) ≤ ((m.factorial : ℝ)) ^ 2)]
+  gcongr
+  exact hb
+
+lemma measurable_η (c ε : ℝ) : Measurable (η c ε) := by
+  unfold η
+  refine Measurable.ite (measurableSet_le measurable_id.abs measurable_const) ?_
+    measurable_const
+  have h1 : Continuous fun ξ : ℝ ↦ c * sqrt (1 - (ξ / ε) ^ 2) :=
+    (Real.continuous_sqrt.comp (by fun_prop)).const_mul c
+  exact ((continuous_besselI0.comp h1).const_mul _).measurable
+
+lemma η_le {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) (ξ : ℝ) :
+    η c ε ξ ≤ c / (2 * ε * sinh c) * besselI0 c := by
+  have hs : 0 < sinh c := sinh_pos_iff.mpr hc
+  have hcoef : 0 ≤ c / (2 * ε * sinh c) :=
+    div_nonneg hc.le (by nlinarith [mul_pos hε hs])
+  unfold η
+  split
+  · refine mul_le_mul_of_nonneg_left (besselI0_le_besselI0 ?_) hcoef
+    have h1 : sqrt (1 - (ξ / ε) ^ 2) ≤ 1 :=
+      Real.sqrt_le_one.mpr (by nlinarith [sq_nonneg (ξ / ε)])
+    calc |c * sqrt (1 - (ξ / ε) ^ 2)|
+        = c * sqrt (1 - (ξ / ε) ^ 2) :=
+          abs_of_nonneg (mul_nonneg hc.le (Real.sqrt_nonneg _))
+      _ ≤ c * 1 := mul_le_mul_of_nonneg_left h1 hc.le
+      _ = c := mul_one c
+      _ = |c| := (abs_of_pos hc).symm
+  · exact mul_nonneg hcoef (besselI0_nonneg c)
+
+lemma integrable_η {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) :
+    MeasureTheory.Integrable (η c ε) := by
+  have hsupp : Function.support (η c ε) ⊆ Set.Icc (-ε) ε := by
+    intro ξ hξ
+    rw [Set.mem_Icc, ← abs_le]
+    by_contra h
+    exact hξ (η_eq_zero_of_abs_gt (not_le.mp h))
+  rw [← MeasureTheory.integrableOn_iff_integrable_of_support_subset hsupp]
+  refine MeasureTheory.Measure.integrableOn_of_bounded
+    (M := c / (2 * ε * sinh c) * besselI0 c)
+    (by rw [Real.volume_Icc]; exact ENNReal.ofReal_ne_top)
+    ((measurable_η c ε).aestronglyMeasurable)
+    (MeasureTheory.ae_of_all _ fun ξ ↦ ?_)
+  rw [Real.norm_eq_abs, abs_of_nonneg (η_nonneg hc hε ξ)]
+  exact η_le hc hε ξ
+
+lemma μ_eq_zero_of_lt_neg {c ε : ℝ} (hε : 0 < ε) {t : ℝ} (ht : t < -ε) :
+    μ c ε t = 0 := by
+  unfold μ
+  rw [if_pos (by linarith : t < 0), pre_μ, neg_eq_zero]
+  refine MeasureTheory.setIntegral_eq_zero_of_forall_eq_zero fun ξ hξ ↦ ?_
+  have h1 : ξ ≤ t := hξ
+  refine η_eq_zero_of_abs_gt ?_
+  rw [abs_of_neg (by linarith : ξ < 0)]
+  linarith
+
+lemma μ_eq_zero_of_gt {c ε : ℝ} (hε : 0 < ε) {t : ℝ} (ht : ε < t) :
+    μ c ε t = 0 := by
+  have h1 := μ_eq_zero_of_lt_neg (c := c) hε (by linarith : -t < -ε)
+  have h2 := μ_neg c ε t
+  linarith [h1, h2]
+
+lemma μ_antitoneOn {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) :
+    AntitoneOn (μ c ε) (Set.Ioi 0) := by
+  intro s hs t ht hst
+  rw [Set.mem_Ioi] at hs ht
+  unfold μ
+  rw [if_neg (by linarith : ¬ t < 0), if_pos ht, if_neg (by linarith : ¬ s < 0),
+    if_pos hs, pre_μ, pre_μ, neg_neg, neg_neg]
+  refine MeasureTheory.setIntegral_mono_set ((integrable_η hc hε).integrableOn)
+    (MeasureTheory.ae_of_all _ fun ξ ↦ η_nonneg hc hε ξ) ?_
+  exact (Set.Iic_subset_Iic.mpr (by linarith : -t ≤ -s)).eventuallyLE
+
+lemma ν_nonpos_of_nonpos {c ε : ℝ} (hc : 0 < c) (hε : 0 < ε) {t : ℝ} (ht : t ≤ 0) :
+    ν c ε t ≤ 0 := by
+  unfold ν
+  refine MeasureTheory.setIntegral_nonpos measurableSet_Iic fun τ hτ ↦ ?_
+  have h1 : τ ≤ t := hτ
+  rcases lt_or_eq_of_le (le_trans h1 ht) with h | h
+  · exact μ_nonpos_of_neg hc hε h
+  · simp [h, μ_zero]
+
+lemma ν_eq_zero_of_lt_neg {c ε : ℝ} (hε : 0 < ε) {t : ℝ} (ht : t < -ε) :
+    ν c ε t = 0 := by
+  unfold ν
+  refine MeasureTheory.setIntegral_eq_zero_of_forall_eq_zero fun τ hτ ↦ ?_
+  exact μ_eq_zero_of_lt_neg hε (lt_of_le_of_lt hτ ht)
+
 @[blueprint
   "bklnw-thm_16"
   (title := "Theorem 16")


### PR DESCRIPTION
Follow-up to #1523, which encoded η in Büthe's closed form with an explicit Bessel I₀ power series and introduced the μ and ν weights. 

This adds the elementary facts about those objects: sign, support and symmetry for η; support, sign, monotonicity and integrability for μ and ν; positivity, monotonicity, summability and two-sided partial-sum bounds for the I₀ series; continuity and measurability where the later integrals need them.

27 lemmas in BKLNW_app.lean, purely additive, no statement changes. 
Every new declaration reports [propext,Classical.choice, Quot.sound].
  
Tool Usage:
The Lean code was developed using Claude Code CLI. Everything is kernel-checked, and I reviewed and assembled the final branch.  The PR built but initially failed CI/CD on the documentation rebuild, updated and reopened to resolve the stale packages issue.

As well, I understand that AI assisted PRs may, or do take longer to review. I am fully open to any feedback on style/pace/format that maintainers have.

Rob
  
