### PR TITLE
fix: state Re(s) > 2 in LSeries_totient_eq blueprint

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1460,7 +1460,7 @@ lemma liouville_eq_moebius_on_squarefree (n : ℕ) (hn : Squarefree n) : liouvil
 @[blueprint
   "LSeries_totient_eq"
   (title := "LSeries totient eq")
-  (statement := /-- Euler totient series: $\sum_{n=1}^{\infty} \varphi(n) n^{-s} = \zeta(s-1)/\zeta(s)$.
+  (statement := /-- Euler totient series: $\sum_{n=1}^{\infty} \varphi(n) n^{-s} = \zeta(s-1)/\zeta(s)$ for $\Re(s) > 2$.
   \begin{verbatim}
   This is IK (1.35).
   \end{verbatim}


### PR DESCRIPTION
## Summary
The blueprint statement for `LSeries_totient_eq` omitted the convergence region. The totient Dirichlet series identity is only valid for `Re(s) > 2`.

## Why this fix is correct
This matches the Lean hypothesis fix and the standard absolute-convergence threshold for `L(φ, s) = ζ(s-1)/ζ(s)`.

## Test plan
- [ ] Blueprint build (if applicable)


Made with [Cursor](https://cursor.com)