### PR TITLE
IK: fill three divisor-sum infra lemmas (#1011)

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -90,9 +90,11 @@ lemma unique_divisor_decomposition {a b d : ℕ} (hab : Coprime a b) (hd : d ∣
   -/)]
 theorem sum_divisors_mul_of_coprime {R : Type*} [CommRing R]
     {f : ArithmeticFunction R} (hf : f.IsMultiplicative)
-    {a b : ℕ} (hab : Coprime a b) (ha : a ≠ 0) (hb : b ≠ 0) :
+    {a b : ℕ} (hab : Coprime a b) (_ha : a ≠ 0) (_hb : b ≠ 0) :
     ∑ d ∈ (a * b).divisors, f d = (∑ d ∈ a.divisors, f d) * (∑ d ∈ b.divisors, f d) := by
-  sorry -- UPSTREAMED TO MATHLIB #36495
+  have hzf : ((zeta : ArithmeticFunction R) * f).IsMultiplicative :=
+    isMultiplicative_zeta.natCast.mul hf
+  simpa only [coe_zeta_mul_apply] using hzf.map_mul_of_coprime hab
 
 /-- If `g` is a multiplicative arithmetic function, then for any $n \neq 0$,
     $\sum_{d | n} \mu(d) \cdot g(d) = \prod_{p | n} (1 - g(p))$. -/
@@ -1621,8 +1623,16 @@ lemma pow_divisors_mul {m n k : ℕ} (hmn : Nat.Coprime m n) :
   -/)]
 lemma divisors_mul_injective {m n : ℕ} (hmn : m.Coprime n) :
     Set.InjOn (fun p : ℕ × ℕ => p.1 * p.2) (m.divisors ×ˢ n.divisors) := by
-  /-- comes from mathlib PR #36495 -/
-  sorry
+  rintro ⟨dm₁, dn₁⟩ h₁ ⟨dm₂, dn₂⟩ h₂ hd
+  simp only [Set.mem_prod, Finset.mem_coe, mem_divisors] at h₁ h₂
+  simp only at hd
+  suffices dm₁ = dm₂ from Prod.ext this <| by
+    rwa [this, Nat.mul_right_inj (by simp [·] at h₂)] at hd
+  exact dvd_antisymm
+    (hmn.coprime_dvd_left h₁.1.1 |>.coprime_dvd_right h₂.2.1
+      |>.dvd_of_dvd_mul_right (hd ▸ dm₁.dvd_mul_right dn₁))
+    (hmn.coprime_dvd_left h₂.1.1 |>.coprime_dvd_right h₁.2.1
+      |>.dvd_of_dvd_mul_right (hd ▸ dm₂.dvd_mul_right dn₂))
 
 @[blueprint
   "pow_divisors_mul_injective"

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -92,7 +92,9 @@ theorem sum_divisors_mul_of_coprime {R : Type*} [CommRing R]
     {f : ArithmeticFunction R} (hf : f.IsMultiplicative)
     {a b : ℕ} (hab : Coprime a b) (ha : a ≠ 0) (hb : b ≠ 0) :
     ∑ d ∈ (a * b).divisors, f d = (∑ d ∈ a.divisors, f d) * (∑ d ∈ b.divisors, f d) := by
-  sorry -- UPSTREAMED TO MATHLIB #36495
+  have hzf : ((zeta : ArithmeticFunction R) * f).IsMultiplicative :=
+    isMultiplicative_zeta.natCast.mul hf
+  simpa only [coe_zeta_mul_apply] using hzf.map_mul_of_coprime hab
 
 /-- If `g` is a multiplicative arithmetic function, then for any $n \neq 0$,
     $\sum_{d | n} \mu(d) \cdot g(d) = \prod_{p | n} (1 - g(p))$. -/
@@ -1618,8 +1620,16 @@ lemma pow_divisors_mul {m n k : ℕ} (hmn : Nat.Coprime m n) :
   -/)]
 lemma divisors_mul_injective {m n : ℕ} (hmn : m.Coprime n) :
     Set.InjOn (fun p : ℕ × ℕ => p.1 * p.2) (m.divisors ×ˢ n.divisors) := by
-  /-- comes from mathlib PR #36495 -/
-  sorry
+  rintro ⟨dm₁, dn₁⟩ h₁ ⟨dm₂, dn₂⟩ h₂ hd
+  simp only [Set.mem_prod, Finset.mem_coe, mem_divisors] at h₁ h₂
+  simp only at hd
+  suffices dm₁ = dm₂ from Prod.ext this <| by
+    rwa [this, Nat.mul_right_inj (by simp [·] at h₂)] at hd
+  exact dvd_antisymm
+    (hmn.coprime_dvd_left h₁.1.1 |>.coprime_dvd_right h₂.2.1
+      |>.dvd_of_dvd_mul_right (hd ▸ dm₁.dvd_mul_right dn₁))
+    (hmn.coprime_dvd_left h₂.1.1 |>.coprime_dvd_right h₁.2.1
+      |>.dvd_of_dvd_mul_right (hd ▸ dm₂.dvd_mul_right dn₂))
 
 @[blueprint
   "pow_divisors_mul_injective"


### PR DESCRIPTION
## Motivation

Fills two of the divisor-sum infrastructure sorries in `PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean`. Refs #1011. Both close by reuse of existing Mathlib API; no new helpers, no new declarations.

## Scope

- `sum_divisors_mul_of_coprime`: for a multiplicative `f` and coprime nonzero `a`, `b`, the sum of `f` over the divisors of `a * b` factorises as the product of the sums over the divisors of `a` and of `b`. Proved by applying `IsMultiplicative.map_mul_of_coprime` to `ζ * f`. The proof does not need the nonzeroness hypotheses, so their binders are renamed `_ha`, `_hb` to keep the build warning-free; the statement is otherwise unchanged.
- `divisors_mul_injective`: the product map `(d, e) ↦ d * e` is injective on `m.divisors ×ˢ n.divisors` for coprime `m`, `n`; a short `dvd_antisymm` argument.
- History: this PR originally also filled `Nat.sum_divisorsAntidiagonal_prime_pow`; that landed on main via #1740 and the chunk was dropped here. `unique_divisor_decomposition` is left alone since mathlib #36495 adds the corresponding API.
- `@[blueprint]` metadata untouched. One file changed.

## Test plan

- [x] `lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1`: clean on the branch rebased onto current main.
- [x] `lake build :blueprint`: clean.
- [x] `#print axioms` on both lemmas: `[propext, Classical.choice, Quot.sound]`. No `sorryAx`.
- [x] `sorry` count in the file goes 7 to 5. The diff adds none and removes two.
- [x] No new warnings beyond the pre-existing `declaration uses 'sorry'` warnings elsewhere in the project.
- [ ] xelatex blueprint check: not applicable, no `@[blueprint]` field content changes.

Made with Claude (Claude Code CLI). Tags: AI, Claude
