### PR TITLE
fix: require Re(s) > 2 in LSeries_totient_eq

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1471,7 +1471,7 @@ lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouvil
 L(\varphi, s) = \prod_{p} \left(1 + \varphi(p)p^{-s} + \varphi(p^2)p^{-2s} + \ldots\right) = \prod_{p} \left(1 - p^{-s  +1}\right)^{-1} \left(1 - p^{-s}\right) = \frac{\zeta(s-1)}{\zeta(s)}.
 \]
   -/)]
-lemma LSeries_totient_eq {s : ℂ} (hs : 1 < s.re) :
+lemma LSeries_totient_eq {s : ℂ} (hs : 2 < s.re) :
     LSeries (↗totient) s = riemannZeta (s - 1) / riemannZeta s := by
   sorry
 


### PR DESCRIPTION
## Summary
`LSeries_totient_eq` used hypothesis `1 < Re(s)`, but `LSeries (↗totient) s` is only absolutely summable for `Re(s) > 2`. In the strip `1 < Re(s) ≤ 2` the series does not converge absolutely, so the identity is false as stated.

## Why this fix is correct
The Euler product for φ requires `Re(s) > 2` and `Re(s-1) > 1`, i.e. `Re(s) > 2`, matching IK (1.35).

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1`


Made with [Cursor](https://cursor.com)