### PR TITLE
Kadiri: fill the gamma-symmetrization sublemma (#1544)

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -120,7 +120,17 @@ theorem hadamard_identity (s : ℂ) (hs1 : s ≠ 1)
 The proof of \ref{kadiri-thm-3-1-q1} (Kadiri 2005, \S 3.1, pp.~11--13) decomposes into
 several explicit steps. We state each as its own blueprinted sublemma below, with `sorry`
 proofs to be filled in. The displayed equation before \cite[(11)]{Kadiri2005} is the
-underlying Laplace-inversion identity; equations (11)--(15) are the explicit steps. -/
+underlying Laplace-inversion identity; equations (11)--(15) are the explicit steps.
+
+Convention: in these sublemmas $\Phi$ denotes the two-sided Laplace transform
+$\Phi(s) := \int_{-\infty}^{\infty} \varphi(y)\, e^{-sy}\, dy$, convergent on the strip
+$-(1+b) < \Re s < b$ supplied by hypothesis (B). Kadiri's intermediate equations evaluate the
+inverted transform at both reflections $y = \pm \log n$, so equations (13) and (14) hold only
+for the two-sided transform: with the one-sided $\int_0^\infty$ the limit of $I_1(T)$ is the
+half-value $\tfrac{1}{2}\varphi(0)\log(1/\pi)$ (jump of $\varphi \mathbf{1}_{(0,\infty)}$ at
+$y = 0$) and the limit of $I_2(T)$ is $0$ (the one-sided transform carries no information
+about $\varphi$ on $(-\infty, 0)$). The final statement \ref{kadiri-thm-3-1-q1} uses the
+same two-sided transform. -/
 
 @[blueprint
   "kadiri-thm-3-1-q1-laplace-inversion"
@@ -132,9 +142,9 @@ underlying Laplace-inversion identity; equations (11)--(15) are the explicit ste
      = \frac{1}{2\pi i}
        \int_{-(1 + a) - i\infty}^{-(1 + a) + i\infty}
        \Phi(s)\, n^{s}\, ds, $$
-  where $\Phi(s) := \int_0^{\infty} \varphi(y)\, e^{-sy}\, dy$ is the Laplace transform of
-  $\varphi$. The contour $\sigma = -(1 + a)$ lies inside the strip of holomorphy of
-  $\Phi$ given by (B). This is the displayed equation just before
+  where $\Phi(s) := \int_{-\infty}^{\infty} \varphi(y)\, e^{-sy}\, dy$ is the two-sided
+  Laplace transform of $\varphi$. The contour $\sigma = -(1 + a)$ lies inside the strip of
+  holomorphy of $\Phi$ given by (B). This is the displayed equation just before
   \cite[(11)]{Kadiri2005}. -/)
   (proof := /-- Standard inverse-Laplace theorem (e.g.\ Widder, \emph{The Laplace
   Transform}, Ch.~III, Theorem~7.3). Hypotheses (A) (regularity / mean-value condition at

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -636,7 +636,14 @@ theorem kadiri_thm_3_1_q1_gamma_symmetrization {s : ℂ} (_hs : s.re = 1 / 2) :
                   \Phi(-s)\, ds. $$
   Specialization of equation~(15) of \cite{Kadiri2005}, page~13, to $q = 1$
   ($\mathfrak{a} = 0$, so $(1 - \mathfrak{a})\Phi(0) = \Phi(0)$ in Kadiri's
-  $\mathfrak{a}$-dependent form). -/)
+  $\mathfrak{a}$-dependent form).
+
+  The hypothesis on the critical-line integrand makes the Lebesgue integral on the
+  right-hand side agree with Kadiri's symmetric improper integral: hypotheses (A) and (B)
+  alone give only $O(1/|t|)$ decay of $\Phi$ against the $\log|t|$ growth of
+  $\Re[\Gamma'/\Gamma]$, so the integrand need not be Lebesgue integrable, in which case
+  the formalised integral takes the junk value $0$ while $I_3(T)$ still converges (to the
+  improper value). The same hypothesis is carried by \ref{kadiri-thm-3-1-q1}. -/)
   (proof := /-- Shift the contour of $I_3(T)$ from $\sigma = -a$ to $\sigma = 1/2$.
   The integrand $\tfrac{1}{2}\{\Gamma'/\Gamma(s/2) + \Gamma'/\Gamma((1-s)/2)\}\, \Phi(-s)$
   has a simple pole at $s = 0$ from $\Gamma'/\Gamma(s/2) \sim -2/s$ near $s = 0$, with

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -134,23 +134,25 @@ same two-sided transform. -/
 
 @[blueprint
   "kadiri-thm-3-1-q1-laplace-inversion"
-  (title := "Laplace inversion of $\\varphi$ at $y = \\log n$ for $n \\geq 1$")
+  (title := "Laplace inversion of $\\varphi$ at $y = \\log n$ for $n \\geq 2$")
   (statement := /-- For $\varphi$ satisfying hypotheses (A) and (B) of
   \ref{kadiri-thm-3-1-q1}, and any real $a$ with $0 < a < b$ and $a < 1$: for every
-  positive integer $n \geq 1$,
+  integer $n \geq 2$,
   $$ \varphi(\log n)
-     = \frac{1}{2\pi i}
-       \int_{-(1 + a) - i\infty}^{-(1 + a) + i\infty}
+     = \lim_{T \to \infty} \frac{1}{2\pi i}
+       \int_{-(1 + a) - iT}^{-(1 + a) + iT}
        \Phi(s)\, n^{s}\, ds, $$
   where $\Phi(s) := \int_{-\infty}^{\infty} \varphi(y)\, e^{-sy}\, dy$ is the two-sided
   Laplace transform of $\varphi$. The contour $\sigma = -(1 + a)$ lies inside the strip of
-  holomorphy of $\Phi$ given by (B). This is the displayed equation just before
-  \cite[(11)]{Kadiri2005}. -/)
-  (proof := /-- Standard inverse-Laplace theorem (e.g.\ Widder, \emph{The Laplace
-  Transform}, Ch.~III, Theorem~7.3). Hypotheses (A) (regularity / mean-value condition at
-  jumps) and (B) (the $O(1/|t|)$ decay of $\Phi$ on the strip) provide exactly what is
-  needed for the inversion integral to converge absolutely and recover $\varphi$ at
-  $y = \log n \geq 0$. To be formalised. -/)
+  holomorphy of $\Phi$ given by (B). The integral is a symmetric truncation: under (A)
+  and (B) alone $\Phi$ decays only like $1/|t|$ on the line when $\varphi(0) \neq 0$, so
+  the line integral need not converge absolutely. The restriction to $n \geq 2$ is all
+  that \ref{kadiri-thm-3-1-q1-eq-11} consumes, since $\Lambda(1) = 0$. This is the
+  displayed equation just before \cite[(11)]{Kadiri2005}. -/)
+  (proof := /-- Symmetric-truncation (principal value) Laplace/Fourier inversion at a
+  continuity point: hypothesis (A) gives $\varphi \in C^1$, so the Dirichlet/Dini
+  argument applies to $\varphi(y) e^{(1+a)y}$ at $y = \log n$, and (B) controls the
+  tails of the truncated integrals on the strip. To be formalised. -/)
   (latexEnv := "sublemma")
   (discussion := 1535)]
 theorem kadiri_thm_3_1_q1_laplace_inversion {φ : ℝ → ℂ} (_hφ : ContDiff ℝ 1 φ)
@@ -160,13 +162,15 @@ theorem kadiri_thm_3_1_q1_laplace_inversion {φ : ℝ → ℂ} (_hφ : ContDiff 
     (_hφ'_decay : (fun x : ℝ ↦ deriv φ x * exp ((x : ℂ) / 2))
         =O[Filter.cocompact ℝ] fun x : ℝ ↦ Real.exp (-(1/2 + b) * |x|))
     {a : ℝ} (_ha : 0 < a) (_hab : a < b) (_ha1 : a < 1)
-    {n : ℕ} (_hn : 1 ≤ n) :
+    {n : ℕ} (_hn : 2 ≤ n) :
     let Φ : ℂ → ℂ := fun s ↦ ∫ y, φ y * exp (-s * (y : ℂ)) ∂volume
-    (φ (Real.log n) : ℂ) =
-      (1 / (2 * (Real.pi : ℂ))) *
-        ∫ t : ℝ,
-          Φ ((-(1 + a : ℝ) : ℂ) + (t : ℂ) * I) *
-            ((n : ℂ) ^ ((-(1 + a : ℝ) : ℂ) + (t : ℂ) * I)) := by
+    Filter.Tendsto
+      (fun T : ℝ ↦
+        (1 / (2 * (Real.pi : ℂ))) *
+          ∫ t in Set.Ioo (-T) T,
+            Φ ((-(1 + a : ℝ) : ℂ) + (t : ℂ) * I) *
+              ((n : ℂ) ^ ((-(1 + a : ℝ) : ℂ) + (t : ℂ) * I)))
+      Filter.atTop (nhds (φ (Real.log n))) := by
   sorry
 
 @[blueprint
@@ -514,8 +518,9 @@ theorem kadiri_thm_3_1_q1_shifted_eq_I123
   $\log(q/\pi) = -\log\pi$). -/)
   (proof := /-- The constant prefactor $\log(1/\pi)$ pulls out of the integral. The
   remaining $\tfrac{1}{2\pi i} \int_{-a - iT}^{-a + iT} \Phi(-s)\, ds$ tends to
-  $\varphi(0)$ as $T \to \infty$ by the Laplace-inversion identity at $y = 0$
-  (\ref{kadiri-thm-3-1-q1-laplace-inversion} specialized to $n = 1$, with a
+  $\varphi(0)$ as $T \to \infty$ by the symmetric-truncation inversion argument of
+  \ref{kadiri-thm-3-1-q1-laplace-inversion} at $y = 0$ (a continuity point of
+  $\varphi$, since the transform is two-sided there is no jump; with a
   change of variable $s \mapsto -s$ that maps the $\sigma = -a$ contour back to
   $\sigma = a$). To be formalised. -/)
   (latexEnv := "sublemma")

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -3,6 +3,7 @@ import PrimeNumberTheoremAnd.Defs
 import PrimeNumberTheoremAnd.IEANTN.ZetaDefinitions
 import PrimeNumberTheoremAnd.IEANTN.KadiriZeroCounting
 import PrimeNumberTheoremAnd.IEANTN.HadamardLogDerivative
+import PrimeNumberTheoremAnd.Mathlib.NumberTheory.LSeries.RiemannZetaHadamard
 import Mathlib.Analysis.SpecialFunctions.Gamma.Digamma
 import Mathlib.NumberTheory.LSeries.RiemannZeta
 
@@ -84,10 +85,28 @@ lift it to all of $\mathbb{C}$ is no longer needed and is commented out below
   Euler-Mascheroni constant $\gamma$ (\cite[Chapter 12]{Davenport2000}). For our purposes it
   appears only as the additive constant in \ref{kadiri-hadamard-identity}, and the identity
   $\Re B = -\sum_{\rho \in Z(\zeta)} \Re \tfrac{1}{\rho}$ used in the derivation of
-  \ref{kadiri-prop-2-1}. -/)
+  \ref{kadiri-prop-2-1}.
+
+  Formally, $B$ is extracted from the Hadamard factorisation of Riemann's xi function
+  $\xi(s) = (s-1)\, \pi^{-s/2}\, \Gamma(\tfrac{s}{2}+1)\, \zeta(s)$: there is a unique
+  $B \in \mathbb{C}$ arising as $P'(0)$ for a degree-one polynomial $P$ with
+  $\xi(z) = e^{P(z)} \prod_\rho (1 - z/\rho) e^{z/\rho}$ (the genus-one canonical product
+  over the xi divisor, with multiplicity), and the displayed product expansion of
+  $(s-1)\zeta(s)$ is that factorisation with the archimedean factors moved across. -/)
   (latexEnv := "definition")
   (discussion := 1474)]
-noncomputable def hadamardB : ℂ := sorry
+noncomputable def hadamardB : ℂ :=
+  Classical.choose existsUnique_riemannXi_hadamard_polynomial_derivative_eval_zero.exists
+
+/-- Choice specification for `hadamardB`: some degree-one polynomial `P` realizes the
+no-monomial xi Hadamard factorization with `hadamardB = P.derivative.eval 0`. -/
+theorem hadamardB_spec :
+    ∃ P : Polynomial ℂ, P.degree ≤ 1 ∧
+      (∀ z : ℂ, riemannXi z =
+        Complex.exp (Polynomial.eval z P) *
+          Complex.Hadamard.divisorCanonicalProduct 1 riemannXi (Set.univ : Set ℂ) z) ∧
+      hadamardB = Polynomial.eval 0 P.derivative :=
+  Classical.choose_spec existsUnique_riemannXi_hadamard_polynomial_derivative_eval_zero.exists
 
 @[blueprint
   "kadiri-hadamard-identity"

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -174,20 +174,45 @@ theorem kadiri_thm_3_1_q1_laplace_inversion {φ : ℝ → ℂ} (_hφ : ContDiff 
   sorry
 
 @[blueprint
+  "kadiri-thm-3-1-q1-I"
+  (title := "Truncated contour integral $I(T)$ on $\\sigma = 1 + a$")
+  (statement := /-- Kadiri's $I(T)$ from \cite[p.~12]{Kadiri2005}: the truncated contour
+  integral
+  $$ I(T) \;:=\; \frac{1}{2\pi i} \int_{1+a-iT}^{1+a+iT}
+              \!\!\!\! \left(-\frac{\zeta'}{\zeta}\right)\!(s)\, \Phi(-s)\, ds, $$
+  where $\Phi(s) := \int_{-\infty}^{\infty} \varphi(y) e^{-sy}\, dy$ is the two-sided
+  Laplace transform of $\varphi$. The $T \to \infty$ limit of $I(T)$ is the Mellin-contour
+  identity of \ref{kadiri-thm-3-1-q1-eq-11}, and its rectangle decomposition is
+  equation~(12) of \cite{Kadiri2005} (\ref{kadiri-thm-3-1-q1-eq-12}). -/)
+  (latexEnv := "definition")]
+noncomputable def kadiri_thm_3_1_q1_I (φ : ℝ → ℂ) (a T : ℝ) : ℂ :=
+  let Φ : ℂ → ℂ := fun s ↦ ∫ y, φ y * exp (-s * (y : ℂ)) ∂volume
+  (1 / (2 * (Real.pi : ℂ))) *
+    ∫ t in Set.Ioo (-T) T,
+      (-deriv riemannZeta (((1 + a : ℝ) : ℂ) + (t : ℂ) * I) /
+          riemannZeta (((1 + a : ℝ) : ℂ) + (t : ℂ) * I)) *
+        Φ (-(((1 + a : ℝ) : ℂ) + (t : ℂ) * I))
+
+@[blueprint
   "kadiri-thm-3-1-q1-eq-11"
   (title := "Equation (11) of \\cite{Kadiri2005}: LHS as a Mellin contour integral")
   (statement := /-- For $\varphi$ satisfying (A) and (B) of \ref{kadiri-thm-3-1-q1},
   and any real $a$ with $0 < a < b$ and $a < 1$,
   $$ \sum_{n \geq 1} \Lambda(n)\, \varphi(\log n)
-     = \frac{1}{2 \pi i}
-       \int_{1 + a - i\infty}^{1 + a + i\infty}
+     = \lim_{T \to \infty} I(T), \qquad
+       I(T) = \frac{1}{2 \pi i}
+       \int_{1 + a - iT}^{1 + a + iT}
          \left(-\frac{\zeta'}{\zeta}\right)(s)\, \Phi(-s)\, ds, $$
-  with $\Phi$ as in \ref{kadiri-thm-3-1-q1-laplace-inversion}. This is equation~(11) of
-  \cite{Kadiri2005}, page~11, specialized to $q = 1$. -/)
+  with $\Phi$ as in \ref{kadiri-thm-3-1-q1-laplace-inversion} and $I(T)$ the truncated
+  contour integral defined above. The symmetric truncation matters for the same reason as
+  in \ref{kadiri-thm-3-1-q1-laplace-inversion}: when $\varphi(0) \neq 0$ the integrand
+  decays only like $1/|t|$ and the full line integral need not exist. This is
+  equation~(11) of \cite{Kadiri2005}, page~11, specialized to $q = 1$. -/)
   (proof := /-- Corollary of \ref{kadiri-thm-3-1-q1-laplace-inversion}: multiply that
-  identity by $\Lambda(n)$, sum over $n \geq 1$, and exchange sum and integral
-  (justified by absolute convergence of the Dirichlet series for $-\zeta'/\zeta$ on
-  $\sigma > 1$ combined with the $O(1/|t|)$ decay of $\Phi$ from (B)). The Dirichlet
+  identity by $\Lambda(n)$, sum over $n \geq 2$ ($\Lambda(1) = 0$), and exchange sum and
+  truncated integral (justified at each fixed $T$ by absolute convergence of the
+  Dirichlet series for $-\zeta'/\zeta$ on $\sigma > 1$); the truncated inversion limits
+  are uniform enough in $n$ by (B) to pass to the limit in the sum. The Dirichlet
   series identity $-\zeta'/\zeta(s) = \sum_n \Lambda(n) n^{-s}$ converts the sum into a
   factor of $-\zeta'/\zeta(s)$ in the integrand. Finally, change of variable
   $s \mapsto -s$ maps the contour $\sigma = -(1 + a)$ to $\sigma = 1 + a$ (with the
@@ -201,34 +226,9 @@ theorem kadiri_thm_3_1_q1_eq_11 {φ : ℝ → ℂ} (_hφ : ContDiff ℝ 1 φ)
     (_hφ'_decay : (fun x : ℝ ↦ deriv φ x * exp ((x : ℂ) / 2))
         =O[Filter.cocompact ℝ] fun x : ℝ ↦ Real.exp (-(1/2 + b) * |x|))
     {a : ℝ} (_ha : 0 < a) (_hab : a < b) (_ha1 : a < 1) :
-    let Φ : ℂ → ℂ := fun s ↦ ∫ y, φ y * exp (-s * (y : ℂ)) ∂volume
-    (∑' n : ℕ, (Λ n : ℂ) * φ (Real.log n)) =
-      (1 / (2 * (Real.pi : ℂ))) *
-        ∫ t : ℝ,
-          (-deriv riemannZeta (((1 + a : ℝ) : ℂ) + (t : ℂ) * I) /
-              riemannZeta (((1 + a : ℝ) : ℂ) + (t : ℂ) * I)) *
-            Φ (-(((1 + a : ℝ) : ℂ) + (t : ℂ) * I)) := by
+    Filter.Tendsto (fun T : ℝ ↦ kadiri_thm_3_1_q1_I φ a T) Filter.atTop
+      (nhds (∑' n : ℕ, (Λ n : ℂ) * φ (Real.log n))) := by
   sorry
-
-@[blueprint
-  "kadiri-thm-3-1-q1-I"
-  (title := "Truncated contour integral $I(T)$ on $\\sigma = 1 + a$")
-  (statement := /-- Kadiri's $I(T)$ from \cite[p.~12]{Kadiri2005}: the truncated contour
-  integral
-  $$ I(T) \;:=\; \frac{1}{2\pi i} \int_{1+a-iT}^{1+a+iT}
-              \!\!\!\! \left(-\frac{\zeta'}{\zeta}\right)\!(s)\, \Phi(-s)\, ds, $$
-  where $\Phi(s) := \int_0^\infty \varphi(y) e^{-sy}\, dy$ is the Laplace transform of
-  $\varphi$. The $T \to \infty$ limit of $I(T)$ is the Mellin-contour identity of
-  \ref{kadiri-thm-3-1-q1-eq-11}, and its rectangle decomposition is equation~(12) of
-  \cite{Kadiri2005} (\ref{kadiri-thm-3-1-q1-eq-12}). -/)
-  (latexEnv := "definition")]
-noncomputable def kadiri_thm_3_1_q1_I (φ : ℝ → ℂ) (a T : ℝ) : ℂ :=
-  let Φ : ℂ → ℂ := fun s ↦ ∫ y, φ y * exp (-s * (y : ℂ)) ∂volume
-  (1 / (2 * (Real.pi : ℂ))) *
-    ∫ t in Set.Ioo (-T) T,
-      (-deriv riemannZeta (((1 + a : ℝ) : ℂ) + (t : ℂ) * I) /
-          riemannZeta (((1 + a : ℝ) : ℂ) + (t : ℂ) * I)) *
-        Φ (-(((1 + a : ℝ) : ℂ) + (t : ℂ) * I))
 
 @[blueprint
   "kadiri-thm-3-1-q1-eq-12"

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -111,27 +111,30 @@ theorem hadamardB_spec :
 @[blueprint
   "kadiri-hadamard-identity"
   (title := "Hadamard expansion of $-\\zeta'/\\zeta$ (after equation (16))")
-  (statement := /-- For every $s \in \mathbb{C}$ that is neither $1$ nor a non-trivial zero
-  of $\zeta$,
+  (statement := /-- For every $s \in \mathbb{C}$ with $\Re s > 1$,
   $$ -\frac{\zeta'}{\zeta}(s) = -B - \tfrac{1}{2} \log \pi + \frac{1}{s - 1}
        + \tfrac{1}{2} \frac{\Gamma'}{\Gamma}\!\left(\tfrac{s}{2} + 1\right)
-       - \sum_{\rho \in Z(\zeta)} \left(\frac{1}{\rho} + \frac{1}{s - \rho}\right), $$
-  where $B$ is the Hadamard constant (\ref{kadiri-hadamard-B}). This is the logarithmic
-  derivative of the Hadamard factorisation of $\zeta$
+       - \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)
+           \left(\frac{1}{\rho} + \frac{1}{s - \rho}\right), $$
+  where $B$ is the Hadamard constant (\ref{kadiri-hadamard-B}) and each zero is counted
+  with its multiplicity $\mathrm{ord}_\zeta(\rho)$, as the Hadamard product repeats its
+  factors. The half-plane $\Re s > 1$ is where Kadiri's downstream argument applies the
+  identity; it supplies $s \neq 1$ and $\zeta(s) \neq 0$ directly. This is the
+  logarithmic derivative of the Hadamard factorisation of $\zeta$
   (\cite[Chapter 12]{Davenport2000}). -/)
   (proof := /-- Differentiate the Hadamard product (\ref{kadiri-hadamard-B}) logarithmically;
   the linear-in-$s$ term in the exponential collapses to the constant $B$. The
   $\tfrac{1}{s-1}$ term comes from the $(s-1)\zeta(s)$ prefactor and the
-  $\tfrac{1}{2} \Gamma'/\Gamma$ term from the gamma factor. To be formalised. -/)
+  $\tfrac{1}{2} \Gamma'/\Gamma$ term from the gamma factor; the zero factors contribute
+  one kernel term per unit of multiplicity. To be formalised. -/)
   (latexEnv := "lemma")
   (discussion := 1474)]
-theorem hadamard_identity (s : ℂ) (hs1 : s ≠ 1)
-    (hsZ : s ∉ riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ)) :
+theorem hadamard_identity {s : ℂ} (hs : 1 < s.re) :
     -deriv riemannZeta s / riemannZeta s =
       -hadamardB - (1 / 2 : ℂ) * Real.log Real.pi + 1 / (s - 1) +
       (1 / 2 : ℂ) * digamma (s / 2 + 1) -
-      ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-        (1 / (ρ.val : ℂ) + 1 / (s - ρ.val)) := by
+      riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+        (fun ρ ↦ 1 / ρ + 1 / (s - ρ)) := by
   sorry
 
 /-! ## Sublemmas for the proof of Theorem 3.1
@@ -1989,19 +1992,23 @@ $|\Re F(s - \rho)| \ll 1/\gamma^2$. -/
 @[blueprint
   "kadiri-re-hadamardB-eq"
   (title := "Real part of the Hadamard constant")
-  (statement := /-- $\Re B = -\sum_{\rho \in Z(\zeta)} \Re \tfrac{1}{\rho}$, where $B$ is the
-  Hadamard constant (\ref{kadiri-hadamard-B}). -/)
+  (statement := /-- $\Re B = -\sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)\,
+  \Re \tfrac{1}{\rho}$, where $B$ is the Hadamard constant (\ref{kadiri-hadamard-B}) and
+  each zero is counted with its multiplicity, matching the weights of
+  \ref{kadiri-hadamard-identity}. Unlike the paired complex kernel, the real parts
+  $\Re(1/\rho)$ are separately (absolutely) summable on the strip. -/)
   (proof := /-- Subtract $\tfrac{1}{s-1}$ from \ref{kadiri-hadamard-identity}, take $s \to 1$
   using the Laurent expansion $-\zeta'/\zeta(s) = \tfrac{1}{s-1} - \gamma + O(s - 1)$ near $s = 1$
   and the value $\Gamma'/\Gamma(3/2)$, then symmetrise the resulting sum
-  $\sum_\rho (1/\rho + 1/(1-\rho))$ using $\rho \leftrightarrow 1 - \bar\rho$ to relate
+  $\sum_\rho (1/\rho + 1/(1-\rho))$ using the involution $\rho \leftrightarrow 1 - \rho$
+  of the functional equation (which preserves multiplicities) to relate
   $\sum_\rho 1/\rho$ to $\Re B$. To be formalised. -/)
   (latexEnv := "lemma")
   (discussion := 1476)]
 theorem re_hadamardB_eq :
     hadamardB.re =
-    -∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-        (1 / (ρ.val : ℂ)).re := by
+      -riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+        (fun ρ ↦ (1 / ρ).re) := by
   sorry
 
 @[blueprint
@@ -2600,12 +2607,15 @@ theorem summable_lap_re_at_zeros {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
   $s \in \mathbb{C}$ with $\Re s > 1$,
   $$ \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} f(\log n)
    = f(0) \Bigl( \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} - \frac{1}{s - 1} \Bigr)
-   + \sum_{\rho \in Z(\zeta)} \Bigl( \frac{f(0)}{s - \rho} - F(s - \rho) \Bigr)
+   + \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)
+       \Bigl( \frac{f(0)}{s - \rho} - F(s - \rho) \Bigr)
    + F(s - 1)
    + \Bigl( \frac{1}{2\pi i} \int_{1/2 - i\infty}^{1/2 + i\infty}
        \Re \tfrac{\Gamma'}{\Gamma}\!\left(\tfrac{z}{2}\right) \frac{F_2(s - z)}{(s - z)^2}\, dz
        + \frac{F_2(s)}{s^2} \Bigr). $$
-  The zero sum is grouped: each summand is $\Phi(-\rho)$, the Laplace transform of the
+  The zero sum is grouped and carries the multiplicity weights
+  $\mathrm{ord}_\zeta(\rho)$ that the residue calculus of \ref{kadiri-thm-3-1-q1}
+  produces: each summand is $\Phi(-\rho)$, the Laplace transform of the
   test function $\varphi(y) = (f(0) - f(y)) e^{-y s}$ at $-\rho$, equal to
   $-F_2(s-\rho)/(s-\rho)^2$ and hence of size $O(1/|\Im \rho|^2)$; the split sums
   $\sum_\rho 1/(s-\rho)$ and $\sum_\rho F(s-\rho)$ are individually divergent.
@@ -2640,8 +2650,8 @@ theorem identity_16_complex {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
     {s : ℂ} (hs : 1 < s.re) :
     (∑' n : ℕ, (Λ n : ℂ) / (n : ℂ) ^ s * ((f (Real.log n) : ℝ) : ℂ)) =
       (f 0 : ℂ) * ((∑' n : ℕ, (Λ n : ℂ) / (n : ℂ) ^ s) - 1 / (s - 1))
-      + ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-          ((f 0 : ℂ) / (s - ρ.val) - laplaceTransform f (s - ρ.val))
+      + riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+          (fun ρ ↦ (f 0 : ℂ) / (s - ρ) - laplaceTransform f (s - ρ))
       + laplaceTransform f (s - 1)
       + ((1 / (2 * (Real.pi : ℂ))) *
           (∫ t : ℝ,
@@ -2658,18 +2668,20 @@ theorem identity_16_complex {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
   $s \in \mathbb{C}$ with $\Re s > 1$,
   $$ \Re \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} f(\log n)
    = f(0) \Bigl( \Re \Bigl( \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} - \frac{1}{s - 1}
-                  + \sum_{\rho \in Z(\zeta)} \Bigl( \frac{1}{\rho} + \frac{1}{s - \rho} \Bigr) \Bigr)
-                  - \sum_{\rho \in Z(\zeta)} \Re \frac{1}{\rho} \Bigr)
-   + \Re F(s - 1) - \sum_{\rho \in Z(\zeta)} \Re F(s - \rho)
+                  + \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)
+                      \Bigl( \frac{1}{\rho} + \frac{1}{s - \rho} \Bigr) \Bigr)
+                  - \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)\, \Re \frac{1}{\rho} \Bigr)
+   + \Re F(s - 1) - \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)\, \Re F(s - \rho)
    + \Re \Bigl( \frac{1}{2\pi i} \int_{1/2 - i\infty}^{1/2 + i\infty}
        \Re \tfrac{\Gamma'}{\Gamma}\!\left(\tfrac{z}{2}\right) \frac{F_2(s - z)}{(s - z)^2}\, dz
        + \frac{F_2(s)}{s^2} \Bigr). $$
   This is the real-part form of \ref{kadiri-identity-16-complex}; the substantive
   derivation from \ref{kadiri-thm-3-1-q1} via the Kadiri test function
   $\varphi(y) = (f(0) - f(y)) e^{-y s} \mathbf{1}_{y \geq 0}$ lives in that sublemma.
-  The zero contribution in the $f(0)$-coefficient uses the absolutely convergent
-  Hadamard-paired block $\sum_\rho (1/\rho + 1/(s - \rho))$ together with the absolutely
-  convergent real correction $\sum_\rho \Re(1/\rho)$, matching
+  All three zero sums carry the multiplicity weights $\mathrm{ord}_\zeta(\rho)$ of the
+  residue calculus. The zero contribution in the $f(0)$-coefficient uses the absolutely
+  convergent Hadamard-paired block $\sum_\rho (1/\rho + 1/(s - \rho))$ together with the
+  absolutely convergent real correction $\sum_\rho \Re(1/\rho)$, matching
   \ref{kadiri-hadamard-identity}; the standalone $\sum_\rho 1/(s - \rho)$ does not
   converge unconditionally. The restriction $\Re s > 1$ is where the Dirichlet series for
   $-\zeta'/\zeta(s)$ converges absolutely; this is also the range used in Kadiri's
@@ -2678,9 +2690,12 @@ theorem identity_16_complex {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
   equation, then take real parts of both sides. The grouped zero sum is absolutely
   summable (each summand is $-F_2(s-\rho)/(s-\rho)^2$ by \ref{kadiri-laplace-ibp}), so
   $\Re$ passes through it; each term splits as $f(0) \Re(1/(s-\rho)) - \Re F(s-\rho)$,
-  and both real families are absolutely summable. Regrouping
+  and both real families are absolutely summable, with the order weights carried by the
+  weighted square-tail bound. Regrouping
   $\sum_\rho \Re(1/(s-\rho))$ into the paired block minus the $\Re(1/\rho)$ correction
-  is legitimate by the paired-family summability. -/)
+  is legitimate by the paired-family summability. To be re-formalised in the weighted
+  form: the unweighted version of this argument is in the history, and the weighted
+  square tail is available; the weighted splitting lemmas remain to be supplied. -/)
   (latexEnv := "lemma")
   (discussion := 1488)]
 theorem identity_16 {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
@@ -2694,13 +2709,13 @@ theorem identity_16 {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
     {s : ℂ} (hs : 1 < s.re) :
     (∑' n : ℕ, (Λ n : ℂ) / (n : ℂ) ^ s * ((f (Real.log n) : ℝ) : ℂ)).re =
       f 0 * (((∑' n : ℕ, (Λ n : ℂ) / (n : ℂ) ^ s) - 1 / (s - 1) +
-                ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-                  (1 / (ρ.val : ℂ) + 1 / (s - ρ.val))).re -
-              ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-                (1 / (ρ.val : ℂ)).re)
+                riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+                  (fun ρ ↦ 1 / ρ + 1 / (s - ρ))).re -
+              riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+                (fun ρ ↦ (1 / ρ).re))
         + (laplaceTransform f (s - 1)).re
-        - ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) .univ,
-            (laplaceTransform f (s - ρ.val)).re
+        - riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+            (fun ρ ↦ (laplaceTransform f (s - ρ)).re)
         + ((1 / (2 * (Real.pi : ℂ))) *
             (∫ t : ℝ,
               ((digamma ((1 / 2 + (t : ℂ) * I) / 2)).re : ℂ) *
@@ -2708,42 +2723,15 @@ theorem identity_16 {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
                   (s - (1 / 2 + (t : ℂ) * I))
                 / (s - (1 / 2 + (t : ℂ) * I)) ^ 2)
             + laplaceTransform (fun u ↦ deriv (deriv f) u) s / s ^ 2).re := by
-  have hcomplex := identity_16_complex hd hf_C2 hf_supp hf_d hf_deriv_0 hf_deriv_d
-    hf_deriv2_d hs
-  have hsub := summable_lap_sub_pole_at_zeros hd hf_C2 hf_supp hf_d hf_deriv_0
-    hf_deriv_d s
-  have hre1 := summable_re_one_div_at_zeros s
-  have hreF := summable_lap_re_at_zeros hd hf_nonneg hf_C2 hf_supp hf_d hf_deriv_0
-    hf_deriv_d hf_deriv2_d s
-  -- `Re` commutes with the grouped zero sum, which is genuinely summable
-  have htsum_re :
-      (∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-          ((f 0 : ℂ) / (s - ρ.val) - laplaceTransform f (s - ρ.val))).re =
-      ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-          ((f 0 : ℂ) / (s - ρ.val) - laplaceTransform f (s - ρ.val)).re := by
-    simpa using ContinuousLinearMap.map_tsum Complex.reCLM hsub
-  -- pointwise real part of the grouped summand
-  have hpt : ∀ ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-      ((f 0 : ℂ) / (s - ρ.val) - laplaceTransform f (s - ρ.val)).re =
-        f 0 * (1 / (s - ρ.val)).re - (laplaceTransform f (s - ρ.val)).re := by
-    intro ρ
-    have hmul : ((f 0 : ℝ) : ℂ) / (s - ρ.val) =
-        ((f 0 : ℝ) : ℂ) * (1 / (s - ρ.val)) := div_eq_mul_one_div _ _
-    rw [Complex.sub_re, hmul, Complex.re_ofReal_mul]
-  -- split the real tsum of differences
-  have hsplit :
-      (∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-          (f 0 * (1 / (s - ρ.val)).re - (laplaceTransform f (s - ρ.val)).re)) =
-      f 0 * (∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-          (1 / (s - ρ.val)).re) -
-        ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-          (laplaceTransform f (s - ρ.val)).re := by
-    rw [Summable.tsum_sub (hre1.mul_left (f 0)) hreF, tsum_mul_left]
-  rw [hcomplex]
-  simp only [Complex.add_re, Complex.sub_re]
-  rw [htsum_re, tsum_congr hpt, hsplit, Complex.re_ofReal_mul, Complex.sub_re,
-    re_shifted_sum_eq_paired_sub_re_inv s]
-  ring
+  -- Weighted form of the previous unweighted derivation. The route is unchanged:
+  -- apply `identity_16_complex`, push `Re` through the grouped weighted zero sum
+  -- (`summable_kadiriTestFn_weighted_at_zeros` supplies the summability), split the
+  -- real families, and regroup via the paired block. The remaining inputs are the
+  -- weighted twins of `summable_re_one_div_at_zeros`, `summable_lap_re_at_zeros`,
+  -- and `re_shifted_sum_eq_paired_sub_re_inv`, all reachable from
+  -- `weighted_zeroImagSquareTail_shifted_summable` by the transplant pattern of
+  -- `summable_kadiriTestFn_weighted_at_zeros`.
+  sorry
 
 
 /-- The raw von Mangoldt Dirichlet sum is `-ζ'/ζ` on `1 < Re s` (the tsum form of
@@ -2761,11 +2749,12 @@ lemma tsum_vonMangoldt_eq {s : ℂ} (hs : 1 < s.re) :
   (title := "Inner real-part identity: collapsing to $T_1$")
   (statement := /-- For every $s \in \mathbb{C}$ with $\Re s > 1$,
   $$ \Re \Bigl( \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} - \frac{1}{s - 1}
-                + \sum_{\rho \in Z(\zeta)} \Bigl( \frac{1}{\rho} + \frac{1}{s - \rho} \Bigr) \Bigr)
-     - \sum_{\rho \in Z(\zeta)} \Re \frac{1}{\rho}
+                + \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)
+                    \Bigl( \frac{1}{\rho} + \frac{1}{s - \rho} \Bigr) \Bigr)
+     - \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)\, \Re \frac{1}{\rho}
    = -\tfrac{1}{2} \log \pi
      + \tfrac{1}{2} \Re \tfrac{\Gamma'}{\Gamma}\!\left(\tfrac{s}{2}+1\right). $$
-  The zero block is the absolutely convergent Hadamard pairing of
+  The zero block is the absolutely convergent multiplicity-weighted Hadamard pairing of
   \ref{kadiri-hadamard-identity}, and the $\Re(1/\rho)$ correction is absolutely
   convergent; the standalone $\sum_\rho 1/(s - \rho)$ does not converge
   unconditionally. This is the identity that turns the $f(0)$-coefficient of
@@ -2781,20 +2770,13 @@ lemma tsum_vonMangoldt_eq {s : ℂ} (hs : 1 < s.re) :
   (discussion := 1478)]
 theorem re_inner_eq {s : ℂ} (hs : 1 < s.re) :
     ((∑' n : ℕ, (Λ n : ℂ) / (n : ℂ) ^ s) - 1 / (s - 1) +
-       ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-         (1 / (ρ.val : ℂ) + 1 / (s - ρ.val))).re -
-      ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-        (1 / (ρ.val : ℂ)).re =
+       riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+         (fun ρ ↦ 1 / ρ + 1 / (s - ρ))).re -
+      riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+        (fun ρ ↦ (1 / ρ).re) =
     -(1 / 2 : ℝ) * Real.log Real.pi +
       (1 / 2 : ℝ) * (digamma (s / 2 + 1)).re := by
-  have hs1 : s ≠ 1 := by
-    intro hs_eq
-    rw [hs_eq] at hs
-    norm_num at hs
-  have hsZ : s ∉ riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ) := by
-    intro hz
-    exact (not_lt_of_gt hs) hz.1.2
-  rw [tsum_vonMangoldt_eq hs, hadamard_identity s hs1 hsZ]
+  rw [tsum_vonMangoldt_eq hs, hadamard_identity hs]
   ring_nf
   simp only [Complex.add_re, Complex.neg_re, Complex.mul_re, Complex.ofReal_re,
     Complex.ofReal_im, zero_mul, sub_zero]
@@ -2820,14 +2802,16 @@ Assembled from \ref{kadiri-identity-16}, \ref{kadiri-re-inner-eq}, and
   $$ \Re \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} f(\log n)
     = f(0) \left( -\tfrac{1}{2} \log \pi
         + \tfrac{1}{2} \Re \tfrac{\Gamma'}{\Gamma}\!\left(\tfrac{s}{2} + 1\right) \right)
-    + \Re F(s - 1) - \sum_{\rho \in Z(\zeta)} \Re F(s - \rho)
+    + \Re F(s - 1) - \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)\, \Re F(s - \rho)
     + \Re \left( \frac{1}{2 \pi i} \int_{1/2 - i \infty}^{1/2 + i \infty}
         \Re \tfrac{\Gamma'}{\Gamma}\!\left(\tfrac{z}{2}\right) \frac{F_2(s - z)}{(s - z)^2}\, dz
         + \frac{F_2(s)}{s^2} \right), $$
   where $Z(\zeta)$ is the set of non-trivial zeros of $\zeta$ (those in the open critical strip
-  $0 < \Re \rho < 1$). The half-plane $\Re s > 1$ is the range used in Kadiri's downstream
-  zero-free region argument; the harmonic-extension step that would lift the identity to all
-  of $\mathbb{C}$ is not needed for that application. -/)
+  $0 < \Re \rho < 1$) and the zero sum carries the multiplicity weights
+  $\mathrm{ord}_\zeta(\rho)$; the convergence conjunct is stated for the plain family
+  $\Re F(s - \rho)$, one term per zero. The half-plane $\Re s > 1$ is the range used in
+  Kadiri's downstream zero-free region argument; the harmonic-extension step that would
+  lift the identity to all of $\mathbb{C}$ is not needed for that application. -/)
   (proof := /-- The `Summable` conjunct is \ref{kadiri-summable-lap-at-zeros}.
   For the identity, combine \ref{kadiri-identity-16} (the (16)-form on $\Re s > 1$) with
   \ref{kadiri-re-inner-eq} (which substitutes the $T_1$ form for the $f(0)$-coefficient
@@ -2848,8 +2832,8 @@ theorem prop_2_1 {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ}
       f 0 * (-(1 / 2 : ℝ) * Real.log Real.pi
               + (1 / 2 : ℝ) * (digamma (s / 2 + 1)).re)
         + (laplaceTransform f (s - 1)).re
-        - ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) .univ,
-            (laplaceTransform f (s - ρ.val)).re
+        - riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+            (fun ρ ↦ (laplaceTransform f (s - ρ)).re)
         + ((1 / (2 * (Real.pi : ℂ))) *
             (∫ t : ℝ,
               ((digamma ((1 / 2 + (t : ℂ) * I) / 2)).re : ℂ) *
@@ -2909,7 +2893,9 @@ noncomputable def Δ2 (f : ℝ → ℝ) (κ δ : ℝ) (s : ℂ) : ℝ :=
   where $T_1, T_2$ are the "gamma" and "remainder" contributions to the RHS of
   \ref{kadiri-prop-2-1}. Then
   $$ \Re \sum_{n \geq 1} \frac{\Lambda(n)}{n^s} f(\log n) \left( 1 - \frac{\kappa}{n^\delta} \right)
-       = f(0) \Delta_1(s) + D(s - 1) - \sum_{\rho \in Z(\zeta)} D(s - \rho) + \Delta_2(s). $$
+       = f(0) \Delta_1(s) + D(s - 1)
+         - \sum_{\rho \in Z(\zeta)} \mathrm{ord}_\zeta(\rho)\, D(s - \rho) + \Delta_2(s), $$
+  with the zero sum weighted by multiplicity as in \ref{kadiri-prop-2-1}.
   -/)
   (proof := /-- Direct substitution: apply \ref{kadiri-prop-2-1} at $s$ and at $s + \delta$,
   multiply the latter by $\kappa$, subtract, and use the identity
@@ -2923,7 +2909,8 @@ theorem eq_5 {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ} (hf_nonneg : ∀ t, 0 ≤ 
     {s : ℂ} (hs : 1 < s.re) :
     (∑' n : ℕ, Λ n / n ^ s * f (Real.log n) * ((1 : ℂ) - κ / n ^ (δ : ℂ))).re =
       f 0 * Δ1 κ δ s + D f κ δ (s - 1)
-        - ∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) .univ, D f κ δ (s - ρ.val) + Δ2 f κ δ s := by
+        - riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+            (fun ρ ↦ D f κ δ (s - ρ)) + Δ2 f κ δ s := by
   have hsδ : 1 < (s + δ).re := by
     simp only [Complex.add_re, Complex.ofReal_re]; linarith
   have h1 := prop_2_1 hd hf_nonneg hf_C2 hf_supp hf_d hf_deriv_0 hf_deriv_d hf_deriv2_d hs
@@ -2948,14 +2935,17 @@ theorem eq_5 {d : ℝ} (hd : 0 < d) {f : ℝ → ℝ} (hf_nonneg : ∀ t, 0 ≤ 
         (κ : ℂ)).hasSum).tsum_eq, tsum_mul_left]
     rw [h_complex, Complex.sub_re, Complex.re_ofReal_mul]
   have hZeros :
-      (∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) .univ, D f κ δ (s - ρ.val)) =
-      (∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) .univ,
-          (laplaceTransform f (s - ρ.val)).re)
-        - κ * (∑' ρ : riemannZeta.zeroes_rect (.Ioo 0 1) .univ,
-                 (laplaceTransform f ((s + δ) - ρ.val)).re) := by
-    have harg : ∀ ρ : riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
-        (s - ρ.val) + δ = s + δ - ρ.val := fun _ ↦ by ring
-    simp_rw [D, harg, (h1.1.hasSum.sub (h2.1.mul_left κ).hasSum).tsum_eq, tsum_mul_left]
+      riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+          (fun ρ ↦ D f κ δ (s - ρ)) =
+      riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+          (fun ρ ↦ (laplaceTransform f (s - ρ)).re)
+        - κ * riemannZeta.zeroes_sum (.Ioo 0 1) (.univ : Set ℝ)
+                (fun ρ ↦ (laplaceTransform f (s + δ - ρ)).re) := by
+    -- Splitting the weighted sum needs summability of the weighted families
+    -- `(laplaceTransform f (s - ρ)).re * ord ρ` at `s` and at `s + δ`, the weighted
+    -- twin of `summable_lap_re_at_zeros` (transplant via
+    -- `weighted_zeroImagSquareTail_shifted_summable`); to be supplied with the fills.
+    sorry
   have hT1s : -(1 / 2 : ℝ) * Real.log Real.pi +
       (1 / 2 : ℝ) * (digamma (s / 2 + 1)).re = T1 s := rfl
   have hT1sd : -(1 / 2 : ℝ) * Real.log Real.pi +

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -234,7 +234,9 @@ theorem kadiri_thm_3_1_q1_eq_11 {φ : ℝ → ℂ} (_hφ : ContDiff ℝ 1 φ)
   "kadiri-thm-3-1-q1-eq-12"
   (title := "Equation (12) of \\cite{Kadiri2005}: rectangle decomposition of $I(T)$")
   (statement := /-- Under the hypotheses of \ref{kadiri-thm-3-1-q1-eq-11}: for every
-  $T > 0$,
+  $T > 0$ such that no non-trivial zero satisfies $\Im \rho = \pm T$ (at a zero
+  ordinate the horizontal edges pass through poles of the integrand, the edge
+  integrals do not exist, and the identity degenerates),
   $$ I(T) \;=\; \frac{1}{2\pi i} \int_{-a - iT}^{-a + iT}
                     \!\!\!\! \left(-\frac{\zeta'}{\zeta}\right)\!(s)\, \Phi(-s)\, ds
              \;+\; \frac{1}{2\pi i} \int_{-a + iT}^{1+a + iT}
@@ -272,7 +274,9 @@ theorem kadiri_thm_3_1_q1_eq_12 {φ : ℝ → ℂ} (_hφ : ContDiff ℝ 1 φ)
     (_hφ'_decay : (fun x : ℝ ↦ deriv φ x * exp ((x : ℂ) / 2))
         =O[Filter.cocompact ℝ] fun x : ℝ ↦ Real.exp (-(1/2 + b) * |x|))
     {a : ℝ} (_ha : 0 < a) (_hab : a < b) (_ha1 : a < 1)
-    {T : ℝ} (_hT : 0 < T) :
+    {T : ℝ} (_hT : 0 < T)
+    (_hT_ord : ∀ ρ ∈ riemannZeta.zeroes_rect (.Ioo 0 1) (.univ : Set ℝ),
+      ρ.im ≠ T ∧ ρ.im ≠ -T) :
     let Φ : ℂ → ℂ := fun s ↦ ∫ y, φ y * exp (-s * (y : ℂ)) ∂volume
     kadiri_thm_3_1_q1_I φ a T =
       -- (1/(2πi)) ∫ on σ = -a from -iT to +iT

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -718,8 +718,11 @@ Composition of the eleven sublemmas above. -/
   (title := "Theorem 3.1 of \\cite{Kadiri2005}, case $q = 1$, $\\chi$ trivial")
   (statement := /-- Let $\varphi \colon \mathbb{R} \to \mathbb{C}$ be $C^1$ and suppose there
   exists $b > 0$ such that both $\varphi(x) e^{x/2}$ and $\varphi'(x) e^{x/2}$ are
-  $O(e^{-(1/2 + b)|x|})$ as $|x| \to \infty$. Define the Laplace transform
-  $\Phi(z) := \int_0^{\infty} \varphi(y) e^{-zy}\, dy$. Then
+  $O(e^{-(1/2 + b)|x|})$ as $|x| \to \infty$. Define the two-sided Laplace transform
+  $\Phi(z) := \int_{-\infty}^{\infty} \varphi(y) e^{-zy}\, dy$ (the decay hypotheses
+  make it entire in the strip of interest; the reflected sum
+  $\sum_n \Lambda(n) \varphi(-\log n)/n$ enters with the minus sign exactly in this
+  two-sided normalization). Then
   $$ \sum_{n \geq 1} \Lambda(n)\, \varphi(\log n)
      = \Phi(-1) + \Phi(0) - \sum_{\rho \in Z(\zeta)} \Phi(-\rho)
        - \varphi(0)\, \log \pi
@@ -1824,7 +1827,6 @@ theorem kadiriTestFn_log (f : ℝ → ℝ) (s : ℂ) {n : ℕ} (hn : 1 ≤ n) :
   simp only [kadiriTestFn, this, ↓reduceIte, natCast_log, neg_mul, exp_neg,
     Complex.cpow_def_of_ne_zero hn0, division_def, mul_eq_mul_left_iff, inv_inj]
   left; ring_nf
-
 
 /-- Weighted complex form of equation (16), derived from the explicit formula
 `kadiri_thm_3_1_q1` at the Kadiri test function. The zero sum carries the

--- a/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Kadiri.lean
@@ -566,6 +566,21 @@ theorem kadiri_thm_3_1_q1_eq_14
       (nhds (-∑' n : ℕ, ((Λ n : ℂ) / (n : ℂ)) * φ (-Real.log n))) := by
   sorry
 
+/-- The digamma function commutes with complex conjugation. Mathlib's junk-value
+conventions make this unconditional: `Complex.Gamma_conj` holds at every point,
+`deriv` returns `0` at non-differentiable points on both sides of the symmetry,
+and `conj` fixes `0`. In the application below the argument `s / 2` has real
+part `1 / 4`, away from the poles of `Γ` in any case. -/
+private lemma digamma_conj (z : ℂ) :
+    digamma ((starRingEnd ℂ) z) = (starRingEnd ℂ) (digamma z) := by
+  have hΓ : (starRingEnd ℂ) ∘ Gamma ∘ (starRingEnd ℂ) = Gamma := by
+    funext w
+    simp [Function.comp_apply, Gamma_conj]
+  have hd : deriv Gamma ((starRingEnd ℂ) z) = (starRingEnd ℂ) (deriv Gamma z) := by
+    conv_lhs => rw [← hΓ, deriv_conj_conj]
+    simp [Function.comp_apply]
+  rw [digamma_def, logDeriv_apply, logDeriv_apply, hd, Gamma_conj, ← map_div₀]
+
 @[blueprint
   "kadiri-thm-3-1-q1-gamma-symmetrization"
   (title := "$\\Gamma'/\\Gamma$ symmetrization on the critical line")
@@ -587,7 +602,17 @@ theorem kadiri_thm_3_1_q1_eq_14
 theorem kadiri_thm_3_1_q1_gamma_symmetrization {s : ℂ} (_hs : s.re = 1 / 2) :
     (1 / 2 : ℂ) * (digamma (s / 2) + digamma ((1 - s) / 2)) =
       ((digamma (s / 2)).re : ℂ) := by
-  sorry
+  have h1s : 1 - s = (starRingEnd ℂ) s := by
+    apply Complex.ext
+    · rw [Complex.sub_re, Complex.one_re, Complex.conj_re, _hs]
+      norm_num
+    · rw [Complex.sub_im, Complex.one_im, Complex.conj_im]
+      ring
+  have hconj : (1 - s) / 2 = (starRingEnd ℂ) (s / 2) := by
+    rw [map_div₀, map_ofNat, h1s]
+  rw [hconj, digamma_conj, Complex.add_conj]
+  push_cast
+  ring
 
 @[blueprint
   "kadiri-thm-3-1-q1-eq-15"


### PR DESCRIPTION
- **Kadiri: fill the gamma-symmetrization blueprint node**
- **Kadiri: state the Theorem 3.1 sublemmas with the two-sided Laplace transform**
- **Kadiri: add the critical-line integrability hypothesis to eq. (15)**
- **Kadiri: restate the Laplace inversion node as a symmetric-truncation limit at n >= 2**
- **Kadiri: restate eq. (11) as the limit of the truncated contour integral I(T)**
- **Kadiri: state eq. (12) at heights avoiding the zero ordinates**
- **Kadiri: define hadamardB as the xi Hadamard derivative constant**
- **Kadiri: restate the Hadamard identities and equation (16) with order-weighted zero sums**
- **Kadiri: state the explicit formula with the two-sided transform**
