### PR TITLE
Wiener: preliminary decay bound II (prelim_decay_2, #562)

### DIFF
--- a/PrimeNumberTheoremAnd.lean
+++ b/PrimeNumberTheoremAnd.lean
@@ -104,6 +104,7 @@ import PrimeNumberTheoremAnd.Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 import PrimeNumberTheoremAnd.Mathlib.Analysis.SpecialFunctions.Pow.Real
 import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.Integral.IntegrableOn
 import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.Integral
 import PrimeNumberTheoremAnd.Mathlib.NumberTheory.AbelSummation
 import PrimeNumberTheoremAnd.Mathlib.NumberTheory.LSeries.RiemannZeta
 import PrimeNumberTheoremAnd.Mathlib.NumberTheory.LSeries.RiemannZetaAbelContinuation

--- a/PrimeNumberTheoremAnd.lean
+++ b/PrimeNumberTheoremAnd.lean
@@ -130,6 +130,7 @@ import PrimeNumberTheoremAnd.ResidueCalcOnRectangles
 import PrimeNumberTheoremAnd.SmoothExistence
 import PrimeNumberTheoremAnd.Sobolev
 import PrimeNumberTheoremAnd.StrongPNT
+import PrimeNumberTheoremAnd.StieltjesFubini
 import PrimeNumberTheoremAnd.Tactic.AdditiveCombination
 import PrimeNumberTheoremAnd.Wiener
 import PrimeNumberTheoremAnd.ZetaBounds

--- a/PrimeNumberTheoremAnd.lean
+++ b/PrimeNumberTheoremAnd.lean
@@ -104,6 +104,7 @@ import PrimeNumberTheoremAnd.Mathlib.Analysis.SpecialFunctions.Pow.Deriv
 import PrimeNumberTheoremAnd.Mathlib.Analysis.SpecialFunctions.Pow.Real
 import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.Integral.IntegrableOn
 import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.Integral
 import PrimeNumberTheoremAnd.Mathlib.NumberTheory.AbelSummation
 import PrimeNumberTheoremAnd.Mathlib.NumberTheory.LSeries.RiemannZeta

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
@@ -170,6 +170,53 @@ theorem tendsto_atBot_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
     Tendsto f atBot (𝓝 0) := by
   simpa [hf.limUnder_atBot_eq_zero_of_integrable hfi] using hf.tendsto_atBot_limUnder
 
+theorem ae_eq_rightLim_real {f : ℝ → ℝ} (hf : BoundedVariationOn f Set.univ) :
+    f =ᵐ[volume] f.rightLim := by
+  rcases hf.locallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn with
+    ⟨p, q, hp, hq, hpq⟩
+  have hp_mono : Monotone p := monotoneOn_univ.mp hp
+  have hq_mono : Monotone q := monotoneOn_univ.mp hq
+  have h_count : Set.Countable {x | ¬ ContinuousAt f x} := by
+    refine (hp_mono.countable_not_continuousAt.union hq_mono.countable_not_continuousAt).mono ?_
+    intro x hx
+    by_contra hx'
+    have hp_cont : ContinuousAt p x := by
+      by_contra hp_cont'
+      exact hx' (Or.inl hp_cont')
+    have hq_cont : ContinuousAt q x := by
+      by_contra hq_cont'
+      exact hx' (Or.inr hq_cont')
+    exact hx (by rw [hpq]; exact hp_cont.sub hq_cont)
+  have h_null : volume {x | ¬ ContinuousAt f x} = 0 :=
+    h_count.measure_zero volume
+  have h_eq : ∀ x, ContinuousAt f x → f x = f.rightLim x := by
+    intro x hx
+    exact hx.continuousWithinAt.rightLim_eq.symm
+  have h_sub : {x | f x ≠ f.rightLim x} ⊆ {x | ¬ ContinuousAt f x} := by
+    intro x hx
+    by_contra hx'
+    exact hx (h_eq x (not_not.mp hx'))
+  exact ae_iff.mpr (measure_mono_null h_sub h_null)
+
+theorem ae_eq_rightLim_complex {f : ℝ → ℂ} (hf : BoundedVariationOn f Set.univ) :
+    f =ᵐ[volume] f.rightLim := by
+  have hre_bv : BoundedVariationOn (fun x : ℝ => (f x).re) Set.univ :=
+    Complex.reCLM.lipschitz.comp_boundedVariationOn hf
+  have him_bv : BoundedVariationOn (fun x : ℝ => (f x).im) Set.univ :=
+    Complex.imCLM.lipschitz.comp_boundedVariationOn hf
+  have hre_ae := hre_bv.ae_eq_rightLim_real
+  have him_ae := him_bv.ae_eq_rightLim_real
+  have hre_lim (x : ℝ) :
+      (fun y : ℝ => (f y).re).rightLim x = (f.rightLim x).re := by
+    exact tendsto_nhds_unique (hre_bv.tendsto_rightLim x)
+      (Complex.continuous_re.continuousAt.tendsto.comp (hf.tendsto_rightLim x))
+  have him_lim (x : ℝ) :
+      (fun y : ℝ => (f y).im).rightLim x = (f.rightLim x).im := by
+    exact tendsto_nhds_unique (him_bv.tendsto_rightLim x)
+      (Complex.continuous_im.continuousAt.tendsto.comp (hf.tendsto_rightLim x))
+  filter_upwards [hre_ae, him_ae] with x hxre hxim
+  exact Complex.ext (by simpa [hre_lim x] using hxre) (by simpa [him_lim x] using hxim)
+
 theorem vectorMeasure_univ_eq_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
     (hfi : Integrable f volume) :
     hf.vectorMeasure Set.univ = 0 := by
@@ -195,5 +242,65 @@ theorem vectorMeasure_Iio_eq_leftLim_of_integrable (hf : BoundedVariationOn f Se
     (hfi : Integrable f volume) (a : ℝ) :
     hf.vectorMeasure (Set.Iio a) = f.leftLim a := by
   rw [hf.vectorMeasure_Iio, hf.limUnder_atBot_eq_zero_of_integrable hfi, sub_zero]
+
+theorem mapRange_re_vectorMeasure_eq {f : ℝ → ℂ} (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    hf.vectorMeasure.mapRange Complex.reCLM.toAddMonoidHom Complex.continuous_re =
+      (Complex.reCLM.lipschitz.comp_boundedVariationOn hf).vectorMeasure := by
+  let hfre : BoundedVariationOn (fun x : ℝ => (f x).re) Set.univ :=
+    Complex.reCLM.lipschitz.comp_boundedVariationOn hf
+  have hfre_i : Integrable (fun x : ℝ => (f x).re) volume :=
+    ContinuousLinearMap.integrable_comp Complex.reCLM hfi
+  have hre_lim (x : ℝ) :
+      (fun y : ℝ => (f y).re).rightLim x = (f.rightLim x).re := by
+    exact tendsto_nhds_unique (hfre.tendsto_rightLim x)
+      (Complex.continuous_re.continuousAt.tendsto.comp (hf.tendsto_rightLim x))
+  have h_univ :
+      hf.vectorMeasure.mapRange Complex.reCLM.toAddMonoidHom Complex.continuous_re Set.univ =
+        hfre.vectorMeasure Set.univ := by
+    rw [VectorMeasure.mapRange_apply]
+    rw [hf.vectorMeasure_univ_eq_zero_of_integrable hfi,
+      hfre.vectorMeasure_univ_eq_zero_of_integrable hfre_i]
+    simp
+  have hgen : (inferInstance : MeasurableSpace ℝ) =
+      MeasurableSpace.generateFrom {s : Set ℝ | ∃ u v, u < v ∧ Ioc u v = s} := by
+    borelize ℝ
+    exact borel_eq_generateFrom_Ioc ℝ
+  refine MeasureTheory.VectorMeasure.ext_of_generateFrom_of_univ hgen
+    (isPiSystem_Ioc (fun x : ℝ => x) (fun x : ℝ => x)) h_univ ?_
+  rintro s ⟨u, v, huv, rfl⟩
+  rw [VectorMeasure.mapRange_apply, hf.vectorMeasure_Ioc huv.le,
+    (Complex.reCLM.lipschitz.comp_boundedVariationOn hf).vectorMeasure_Ioc huv.le]
+  simp [Function.comp_def, hre_lim u, hre_lim v]
+
+theorem mapRange_im_vectorMeasure_eq {f : ℝ → ℂ} (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    hf.vectorMeasure.mapRange Complex.imCLM.toAddMonoidHom Complex.continuous_im =
+      (Complex.imCLM.lipschitz.comp_boundedVariationOn hf).vectorMeasure := by
+  let hfim : BoundedVariationOn (fun x : ℝ => (f x).im) Set.univ :=
+    Complex.imCLM.lipschitz.comp_boundedVariationOn hf
+  have hfim_i : Integrable (fun x : ℝ => (f x).im) volume :=
+    ContinuousLinearMap.integrable_comp Complex.imCLM hfi
+  have him_lim (x : ℝ) :
+      (fun y : ℝ => (f y).im).rightLim x = (f.rightLim x).im := by
+    exact tendsto_nhds_unique (hfim.tendsto_rightLim x)
+      (Complex.continuous_im.continuousAt.tendsto.comp (hf.tendsto_rightLim x))
+  have h_univ :
+      hf.vectorMeasure.mapRange Complex.imCLM.toAddMonoidHom Complex.continuous_im Set.univ =
+        hfim.vectorMeasure Set.univ := by
+    rw [VectorMeasure.mapRange_apply]
+    rw [hf.vectorMeasure_univ_eq_zero_of_integrable hfi,
+      hfim.vectorMeasure_univ_eq_zero_of_integrable hfim_i]
+    simp
+  have hgen : (inferInstance : MeasurableSpace ℝ) =
+      MeasurableSpace.generateFrom {s : Set ℝ | ∃ u v, u < v ∧ Ioc u v = s} := by
+    borelize ℝ
+    exact borel_eq_generateFrom_Ioc ℝ
+  refine MeasureTheory.VectorMeasure.ext_of_generateFrom_of_univ hgen
+    (isPiSystem_Ioc (fun x : ℝ => x) (fun x : ℝ => x)) h_univ ?_
+  rintro s ⟨u, v, huv, rfl⟩
+  rw [VectorMeasure.mapRange_apply, hf.vectorMeasure_Ioc huv.le,
+    (Complex.imCLM.lipschitz.comp_boundedVariationOn hf).vectorMeasure_Ioc huv.le]
+  simp [Function.comp_def, him_lim u, him_lim v]
 
 end BoundedVariationOn

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
@@ -1,0 +1,137 @@
+import Mathlib.Algebra.Order.Interval.Set.Group
+import Mathlib.Algebra.Order.ToIntervalMod
+import Mathlib.MeasureTheory.VectorMeasure.AddContent
+import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
+import Mathlib.MeasureTheory.VectorMeasure.Variation.Basic
+
+open Set MeasureTheory
+open scoped ENNReal
+
+namespace MeasureTheory.VectorMeasure
+
+variable {α E : Type*} [MeasurableSpace α] [AddCommGroup E] [TopologicalSpace E] [T2Space E]
+
+lemma ext_of_generateFrom_of_univ {S : Set (Set α)} {μ ν : VectorMeasure α E}
+    (h_gen : ‹MeasurableSpace α› = MeasurableSpace.generateFrom S) (h_inter : IsPiSystem S)
+    (h_univ : μ univ = ν univ) (h_eq : ∀ s ∈ S, μ s = ν s) : μ = ν := by
+  refine VectorMeasure.ext ?_
+  intro t ht
+  induction t, ht using MeasurableSpace.induction_on_inter h_gen h_inter with
+  | empty => simp
+  | basic u hu => exact h_eq u hu
+  | compl u hu ihu =>
+      rw [VectorMeasure.of_compl hu, VectorMeasure.of_compl hu, h_univ, ihu]
+  | iUnion f hfd hfm ihf =>
+      rw [VectorMeasure.of_disjoint_iUnion hfm hfd, VectorMeasure.of_disjoint_iUnion hfm hfd]
+      exact tsum_congr ihf
+
+end MeasureTheory.VectorMeasure
+
+namespace BoundedVariationOn
+
+variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E] {f : ℝ → E}
+
+theorem vectorMeasure_variation_univ_le_eVariationOn (hf : BoundedVariationOn f Set.univ) :
+    (hf.vectorMeasure).variation Set.univ ≤ eVariationOn f Set.univ := by
+  let μaux : Measure ℝ := (hf.stieltjesFunctionRightLim (0 : ℝ)).measure
+  haveI : IsFiniteMeasure μaux := by
+    dsimp [μaux]
+    apply StieltjesFunction.isFiniteMeasure_of_forall_abs_le
+      (C := (eVariationOn f.rightLim Set.univ).toReal)
+    intro x
+    exact variationOnFromTo.abs_le_eVariationOn hf.rightLim
+  let m : AddContent E {s : Set ℝ | ∃ u v, u ≤ v ∧ s = Ioc u v} :=
+    AddContent.onIoc f.rightLim
+  have hdom : ∀ s ∈ {s : Set ℝ | ∃ u v, u ≤ v ∧ s = Ioc u v}, ‖m s‖ₑ ≤ μaux s := by
+    rintro s ⟨u, v, huv, rfl⟩
+    rw [AddContent.onIoc_apply huv]
+    simp only [μaux, StieltjesFunction.measure_Ioc,
+      BoundedVariationOn.stieltjesFunctionRightLim_apply]
+    rw [← variationOnFromTo.add hf.rightLim.locallyBoundedVariationOn
+      (mem_univ (0 : ℝ)) (mem_univ u) (mem_univ v)]
+    simp only [add_sub_cancel_left, variationOnFromTo, huv, ↓reduceIte, univ_inter]
+    rw [ENNReal.ofReal_toReal]
+    · rw [← edist_eq_enorm_sub]
+      exact eVariationOn.edist_le _ (by grind) (by grind)
+    · exact ((eVariationOn.mono _ (subset_univ _)).trans_lt hf.rightLim.lt_top).ne
+  have hgen_le : (inferInstance : MeasurableSpace ℝ) =
+      MeasurableSpace.generateFrom {s : Set ℝ | ∃ u v, u ≤ v ∧ s = Ioc u v} := by
+    borelize ℝ
+    change borel ℝ = MeasurableSpace.generateFrom {s : Set ℝ | ∃ u v, u ≤ v ∧ s = Ioc u v}
+    rw [borel_eq_generateFrom_Ioc_le ℝ]
+    congr 1
+    ext s
+    constructor
+    · rintro ⟨u, v, huv, hs⟩
+      exact ⟨u, v, huv, hs.symm⟩
+    · rintro ⟨u, v, huv, hs⟩
+      exact ⟨u, v, huv, hs.symm⟩
+  rcases VectorMeasure.exists_extension_of_isSetSemiring_of_le_measure_of_generateFrom
+    MeasureTheory.IsSetSemiring.Ioc hdom hgen_le with ⟨m', hm', hm_bound⟩
+  have h_on_le : ∀ s ∈ {s : Set ℝ | ∃ u v, u ≤ v ∧ s = Ioc u v},
+      m' s = hf.vectorMeasure s := by
+    rintro s ⟨u, v, huv, rfl⟩
+    rw [hm' _ ⟨u, v, huv, rfl⟩, AddContent.onIoc_apply huv, hf.vectorMeasure_Ioc huv]
+  have h_univ : m' Set.univ = hf.vectorMeasure Set.univ := by
+    have hsets : (⋃ n : ℤ, Ioc ((n : ℤ) : ℝ) (((n : ℤ) : ℝ) + 1)) =
+        (Set.univ : Set ℝ) := by
+      simpa using iUnion_Ioc_intCast ℝ
+    rw [← hsets]
+    rw [VectorMeasure.of_disjoint_iUnion, VectorMeasure.of_disjoint_iUnion]
+    · apply tsum_congr
+      intro n
+      exact h_on_le _ ⟨(n : ℝ), (n : ℝ) + 1, by linarith, rfl⟩
+    · intro i
+      exact measurableSet_Ioc
+    · exact Set.pairwise_disjoint_Ioc_intCast ℝ
+    · intro i
+      exact measurableSet_Ioc
+    · exact Set.pairwise_disjoint_Ioc_intCast ℝ
+  have hgen_strict : (inferInstance : MeasurableSpace ℝ) =
+      MeasurableSpace.generateFrom {s : Set ℝ | ∃ u v, u < v ∧ Ioc u v = s} := by
+    borelize ℝ
+    exact borel_eq_generateFrom_Ioc ℝ
+  have h_ext : m' = hf.vectorMeasure := by
+    refine VectorMeasure.ext_of_generateFrom_of_univ hgen_strict
+      (isPiSystem_Ioc (fun x : ℝ => x) (fun x : ℝ => x)) h_univ ?_
+    rintro s ⟨u, v, huv, rfl⟩
+    exact h_on_le _ ⟨u, v, huv.le, rfl⟩
+  rw [← h_ext]
+  have hvar_le : m'.variation ≤ μaux :=
+    VectorMeasure.variation_le_of_forall_enorm_le fun s _hs => hm_bound s
+  calc
+    m'.variation Set.univ ≤ μaux Set.univ := hvar_le Set.univ
+    _ ≤ eVariationOn f Set.univ := by
+      have hcover : (⋃ n : ℕ, Ioc (-(n : ℝ)) (n : ℝ)) = (Set.univ : Set ℝ) := by
+        ext x
+        simp only [mem_iUnion, mem_Ioc, mem_univ, iff_true]
+        obtain ⟨n, hn⟩ := exists_nat_gt |x|
+        refine ⟨n, ?_, ?_⟩
+        · linarith [neg_abs_le x]
+        · exact (le_abs_self x).trans hn.le
+      have hmono : Monotone (fun n : ℕ => Ioc (-(n : ℝ)) (n : ℝ)) := by
+        intro n m hnm
+        have hnmR : (n : ℝ) ≤ (m : ℝ) := by exact_mod_cast hnm
+        exact Set.Ioc_subset_Ioc (by linarith) hnmR
+      calc
+        μaux Set.univ = μaux (⋃ n : ℕ, Ioc (-(n : ℝ)) (n : ℝ)) := by rw [hcover]
+        _ = ⨆ n : ℕ, μaux (Ioc (-(n : ℝ)) (n : ℝ)) := hmono.measure_iUnion
+        _ ≤ eVariationOn f Set.univ := by
+          rw [iSup_le_iff]
+          intro n
+          have hnnonneg : 0 ≤ (n : ℝ) := by exact_mod_cast Nat.zero_le n
+          have hnle : -(n : ℝ) ≤ (n : ℝ) := by linarith
+          calc
+            μaux (Ioc (-(n : ℝ)) (n : ℝ))
+                = eVariationOn f.rightLim (Set.univ ∩ Icc (-(n : ℝ)) (n : ℝ)) := by
+              simp only [μaux, StieltjesFunction.measure_Ioc,
+                BoundedVariationOn.stieltjesFunctionRightLim_apply]
+              rw [← variationOnFromTo.add hf.rightLim.locallyBoundedVariationOn
+                (mem_univ (0 : ℝ)) (mem_univ (-(n : ℝ))) (mem_univ (n : ℝ))]
+              simp only [add_sub_cancel_left, variationOnFromTo, hnle, ↓reduceIte]
+              rw [ENNReal.ofReal_toReal]
+              exact ((eVariationOn.mono _ inter_subset_left).trans_lt hf.rightLim.lt_top).ne
+            _ ≤ eVariationOn f.rightLim Set.univ := eVariationOn.mono _ inter_subset_left
+            _ ≤ eVariationOn f Set.univ := eVariationOn.eVariationOn_rightLim_le
+
+end BoundedVariationOn

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
@@ -1,11 +1,13 @@
 import Mathlib.Algebra.Order.Interval.Set.Group
 import Mathlib.Algebra.Order.ToIntervalMod
+import Mathlib.MeasureTheory.Integral.IntegrableOn
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.MeasureTheory.VectorMeasure.AddContent
 import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 import Mathlib.MeasureTheory.VectorMeasure.Variation.Basic
 
-open Set MeasureTheory
-open scoped ENNReal
+open Filter Set MeasureTheory
+open scoped ENNReal Topology
 
 namespace MeasureTheory.VectorMeasure
 
@@ -133,5 +135,65 @@ theorem vectorMeasure_variation_univ_le_eVariationOn (hf : BoundedVariationOn f 
               exact ((eVariationOn.mono _ inter_subset_left).trans_lt hf.rightLim.lt_top).ne
             _ ≤ eVariationOn f.rightLim Set.univ := eVariationOn.mono _ inter_subset_left
             _ ≤ eVariationOn f Set.univ := eVariationOn.eVariationOn_rightLim_le
+
+theorem limUnder_atTop_eq_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    limUnder atTop f = 0 := by
+  apply IntegrableAtFilter.eq_zero_of_tendsto (hfi.integrableAtFilter atTop) ?_
+    hf.tendsto_atTop_limUnder
+  intro s hs
+  rcases mem_atTop_sets.mp hs with ⟨a, ha⟩
+  rw [← top_le_iff]
+  calc
+    ∞ = volume (Set.Ici a) := by rw [Real.volume_Ici]
+    _ ≤ volume s := measure_mono ha
+
+theorem tendsto_atTop_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    Tendsto f atTop (𝓝 0) := by
+  simpa [hf.limUnder_atTop_eq_zero_of_integrable hfi] using hf.tendsto_atTop_limUnder
+
+theorem limUnder_atBot_eq_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    limUnder atBot f = 0 := by
+  apply IntegrableAtFilter.eq_zero_of_tendsto (hfi.integrableAtFilter atBot) ?_
+    hf.tendsto_atBot_limUnder
+  intro s hs
+  rcases mem_atBot_sets.mp hs with ⟨a, ha⟩
+  rw [← top_le_iff]
+  calc
+    ∞ = volume (Set.Iic a) := by rw [Real.volume_Iic]
+    _ ≤ volume s := measure_mono ha
+
+theorem tendsto_atBot_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    Tendsto f atBot (𝓝 0) := by
+  simpa [hf.limUnder_atBot_eq_zero_of_integrable hfi] using hf.tendsto_atBot_limUnder
+
+theorem vectorMeasure_univ_eq_zero_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) :
+    hf.vectorMeasure Set.univ = 0 := by
+  rw [hf.vectorMeasure_univ, hf.limUnder_atTop_eq_zero_of_integrable hfi,
+    hf.limUnder_atBot_eq_zero_of_integrable hfi, sub_self]
+
+theorem vectorMeasure_Ici_eq_neg_leftLim_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) (a : ℝ) :
+    hf.vectorMeasure (Set.Ici a) = -f.leftLim a := by
+  rw [hf.vectorMeasure_Ici, hf.limUnder_atTop_eq_zero_of_integrable hfi, zero_sub]
+
+theorem vectorMeasure_Ioi_eq_neg_rightLim_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) (a : ℝ) :
+    hf.vectorMeasure (Set.Ioi a) = -f.rightLim a := by
+  rw [hf.vectorMeasure_Ioi, hf.limUnder_atTop_eq_zero_of_integrable hfi, zero_sub]
+
+theorem vectorMeasure_Iic_eq_rightLim_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) (a : ℝ) :
+    hf.vectorMeasure (Set.Iic a) = f.rightLim a := by
+  rw [hf.vectorMeasure_Iic, hf.limUnder_atBot_eq_zero_of_integrable hfi, sub_zero]
+
+theorem vectorMeasure_Iio_eq_leftLim_of_integrable (hf : BoundedVariationOn f Set.univ)
+    (hfi : Integrable f volume) (a : ℝ) :
+    hf.vectorMeasure (Set.Iio a) = f.leftLim a := by
+  rw [hf.vectorMeasure_Iio, hf.limUnder_atBot_eq_zero_of_integrable hfi, sub_zero]
 
 end BoundedVariationOn

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/BoundedVariation.lean
@@ -29,6 +29,14 @@ lemma ext_of_generateFrom_of_univ {S : Set (Set α)} {μ ν : VectorMeasure α E
 
 end MeasureTheory.VectorMeasure
 
+namespace StieltjesFunction
+
+instance instIsFiniteMeasureRestrictIoc (p : StieltjesFunction ℝ) (a b : ℝ) :
+    IsFiniteMeasure (p.measure.restrict (Set.Ioc a b)) :=
+  ⟨by simp [p.measure_Ioc]⟩
+
+end StieltjesFunction
+
 namespace BoundedVariationOn
 
 variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E] {f : ℝ → E}
@@ -197,6 +205,72 @@ theorem ae_eq_rightLim_real {f : ℝ → ℝ} (hf : BoundedVariationOn f Set.uni
     by_contra hx'
     exact hx (h_eq x (not_not.mp hx'))
   exact ae_iff.mpr (measure_mono_null h_sub h_null)
+
+theorem exists_stieltjesFunction_sub_rightLim {f : ℝ → ℝ}
+    (hf : BoundedVariationOn f Set.univ) :
+    ∃ p q : StieltjesFunction ℝ, ∀ x : ℝ, f.rightLim x = p x - q x := by
+  rcases hf.locallyBoundedVariationOn.exists_monotoneOn_sub_monotoneOn with
+    ⟨p0, q0, hp0, hq0, hpq0⟩
+  have hpmono : Monotone p0 := monotoneOn_univ.mp hp0
+  have hqmono : Monotone q0 := monotoneOn_univ.mp hq0
+  let p : StieltjesFunction ℝ := hpmono.stieltjesFunction
+  let q : StieltjesFunction ℝ := hqmono.stieltjesFunction
+  refine ⟨p, q, fun x => ?_⟩
+  have hf_t : Tendsto f (𝓝[>] x) (𝓝 (f.rightLim x)) := hf.tendsto_rightLim x
+  have hp_t : Tendsto p0 (𝓝[>] x) (𝓝 (p x)) := by
+    simpa [p, Monotone.stieltjesFunction_eq] using hpmono.tendsto_rightLim x
+  have hq_t : Tendsto q0 (𝓝[>] x) (𝓝 (q x)) := by
+    simpa [q, Monotone.stieltjesFunction_eq] using hqmono.tendsto_rightLim x
+  have hsub_t : Tendsto (fun y => p0 y - q0 y) (𝓝[>] x) (𝓝 (p x - q x)) :=
+    hp_t.sub hq_t
+  exact tendsto_nhds_unique hf_t (hsub_t.congr' (Eventually.of_forall fun y =>
+    (congr_fun hpq0 y).symm))
+
+theorem vectorMeasure_restrict_eq_stieltjesFunction_sub_rightLim {f : ℝ → ℝ}
+    (hf : BoundedVariationOn f Set.univ) {p q : StieltjesFunction ℝ}
+    (hpq : ∀ x : ℝ, f.rightLim x = p x - q x) {a b : ℝ} (hab : a ≤ b) :
+    hf.vectorMeasure.restrict (Set.Ioc a b) =
+      (p.measure.restrict (Set.Ioc a b)).toSignedMeasure -
+        (q.measure.restrict (Set.Ioc a b)).toSignedMeasure := by
+  have hgen : (inferInstance : MeasurableSpace ℝ) =
+      MeasurableSpace.generateFrom {s : Set ℝ | ∃ u v, u < v ∧ Ioc u v = s} := by
+    borelize ℝ
+    exact borel_eq_generateFrom_Ioc ℝ
+  refine MeasureTheory.VectorMeasure.ext_of_generateFrom_of_univ hgen
+    (isPiSystem_Ioc (fun x : ℝ => x) (fun x : ℝ => x)) ?_ ?_
+  · rw [VectorMeasure.restrict_apply hf.vectorMeasure measurableSet_Ioc MeasurableSet.univ]
+    simp only [univ_inter]
+    rw [VectorMeasure.sub_apply, Measure.toSignedMeasure_apply_measurable MeasurableSet.univ,
+      Measure.toSignedMeasure_apply_measurable MeasurableSet.univ]
+    simp only [Measure.restrict_apply MeasurableSet.univ, univ_inter, measureReal_def]
+    rw [hf.vectorMeasure_Ioc hab, p.measure_Ioc, q.measure_Ioc]
+    have hpnonneg : 0 ≤ (p b : ℝ) - p a := sub_nonneg.mpr (p.mono hab)
+    have hqnonneg : 0 ≤ (q b : ℝ) - q a := sub_nonneg.mpr (q.mono hab)
+    rw [ENNReal.toReal_ofReal hpnonneg, ENNReal.toReal_ofReal hqnonneg]
+    rw [hpq a, hpq b]
+    ring
+  · rintro s ⟨u, v, _huv, rfl⟩
+    rw [VectorMeasure.restrict_apply hf.vectorMeasure measurableSet_Ioc measurableSet_Ioc]
+    rw [VectorMeasure.sub_apply, Measure.toSignedMeasure_apply_measurable measurableSet_Ioc,
+      Measure.toSignedMeasure_apply_measurable measurableSet_Ioc]
+    simp only [Measure.restrict_apply measurableSet_Ioc, measureReal_def]
+    rw [Set.Ioc_inter_Ioc]
+    let c : ℝ := max u a
+    let d : ℝ := min v b
+    change hf.vectorMeasure (Set.Ioc c d) =
+      ((p.measure (Set.Ioc c d)).toReal : ℝ) - ((q.measure (Set.Ioc c d)).toReal : ℝ)
+    by_cases hcd : c ≤ d
+    · rw [hf.vectorMeasure_Ioc hcd, p.measure_Ioc, q.measure_Ioc]
+      have hpnonneg : 0 ≤ (p d : ℝ) - p c := sub_nonneg.mpr (p.mono hcd)
+      have hqnonneg : 0 ≤ (q d : ℝ) - q c := sub_nonneg.mpr (q.mono hcd)
+      rw [ENNReal.toReal_ofReal hpnonneg, ENNReal.toReal_ofReal hqnonneg]
+      rw [hpq c, hpq d]
+      ring
+    · have hdc : d < c := lt_of_not_ge hcd
+      have hemp : Set.Ioc c d = (∅ : Set ℝ) := by
+        rw [Set.Ioc_eq_empty]
+        linarith
+      simp [hemp]
 
 theorem ae_eq_rightLim_complex {f : ℝ → ℂ} (hf : BoundedVariationOn f Set.univ) :
     f =ᵐ[volume] f.rightLim := by

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -403,6 +403,139 @@ theorem vectorMeasure_integral_restrict_toComplexMeasureZero_sub_mul_eq_setInteg
           setToFun νc.variation (cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) hdomν g := by
           exact setToFun_sub_measure hdomμ hdomν hμc_g hνc_g
 
+theorem vectorMeasure_restrict_variation_le (μ : VectorMeasure X ℂ) {s : Set X}
+    (hs : MeasurableSet s) : (μ.restrict s).variation ≤ μ.variation := by
+  refine variation_le_of_forall_enorm_le fun E hE => ?_
+  rw [VectorMeasure.restrict_apply μ hs hE]
+  exact (enorm_measure_le_variation μ (E ∩ s)).trans (measure_mono Set.inter_subset_left)
+
+/-- The indicator restriction `f ↦ s.indicator f` as a `1`-Lipschitz self-map of `L¹(m)`. -/
+noncomputable def indicatorL1 (m : Measure X) (s : Set X) (hs : MeasurableSet s) :
+    (X →₁[m] ℂ) → (X →₁[m] ℂ) :=
+  fun f => ((L1.integrable_coeFn f).indicator hs).toL1 (s.indicator ⇑f)
+
+theorem coeFn_indicatorL1 {m : Measure X} {s : Set X} (hs : MeasurableSet s) (f : X →₁[m] ℂ) :
+    ⇑(indicatorL1 m s hs f) =ᵐ[m] s.indicator ⇑f := by
+  rw [indicatorL1]
+  exact Integrable.coeFn_toL1 ((L1.integrable_coeFn f).indicator hs)
+
+theorem lipschitzWith_indicatorL1 {m : Measure X} {s : Set X} (hs : MeasurableSet s) :
+    LipschitzWith 1 (indicatorL1 m s hs) := by
+  intro f g
+  rw [ENNReal.coe_one, one_mul, Lp.edist_eq_eLpNorm_neg_add, Lp.edist_eq_eLpNorm_neg_add]
+  refine eLpNorm_mono_ae ?_
+  filter_upwards [coeFn_indicatorL1 hs f, coeFn_indicatorL1 hs g] with x hxf hxg
+  simp only [Pi.add_apply, Pi.neg_apply, hxf, hxg]
+  by_cases hxs : x ∈ s
+  · simp [Set.indicator_of_mem hxs]
+  · simp [Set.indicator_of_notMem hxs]
+
+/-- The map `f ↦ setToFun m T hT (s.indicator f)` is continuous on `L¹(m)`. The indicator
+restriction `f ↦ s.indicator f` is a `1`-Lipschitz self-map of `L¹(m)`, after which
+`continuous_setToFun` applies. -/
+theorem continuous_setToFun_indicator {m : Measure X} {T : Set X → ℂ →L[ℝ] ℂ} {C : ℝ}
+    (hT : DominatedFinMeasAdditive m T C) {s : Set X} (hs : MeasurableSet s) :
+    Continuous fun f : X →₁[m] ℂ => setToFun m T hT (s.indicator ⇑f) := by
+  have heq : (fun f : X →₁[m] ℂ => setToFun m T hT (s.indicator ⇑f)) =
+      (fun f : X →₁[m] ℂ => setToFun m T hT ⇑f) ∘ (indicatorL1 m s hs) := by
+    funext f
+    exact (setToFun_congr_ae hT (coeFn_indicatorL1 hs f)).symm
+  rw [heq]
+  exact (continuous_setToFun hT).comp (lipschitzWith_indicatorL1 hs).continuous
+
+theorem vectorMeasure_integral_mul_complex_add (μ : VectorMeasure X ℂ) {f g : X → ℂ}
+    (hf : Integrable f μ.variation) (hg : Integrable g μ.variation) :
+    VectorMeasure.integral μ (f + g) (ContinuousLinearMap.mul ℝ ℂ) =
+      VectorMeasure.integral μ f (ContinuousLinearMap.mul ℝ ℂ) +
+        VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ) := by
+  rw [← setToFun_mul_complex_variation_eq_integral μ hf,
+    ← setToFun_mul_complex_variation_eq_integral μ hg,
+    ← setToFun_mul_complex_variation_eq_integral μ (hf.add hg)]
+  exact setToFun_add (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) hf hg
+
+theorem vectorMeasure_integral_indicator_eq_restrict (μ : VectorMeasure X ℂ)
+    [IsFiniteMeasure μ.variation] {s : Set X} (hs : MeasurableSet s) {g : X → ℂ}
+    (hg : Integrable g μ.variation) :
+    VectorMeasure.integral μ (s.indicator g) (ContinuousLinearMap.mul ℝ ℂ) =
+      VectorMeasure.integral (μ.restrict s) g (ContinuousLinearMap.mul ℝ ℂ) := by
+  have hvar_le : (μ.restrict s).variation ≤ μ.variation := vectorMeasure_restrict_variation_le μ hs
+  have hfin : IsFiniteMeasure (μ.restrict s).variation :=
+    ⟨lt_of_le_of_lt (hvar_le Set.univ) (measure_lt_top μ.variation Set.univ)⟩
+  -- Reduce to a statement provable by induction over `g` against `μ.variation`.
+  set B := ContinuousLinearMap.mul ℝ ℂ with hB
+  -- The predicate to induct on.
+  set P : (X → ℂ) → Prop := fun g =>
+    VectorMeasure.integral μ (s.indicator g) B = VectorMeasure.integral (μ.restrict s) g B with hP
+  suffices hsuff : ∀ ⦃g : X → ℂ⦄, Integrable g μ.variation → P g from hsuff hg
+  intro g hg
+  refine Integrable.induction P ?_ ?_ ?_ ?_ hg
+  · -- base case: `g = t.indicator (fun _ => c)`
+    intro c t ht htfin
+    have htfin' : μ.variation t ≠ ∞ := htfin.ne
+    have hsint : μ.variation (s ∩ t) ≠ ∞ :=
+      ne_top_of_le_ne_top htfin' (measure_mono Set.inter_subset_right)
+    have hrtfin : (μ.restrict s).variation t ≠ ∞ := (measure_lt_top _ _).ne
+    change VectorMeasure.integral μ (s.indicator (t.indicator fun _ => c)) B =
+      VectorMeasure.integral (μ.restrict s) (t.indicator fun _ => c) B
+    rw [Set.indicator_indicator, hB,
+      vectorMeasure_integral_mul_complex_indicator_const μ (hs.inter ht) hsint c,
+      vectorMeasure_integral_mul_complex_indicator_const (μ.restrict s) ht hrtfin c,
+      VectorMeasure.restrict_apply μ hs ht, Set.inter_comm s t]
+  · -- additivity
+    intro f₁ f₂ _ hf₁ hf₂ hPf₁ hPf₂
+    have hf₁r : Integrable f₁ (μ.restrict s).variation := hf₁.mono_measure hvar_le
+    have hf₂r : Integrable f₂ (μ.restrict s).variation := hf₂.mono_measure hvar_le
+    change VectorMeasure.integral μ (s.indicator (f₁ + f₂)) B =
+      VectorMeasure.integral (μ.restrict s) (f₁ + f₂) B
+    rw [Set.indicator_add', hB,
+      vectorMeasure_integral_mul_complex_add μ (hf₁.indicator hs) (hf₂.indicator hs),
+      vectorMeasure_integral_mul_complex_add (μ.restrict s) hf₁r hf₂r]
+    exact congr_arg₂ (· + ·) hPf₁ hPf₂
+  · -- closedness
+    have hdomμ := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ
+    have hLHS : Continuous fun f : X →₁[μ.variation] ℂ =>
+        VectorMeasure.integral μ (s.indicator ⇑f) B := by
+      have := continuous_setToFun_indicator hdomμ hs
+      refine this.congr fun f => ?_
+      exact setToFun_mul_complex_variation_eq_integral μ ((L1.integrable_coeFn f).indicator hs)
+    have hdomρ := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation (μ.restrict s)
+    have hdomρ_up : DominatedFinMeasAdditive μ.variation
+        (cbmApplyMeasure (μ.restrict s) B) 1 :=
+      DominatedFinMeasAdditive.of_measure_le hvar_le hdomρ zero_le_one
+    have hRHS : Continuous fun f : X →₁[μ.variation] ℂ =>
+        VectorMeasure.integral (μ.restrict s) (⇑f) B := by
+      have hcont : Continuous fun f : X →₁[μ.variation] ℂ =>
+          setToFun μ.variation (cbmApplyMeasure (μ.restrict s) B) hdomρ_up ⇑f :=
+        continuous_setToFun hdomρ_up
+      refine hcont.congr fun f => ?_
+      have hfr : Integrable (⇑f) (μ.restrict s).variation :=
+        (L1.integrable_coeFn f).mono_measure hvar_le
+      rw [← setToFun_mul_complex_variation_eq_integral (μ.restrict s) hfr]
+      exact setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top
+        (by simpa [one_smul] using hvar_le) hdomρ_up hdomρ _ (L1.integrable_coeFn f)
+    exact isClosed_eq hLHS hRHS
+  · -- a.e. congruence
+    intro f₁ f₂ hf₁₂ hf₁ hPf₁
+    have hf₂ : Integrable f₂ μ.variation := hf₁.congr hf₁₂
+    have hf₁r : Integrable f₁ (μ.restrict s).variation := hf₁.mono_measure hvar_le
+    have hf₂r : Integrable f₂ (μ.restrict s).variation := hf₂.mono_measure hvar_le
+    have hf₁₂r : f₁ =ᵐ[(μ.restrict s).variation] f₂ :=
+      (Measure.absolutelyContinuous_of_le hvar_le) hf₁₂
+    have hind₁₂ : s.indicator f₁ =ᵐ[μ.variation] s.indicator f₂ := by
+      filter_upwards [hf₁₂] with x hx
+      by_cases hxs : x ∈ s
+      · simp [Set.indicator_of_mem hxs, hx]
+      · simp [Set.indicator_of_notMem hxs]
+    change VectorMeasure.integral μ (s.indicator f₂) B =
+      VectorMeasure.integral (μ.restrict s) f₂ B
+    rw [← setToFun_mul_complex_variation_eq_integral μ (hf₂.indicator hs),
+      ← setToFun_mul_complex_variation_eq_integral (μ.restrict s) hf₂r,
+      setToFun_congr_ae _ hind₁₂.symm,
+      setToFun_congr_ae _ hf₁₂r.symm,
+      setToFun_mul_complex_variation_eq_integral μ (hf₁.indicator hs),
+      setToFun_mul_complex_variation_eq_integral (μ.restrict s) hf₁r]
+    exact hPf₁
+
 theorem norm_setToFun_mul_complex_variation_le_of_norm_le (μ : VectorMeasure X ℂ)
     {g : X → ℂ} {C : ℝ} (hg : Integrable g μ.variation) (hC : 0 ≤ C)
     (hbound : ∀ x, ‖g x‖ ≤ C) (hμ : μ.variation univ ≠ ∞) :

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -1,0 +1,101 @@
+import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
+import Mathlib.MeasureTheory.VectorMeasure.Integral
+
+open Set MeasureTheory VectorMeasure ContinuousLinearMap
+open scoped ENNReal BoundedContinuousFunction
+
+namespace MeasureTheory
+
+variable {X F : Type*} [MeasurableSpace X] [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+theorem dominatedFinMeasAdditive_cbmApplyMeasure_lsmul_variation (μ : VectorMeasure X F) :
+    DominatedFinMeasAdditive μ.variation (cbmApplyMeasure μ (lsmul ℝ ℝ)) 1 := by
+  refine ⟨fun _s _t hs ht _ _ hdisj ↦ cbmApplyMeasure_union μ (lsmul ℝ ℝ) hs ht hdisj,
+    fun s _hs hsf ↦ ?_⟩
+  calc
+    ‖cbmApplyMeasure μ (lsmul ℝ ℝ) s‖
+        ≤ ‖(lsmul ℝ ℝ : ℝ →L[ℝ] F →L[ℝ] F)‖ * ‖μ s‖ :=
+      norm_cbmApplyMeasure_le μ (lsmul ℝ ℝ) s
+    _ ≤ 1 * ‖μ s‖ := by
+      exact mul_le_mul_of_nonneg_right opNorm_lsmul_le (norm_nonneg _)
+    _ ≤ 1 * μ.variation.real s := by
+      gcongr
+      exact norm_measure_le_variation hsf.ne
+
+theorem setToFun_lsmul_variation_eq_integral [CompleteSpace F] (μ : VectorMeasure X F)
+    {g : X → ℝ} (hg : Integrable g μ.variation) :
+    setToFun μ.variation (cbmApplyMeasure μ (lsmul ℝ ℝ))
+        (dominatedFinMeasAdditive_cbmApplyMeasure_lsmul_variation μ) g =
+      ∫ᵛ x, g x ∂•μ := by
+  rw [VectorMeasure.integral]
+  rw [dif_pos (inferInstance : CompleteSpace F)]
+  refine setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top ?_
+    (dominatedFinMeasAdditive_cbmApplyMeasure_lsmul_variation μ)
+    (dominatedFinMeasAdditive_cbmApplyMeasure μ (lsmul ℝ ℝ)) g hg
+  simp only [one_smul]
+  refine variation_le_of_forall_enorm_le ?_
+  intro s _hs
+  have hnorm : ‖(μ.transpose (lsmul ℝ ℝ)) s‖ ≤ ‖μ s‖ := by
+    calc
+      ‖(μ.transpose (lsmul ℝ ℝ)) s‖ = ‖cbmApplyMeasure μ (lsmul ℝ ℝ) s‖ := rfl
+      _ ≤ ‖(lsmul ℝ ℝ : ℝ →L[ℝ] F →L[ℝ] F)‖ * ‖μ s‖ :=
+        norm_cbmApplyMeasure_le μ (lsmul ℝ ℝ) s
+      _ ≤ 1 * ‖μ s‖ := by
+        exact mul_le_mul_of_nonneg_right opNorm_lsmul_le (norm_nonneg _)
+      _ = ‖μ s‖ := one_mul _
+  have henorm : ‖(μ.transpose (lsmul ℝ ℝ)) s‖ₑ ≤ ‖μ s‖ₑ := by
+    simpa [ofReal_norm] using ENNReal.ofReal_le_ofReal hnorm
+  exact henorm.trans (enorm_measure_le_variation μ s)
+
+theorem norm_setToFun_lsmul_variation_le_of_norm_le [CompleteSpace F] (μ : VectorMeasure X F)
+    {g : X → ℝ} {C : ℝ} (hg : Integrable g μ.variation) (hC : 0 ≤ C)
+    (hbound : ∀ x, ‖g x‖ ≤ C) (hμ : μ.variation univ ≠ ∞) :
+    ‖setToFun μ.variation (cbmApplyMeasure μ (lsmul ℝ ℝ))
+        (dominatedFinMeasAdditive_cbmApplyMeasure_lsmul_variation μ) g‖ ≤
+      C * (μ.variation univ).toReal := by
+  calc
+    ‖setToFun μ.variation (cbmApplyMeasure μ (lsmul ℝ ℝ))
+        (dominatedFinMeasAdditive_cbmApplyMeasure_lsmul_variation μ) g‖
+        ≤ 1 * ‖hg.toL1 g‖ :=
+      norm_setToFun_le (dominatedFinMeasAdditive_cbmApplyMeasure_lsmul_variation μ) hg
+        zero_le_one
+    _ = ‖hg.toL1 g‖ := one_mul _
+    _ ≤ C * (μ.variation univ).toReal := by
+      rw [Integrable.norm_toL1_eq_lintegral_enorm]
+      have hlin :
+          (∫⁻ x, ‖g x‖ₑ ∂μ.variation) ≤ ENNReal.ofReal C * μ.variation univ := by
+        calc
+          (∫⁻ x, ‖g x‖ₑ ∂μ.variation) ≤ ∫⁻ _x, ENNReal.ofReal C ∂μ.variation := by
+            refine lintegral_mono fun x ↦ ?_
+            rw [← ofReal_norm (g x)]
+            exact ENNReal.ofReal_le_ofReal (hbound x)
+          _ = ENNReal.ofReal C * μ.variation univ := lintegral_const _
+      have htop : ENNReal.ofReal C * μ.variation univ ≠ ∞ :=
+        ENNReal.mul_ne_top ENNReal.ofReal_ne_top hμ
+      have hreal := ENNReal.toReal_mono htop hlin
+      simpa [ENNReal.toReal_mul, ENNReal.toReal_ofReal hC, measureReal_def] using hreal
+
+namespace VectorMeasure
+
+theorem norm_integral_smul_le_of_norm_le (μ : VectorMeasure X F) {g : X → ℝ} {C : ℝ}
+    (hg : Integrable g μ.variation) (hC : 0 ≤ C) (hbound : ∀ x, ‖g x‖ ≤ C)
+    (hμ : μ.variation univ ≠ ∞) :
+    ‖∫ᵛ x, g x ∂•μ‖ ≤ C * (μ.variation univ).toReal := by
+  by_cases hF : CompleteSpace F
+  · letI := hF
+    rw [← setToFun_lsmul_variation_eq_integral μ hg]
+    exact norm_setToFun_lsmul_variation_le_of_norm_le μ hg hC hbound hμ
+  · rw [integral]
+    simp [hF, mul_nonneg hC ENNReal.toReal_nonneg]
+
+theorem norm_integral_smul_boundedContinuousFunction_le {X F : Type*} [MeasurableSpace X]
+    [TopologicalSpace X] [OpensMeasurableSpace X] [NormedAddCommGroup F] [NormedSpace ℝ F]
+    (μ : VectorMeasure X F) [IsFiniteMeasure μ.variation] (g : X →ᵇ ℝ) :
+    ‖∫ᵛ x, g x ∂•μ‖ ≤ ‖g‖ * (μ.variation univ).toReal :=
+  norm_integral_smul_le_of_norm_le μ (BoundedContinuousFunction.integrable μ.variation g)
+    (norm_nonneg g) (BoundedContinuousFunction.norm_coe_le_norm g)
+    (measure_ne_top μ.variation univ)
+
+end VectorMeasure
+
+end MeasureTheory

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -1,4 +1,5 @@
 import Mathlib.MeasureTheory.Integral.BoundedContinuousFunction
+import Mathlib.MeasureTheory.Measure.Complex
 import Mathlib.MeasureTheory.VectorMeasure.Integral
 
 open Set MeasureTheory VectorMeasure ContinuousLinearMap
@@ -160,6 +161,87 @@ theorem vectorMeasure_integral_mul_complex_const (μ : VectorMeasure X ℂ)
   rw [← Set.indicator_univ (fun _ : X => x)]
   exact vectorMeasure_integral_mul_complex_indicator_const μ MeasurableSet.univ
     (measure_ne_top _ _) x
+
+namespace Measure
+
+noncomputable abbrev toComplexMeasureZero (μ : Measure X) [IsFiniteMeasure μ] :
+    VectorMeasure X ℂ :=
+  μ.toSignedMeasure.toComplexMeasure 0
+
+theorem toComplexMeasureZero_apply (μ : Measure X) [IsFiniteMeasure μ] {s : Set X}
+    (hs : MeasurableSet s) :
+    μ.toComplexMeasureZero s = (μ.real s : ℂ) := by
+  classical
+  change { re := if MeasurableSet s then μ.real s else 0, im := (0 : ℝ) } =
+    (μ.real s : ℂ)
+  rw [if_pos hs]
+  rfl
+
+theorem toComplexMeasureZero_variation_le (μ : Measure X) [IsFiniteMeasure μ] :
+    μ.toComplexMeasureZero.variation ≤ μ := by
+  refine variation_le_of_forall_enorm_le ?_
+  intro s hs
+  have hnorm : ‖μ.toComplexMeasureZero s‖ ≤ μ.real s := by
+    rw [toComplexMeasureZero_apply μ hs]
+    rw [Complex.norm_real, Real.norm_eq_abs,
+      abs_of_nonneg (show 0 ≤ μ.real s from measureReal_nonneg)]
+  calc
+    ‖μ.toComplexMeasureZero s‖ₑ = ENNReal.ofReal ‖μ.toComplexMeasureZero s‖ := by
+      exact (ofReal_norm _).symm
+    _ ≤ ENNReal.ofReal (μ.real s) := ENNReal.ofReal_le_ofReal hnorm
+    _ = μ s := ENNReal.ofReal_toReal (measure_ne_top μ s)
+
+end Measure
+
+theorem dominatedFinMeasAdditive_cbmApplyMeasure_toComplexMeasureZero_mul_complex
+    (μ : Measure X) [IsFiniteMeasure μ] :
+    DominatedFinMeasAdditive μ
+      (cbmApplyMeasure μ.toComplexMeasureZero (ContinuousLinearMap.mul ℝ ℂ) :
+        Set X → ℂ →L[ℝ] ℂ) 1 := by
+  refine ⟨fun _s _t hs ht _ _ hdisj =>
+    cbmApplyMeasure_union _ _ hs ht hdisj, fun s hs _hsf => ?_⟩
+  have hnormμ : ‖μ.toComplexMeasureZero s‖ ≤ μ.real s := by
+    rw [Measure.toComplexMeasureZero_apply μ hs]
+    rw [Complex.norm_real, Real.norm_eq_abs,
+      abs_of_nonneg (show 0 ≤ μ.real s from measureReal_nonneg)]
+  calc
+    ‖cbmApplyMeasure μ.toComplexMeasureZero (ContinuousLinearMap.mul ℝ ℂ) s‖
+        ≤ ‖(ContinuousLinearMap.mul ℝ ℂ : ℂ →L[ℝ] ℂ →L[ℝ] ℂ)‖ *
+            ‖μ.toComplexMeasureZero s‖ :=
+      norm_cbmApplyMeasure_le μ.toComplexMeasureZero (ContinuousLinearMap.mul ℝ ℂ) s
+    _ ≤ 1 * ‖μ.toComplexMeasureZero s‖ := by
+      exact mul_le_mul_of_nonneg_right (ContinuousLinearMap.opNorm_mul_le ℝ ℂ) (norm_nonneg _)
+    _ ≤ 1 * μ.real s :=
+      mul_le_mul_of_nonneg_left hnormμ zero_le_one
+
+theorem vectorMeasure_integral_toComplexMeasureZero_mul_eq_integral
+    (μ : Measure X) [IsFiniteMeasure μ] {g : X → ℂ} (hg : Integrable g μ) :
+    VectorMeasure.integral μ.toComplexMeasureZero g (ContinuousLinearMap.mul ℝ ℂ) =
+      ∫ x, g x ∂μ := by
+  rw [← setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureZero]
+  · rw [integral_eq_setToFun]
+    have hvar_le := Measure.toComplexMeasureZero_variation_le μ
+    have hdomμ := dominatedFinMeasAdditive_cbmApplyMeasure_toComplexMeasureZero_mul_complex μ
+    calc
+      setToFun μ.toComplexMeasureZero.variation
+          (cbmApplyMeasure μ.toComplexMeasureZero (ContinuousLinearMap.mul ℝ ℂ))
+          (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+            μ.toComplexMeasureZero) g
+          = setToFun μ
+              (cbmApplyMeasure μ.toComplexMeasureZero (ContinuousLinearMap.mul ℝ ℂ))
+              hdomμ g := by
+            exact (setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top
+              (by simpa using hvar_le) hdomμ
+              (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+                μ.toComplexMeasureZero) g hg).symm
+      _ = setToFun μ (weightedSMul μ) (dominatedFinMeasAdditive_weightedSMul μ) g := by
+            exact setToFun_congr_left' hdomμ (dominatedFinMeasAdditive_weightedSMul μ)
+              (fun s hs _hfin => by
+                ext z
+                rw [cbmApplyMeasure_apply, Measure.toComplexMeasureZero_apply μ hs,
+                  weightedSMul_apply]
+                simp [mul_comm]) g
+  · exact hg.mono_measure (Measure.toComplexMeasureZero_variation_le μ)
 
 theorem norm_setToFun_mul_complex_variation_le_of_norm_le (μ : VectorMeasure X ℂ)
     {g : X → ℂ} {C : ℝ} (hg : Integrable g μ.variation) (hC : 0 ≤ C)

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -162,6 +162,96 @@ theorem vectorMeasure_integral_mul_complex_const (μ : VectorMeasure X ℂ)
   exact vectorMeasure_integral_mul_complex_indicator_const μ MeasurableSet.univ
     (measure_ne_top _ _) x
 
+theorem complexMeasure_re_toComplexMeasure_add_im_toComplexMeasure_eq (μ : VectorMeasure X ℂ) :
+    ((ComplexMeasure.re μ).toComplexMeasure 0) +
+      ((0 : SignedMeasure X).toComplexMeasure (ComplexMeasure.im μ)) = μ := by
+  ext s hs
+  rw [VectorMeasure.add_apply, SignedMeasure.toComplexMeasure_apply,
+    SignedMeasure.toComplexMeasure_apply, ComplexMeasure.re_apply, ComplexMeasure.im_apply,
+    VectorMeasure.mapRange_apply, VectorMeasure.mapRange_apply]
+  exact Complex.ext (by simp) (by simp)
+
+theorem complexMeasure_re_toComplexMeasure_variation_le (μ : VectorMeasure X ℂ) :
+    (((ComplexMeasure.re μ).toComplexMeasure 0).variation) ≤ μ.variation := by
+  refine variation_le_of_forall_enorm_le ?_
+  intro s hs
+  rw [SignedMeasure.toComplexMeasure_apply, ComplexMeasure.re_apply, VectorMeasure.mapRange_apply]
+  have hnorm : ‖({ re := (μ s).re, im := (0 : ℝ) } : ℂ)‖ ≤ ‖μ s‖ := by
+    rw [show ({ re := (μ s).re, im := (0 : ℝ) } : ℂ) = ((μ s).re : ℂ) by rfl,
+      Complex.norm_real]
+    exact Complex.abs_re_le_norm (μ s)
+  calc
+    ‖({ re := (μ s).re, im := (0 : ℝ) } : ℂ)‖ₑ =
+        ENNReal.ofReal ‖({ re := (μ s).re, im := (0 : ℝ) } : ℂ)‖ := by
+      exact (ofReal_norm _).symm
+    _ ≤ ENNReal.ofReal ‖μ s‖ := ENNReal.ofReal_le_ofReal hnorm
+    _ = ‖μ s‖ₑ := by exact ofReal_norm _
+    _ ≤ μ.variation s := enorm_measure_le_variation μ s
+
+theorem complexMeasure_im_toComplexMeasure_variation_le (μ : VectorMeasure X ℂ) :
+    (((0 : SignedMeasure X).toComplexMeasure (ComplexMeasure.im μ)).variation) ≤
+      μ.variation := by
+  refine variation_le_of_forall_enorm_le ?_
+  intro s hs
+  rw [SignedMeasure.toComplexMeasure_apply, ComplexMeasure.im_apply, VectorMeasure.mapRange_apply]
+  have hnorm : ‖({ re := (0 : ℝ), im := (μ s).im } : ℂ)‖ ≤ ‖μ s‖ := by
+    rw [show ({ re := (0 : ℝ), im := (μ s).im } : ℂ) =
+        ((μ s).im : ℂ) * Complex.I by
+      apply Complex.ext <;> simp]
+    rw [Complex.norm_mul, Complex.norm_real]
+    simpa using Complex.abs_im_le_norm (μ s)
+  calc
+    ‖({ re := (0 : ℝ), im := (μ s).im } : ℂ)‖ₑ =
+        ENNReal.ofReal ‖({ re := (0 : ℝ), im := (μ s).im } : ℂ)‖ := by
+      exact (ofReal_norm _).symm
+    _ ≤ ENNReal.ofReal ‖μ s‖ := ENNReal.ofReal_le_ofReal hnorm
+    _ = ‖μ s‖ₑ := by exact ofReal_norm _
+    _ ≤ μ.variation s := enorm_measure_le_variation μ s
+
+theorem vectorMeasure_integral_eq_re_add_I_im_of_integrable (μ : VectorMeasure X ℂ)
+    {g : X → ℂ} (hg : Integrable g μ.variation) :
+    VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ) =
+      VectorMeasure.integral ((ComplexMeasure.re μ).toComplexMeasure 0) g
+        (ContinuousLinearMap.mul ℝ ℂ) +
+        VectorMeasure.integral
+          ((0 : SignedMeasure X).toComplexMeasure (ComplexMeasure.im μ)) g
+          (ContinuousLinearMap.mul ℝ ℂ) := by
+  let μre : VectorMeasure X ℂ := (ComplexMeasure.re μ).toComplexMeasure 0
+  let μim : VectorMeasure X ℂ := (0 : SignedMeasure X).toComplexMeasure (ComplexMeasure.im μ)
+  have hsum : μre + μim = μ := by
+    simpa [μre, μim] using complexMeasure_re_toComplexMeasure_add_im_toComplexMeasure_eq μ
+  have hre_le : μre.variation ≤ μ.variation := by
+    simpa [μre] using complexMeasure_re_toComplexMeasure_variation_le μ
+  have him_le : μim.variation ≤ μ.variation := by
+    simpa [μim] using complexMeasure_im_toComplexMeasure_variation_le μ
+  have hgre : Integrable g μre.variation := hg.mono_measure hre_le
+  have hgim : Integrable g μim.variation := hg.mono_measure him_le
+  have hvar_sum : μ.variation ≤ μre.variation + μim.variation := by
+    rw [← hsum]
+    exact VectorMeasure.variation_add_le
+  have hT_eq : ∀ s : Set X, MeasurableSet s →
+      (μre.variation + μim.variation) s < (∞ : ℝ≥0∞) →
+        cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ) s =
+          (cbmApplyMeasure μre (ContinuousLinearMap.mul ℝ ℂ) +
+            cbmApplyMeasure μim (ContinuousLinearMap.mul ℝ ℂ)) s := by
+    intro s hs _hfin
+    ext z
+    have hmeasure : μ s = μre s + μim s := by
+      rw [← hsum]
+      rfl
+    simp [cbmApplyMeasure_apply, hmeasure, mul_add]
+  change VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ) =
+    VectorMeasure.integral μre g (ContinuousLinearMap.mul ℝ ℂ) +
+      VectorMeasure.integral μim g (ContinuousLinearMap.mul ℝ ℂ)
+  rw [← setToFun_mul_complex_variation_eq_integral μ hg]
+  rw [← setToFun_mul_complex_variation_eq_integral μre hgre]
+  rw [← setToFun_mul_complex_variation_eq_integral μim hgim]
+  exact setToFun_add_left''
+    (hT := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μre)
+    (hT' := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μim)
+    (hT'' := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ)
+    hT_eq hgre hgim hvar_sum zero_le_one zero_le_one zero_le_one
+
 namespace Measure
 
 noncomputable abbrev toComplexMeasureZero (μ : Measure X) [IsFiniteMeasure μ] :
@@ -242,6 +332,76 @@ theorem vectorMeasure_integral_toComplexMeasureZero_mul_eq_integral
                   weightedSMul_apply]
                 simp [mul_comm]) g
   · exact hg.mono_measure (Measure.toComplexMeasureZero_variation_le μ)
+
+theorem vectorMeasure_integral_restrict_toComplexMeasureZero_mul_eq_setIntegral
+    (μ : Measure X) {s : Set X} [IsFiniteMeasure (μ.restrict s)]
+    {g : X → ℂ} (hg : IntegrableOn g s μ) :
+    VectorMeasure.integral (μ.restrict s).toComplexMeasureZero g
+        (ContinuousLinearMap.mul ℝ ℂ) =
+      ∫ x in s, g x ∂μ := by
+  simpa using
+    vectorMeasure_integral_toComplexMeasureZero_mul_eq_integral (μ.restrict s) hg.integrable
+
+theorem vectorMeasure_integral_restrict_toComplexMeasureZero_sub_mul_eq_setIntegral_sub
+    (μ ν : Measure X) {s : Set X}
+    [IsFiniteMeasure (μ.restrict s)] [IsFiniteMeasure (ν.restrict s)]
+    {g : X → ℂ} (hμg : IntegrableOn g s μ) (hνg : IntegrableOn g s ν) :
+    VectorMeasure.integral
+        ((μ.restrict s).toComplexMeasureZero - (ν.restrict s).toComplexMeasureZero)
+        g (ContinuousLinearMap.mul ℝ ℂ) =
+      (∫ x in s, g x ∂μ) - ∫ x in s, g x ∂ν := by
+  let μc : VectorMeasure X ℂ := (μ.restrict s).toComplexMeasureZero
+  let νc : VectorMeasure X ℂ := (ν.restrict s).toComplexMeasureZero
+  let ξ : VectorMeasure X ℂ := μc - νc
+  have hμc_var_le : μc.variation ≤ μ.restrict s := by
+    simpa [μc] using Measure.toComplexMeasureZero_variation_le (μ.restrict s)
+  have hνc_var_le : νc.variation ≤ ν.restrict s := by
+    simpa [νc] using Measure.toComplexMeasureZero_variation_le (ν.restrict s)
+  have hμc_g : Integrable g μc.variation := hμg.integrable.mono_measure hμc_var_le
+  have hνc_g : Integrable g νc.variation := hνg.integrable.mono_measure hνc_var_le
+  have hsum_g : Integrable g (μc.variation + νc.variation) := hμc_g.add_measure hνc_g
+  have hξ_var_le : ξ.variation ≤ μc.variation + νc.variation := by
+    simpa [ξ] using VectorMeasure.variation_sub_le (μ := μc) (ν := νc)
+  have hξ_g : Integrable g ξ.variation := hsum_g.mono_measure hξ_var_le
+  have hdomξ := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation ξ
+  have hdomξ_sum : DominatedFinMeasAdditive (μc.variation + νc.variation)
+      (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) 1 :=
+    DominatedFinMeasAdditive.of_measure_le hξ_var_le hdomξ zero_le_one
+  have hdomμ := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μc
+  have hdomν := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation νc
+  have hdom_sub :=
+    DominatedFinMeasAdditive.sub_measure μc.variation νc.variation hdomμ hdomν
+  have hT_eq : ∀ t : Set X, MeasurableSet t →
+      (μc.variation + νc.variation) t < (∞ : ℝ≥0∞) →
+        cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ) t =
+          (cbmApplyMeasure μc (ContinuousLinearMap.mul ℝ ℂ) -
+            cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) t := by
+    intro t ht _hfin
+    ext z
+    simp [ξ, cbmApplyMeasure_apply, sub_eq_add_neg, mul_add]
+  change VectorMeasure.integral ξ g (ContinuousLinearMap.mul ℝ ℂ) =
+    (∫ x in s, g x ∂μ) - ∫ x in s, g x ∂ν
+  rw [← setToFun_mul_complex_variation_eq_integral ξ hξ_g]
+  rw [← vectorMeasure_integral_restrict_toComplexMeasureZero_mul_eq_setIntegral μ hμg]
+  rw [← vectorMeasure_integral_restrict_toComplexMeasureZero_mul_eq_setIntegral ν hνg]
+  change setToFun ξ.variation (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) hdomξ g =
+    VectorMeasure.integral μc g (ContinuousLinearMap.mul ℝ ℂ) -
+      VectorMeasure.integral νc g (ContinuousLinearMap.mul ℝ ℂ)
+  rw [← setToFun_mul_complex_variation_eq_integral μc hμc_g]
+  rw [← setToFun_mul_complex_variation_eq_integral νc hνc_g]
+  calc
+    setToFun ξ.variation (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) hdomξ g =
+        setToFun (μc.variation + νc.variation)
+          (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) hdomξ_sum g := by
+          exact (setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top
+            (by simpa [one_smul] using hξ_var_le) hdomξ_sum hdomξ g hsum_g).symm
+    _ = setToFun (μc.variation + νc.variation)
+          (cbmApplyMeasure μc (ContinuousLinearMap.mul ℝ ℂ) -
+            cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) hdom_sub g := by
+          exact setToFun_congr_left' hdomξ_sum hdom_sub hT_eq g
+    _ = setToFun μc.variation (cbmApplyMeasure μc (ContinuousLinearMap.mul ℝ ℂ)) hdomμ g -
+          setToFun νc.variation (cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) hdomν g := by
+          exact setToFun_sub_measure hdomμ hdomν hμc_g hνc_g
 
 theorem norm_setToFun_mul_complex_variation_le_of_norm_le (μ : VectorMeasure X ℂ)
     {g : X → ℂ} {C : ℝ} (hg : Integrable g μ.variation) (hC : 0 ≤ C)

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -98,4 +98,97 @@ theorem norm_integral_smul_boundedContinuousFunction_le {X F : Type*} [Measurabl
 
 end VectorMeasure
 
+variable {X : Type*} [MeasurableSpace X]
+
+theorem dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+    (μ : VectorMeasure X ℂ) :
+    DominatedFinMeasAdditive μ.variation
+      (cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ)) 1 := by
+  refine ⟨fun _s _t hs ht _ _ hdisj ↦
+    cbmApplyMeasure_union μ (ContinuousLinearMap.mul ℝ ℂ) hs ht hdisj, fun s _hs hsf ↦ ?_⟩
+  calc
+    ‖cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ) s‖
+        ≤ ‖(ContinuousLinearMap.mul ℝ ℂ : ℂ →L[ℝ] ℂ →L[ℝ] ℂ)‖ * ‖μ s‖ :=
+      norm_cbmApplyMeasure_le μ (ContinuousLinearMap.mul ℝ ℂ) s
+    _ ≤ 1 * ‖μ s‖ := by
+      exact mul_le_mul_of_nonneg_right (ContinuousLinearMap.opNorm_mul_le ℝ ℂ) (norm_nonneg _)
+    _ ≤ 1 * μ.variation.real s := by
+      gcongr
+      exact norm_measure_le_variation hsf.ne
+
+theorem setToFun_mul_complex_variation_eq_integral (μ : VectorMeasure X ℂ)
+    {g : X → ℂ} (hg : Integrable g μ.variation) :
+    setToFun μ.variation (cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ))
+        (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) g =
+      VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ) := by
+  rw [VectorMeasure.integral]
+  rw [dif_pos (inferInstance : CompleteSpace ℂ)]
+  refine setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top ?_
+    (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ)
+    (dominatedFinMeasAdditive_cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ)) g hg
+  simp only [one_smul]
+  refine variation_le_of_forall_enorm_le ?_
+  intro s _hs
+  have hnorm : ‖(μ.transpose (ContinuousLinearMap.mul ℝ ℂ)) s‖ ≤ ‖μ s‖ := by
+    calc
+      ‖(μ.transpose (ContinuousLinearMap.mul ℝ ℂ)) s‖ =
+          ‖cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ) s‖ := rfl
+      _ ≤ ‖(ContinuousLinearMap.mul ℝ ℂ : ℂ →L[ℝ] ℂ →L[ℝ] ℂ)‖ * ‖μ s‖ :=
+        norm_cbmApplyMeasure_le μ (ContinuousLinearMap.mul ℝ ℂ) s
+      _ ≤ 1 * ‖μ s‖ := by
+        exact mul_le_mul_of_nonneg_right (ContinuousLinearMap.opNorm_mul_le ℝ ℂ) (norm_nonneg _)
+      _ = ‖μ s‖ := one_mul _
+  have henorm : ‖(μ.transpose (ContinuousLinearMap.mul ℝ ℂ)) s‖ₑ ≤ ‖μ s‖ₑ := by
+    simpa [ofReal_norm] using ENNReal.ofReal_le_ofReal hnorm
+  exact henorm.trans (enorm_measure_le_variation μ s)
+
+theorem norm_setToFun_mul_complex_variation_le_of_norm_le (μ : VectorMeasure X ℂ)
+    {g : X → ℂ} {C : ℝ} (hg : Integrable g μ.variation) (hC : 0 ≤ C)
+    (hbound : ∀ x, ‖g x‖ ≤ C) (hμ : μ.variation univ ≠ ∞) :
+    ‖setToFun μ.variation (cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ))
+        (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) g‖ ≤
+      C * (μ.variation univ).toReal := by
+  calc
+    ‖setToFun μ.variation (cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ))
+        (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) g‖
+        ≤ 1 * ‖hg.toL1 g‖ :=
+      norm_setToFun_le (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) hg
+        zero_le_one
+    _ = ‖hg.toL1 g‖ := one_mul _
+    _ ≤ C * (μ.variation univ).toReal := by
+      rw [Integrable.norm_toL1_eq_lintegral_enorm]
+      have hlin :
+          (∫⁻ x, ‖g x‖ₑ ∂μ.variation) ≤ ENNReal.ofReal C * μ.variation univ := by
+        calc
+          (∫⁻ x, ‖g x‖ₑ ∂μ.variation) ≤ ∫⁻ _x, ENNReal.ofReal C ∂μ.variation := by
+            refine lintegral_mono fun x ↦ ?_
+            rw [← ofReal_norm (g x)]
+            exact ENNReal.ofReal_le_ofReal (hbound x)
+          _ = ENNReal.ofReal C * μ.variation univ := lintegral_const _
+      have htop : ENNReal.ofReal C * μ.variation univ ≠ ∞ :=
+        ENNReal.mul_ne_top ENNReal.ofReal_ne_top hμ
+      have hreal := ENNReal.toReal_mono htop hlin
+      simpa [ENNReal.toReal_mul, ENNReal.toReal_ofReal hC, measureReal_def] using hreal
+
+namespace VectorMeasure
+
+theorem norm_integral_mul_complex_le_of_norm_le (μ : VectorMeasure X ℂ) {g : X → ℂ} {C : ℝ}
+    (hg : Integrable g μ.variation) (hC : 0 ≤ C) (hbound : ∀ x, ‖g x‖ ≤ C)
+    (hμ : μ.variation univ ≠ ∞) :
+    ‖VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ)‖ ≤
+      C * (μ.variation univ).toReal := by
+  rw [← setToFun_mul_complex_variation_eq_integral μ hg]
+  exact norm_setToFun_mul_complex_variation_le_of_norm_le μ hg hC hbound hμ
+
+theorem norm_integral_mul_complex_boundedContinuousFunction_le {X : Type*} [MeasurableSpace X]
+    [TopologicalSpace X] [OpensMeasurableSpace X] (μ : VectorMeasure X ℂ)
+    [IsFiniteMeasure μ.variation] (g : X →ᵇ ℂ) :
+    ‖VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ)‖ ≤
+      ‖g‖ * (μ.variation univ).toReal :=
+  norm_integral_mul_complex_le_of_norm_le μ
+    (BoundedContinuousFunction.integrable μ.variation g) (norm_nonneg g)
+    (BoundedContinuousFunction.norm_coe_le_norm g) (measure_ne_top μ.variation univ)
+
+end VectorMeasure
+
 end MeasureTheory

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -142,6 +142,25 @@ theorem setToFun_mul_complex_variation_eq_integral (μ : VectorMeasure X ℂ)
     simpa [ofReal_norm] using ENNReal.ofReal_le_ofReal hnorm
   exact henorm.trans (enorm_measure_le_variation μ s)
 
+theorem vectorMeasure_integral_mul_complex_indicator_const (μ : VectorMeasure X ℂ)
+    {s : Set X} (hs : MeasurableSet s) (hμs : μ.variation s ≠ ∞) (x : ℂ) :
+    VectorMeasure.integral μ (s.indicator fun _ => x) (ContinuousLinearMap.mul ℝ ℂ) =
+      x * μ s := by
+  have hg : Integrable (s.indicator fun _ => x) μ.variation :=
+    (integrableOn_const hμs).integrable_indicator hs
+  rw [← setToFun_mul_complex_variation_eq_integral μ hg]
+  rw [setToFun_indicator_const (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ)
+    hs hμs]
+  exact cbmApplyMeasure_apply μ (ContinuousLinearMap.mul ℝ ℂ) s x
+
+theorem vectorMeasure_integral_mul_complex_const (μ : VectorMeasure X ℂ)
+    [IsFiniteMeasure μ.variation] (x : ℂ) :
+    VectorMeasure.integral μ (fun _ => x) (ContinuousLinearMap.mul ℝ ℂ) =
+      x * μ Set.univ := by
+  rw [← Set.indicator_univ (fun _ : X => x)]
+  exact vectorMeasure_integral_mul_complex_indicator_const μ MeasurableSet.univ
+    (measure_ne_top _ _) x
+
 theorem norm_setToFun_mul_complex_variation_le_of_norm_le (μ : VectorMeasure X ℂ)
     {g : X → ℂ} {C : ℝ} (hg : Integrable g μ.variation) (hC : 0 ≤ C)
     (hbound : ∀ x, ‖g x‖ ≤ C) (hμ : μ.variation univ ≠ ∞) :

--- a/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
+++ b/PrimeNumberTheoremAnd/Mathlib/MeasureTheory/VectorMeasure/Integral.lean
@@ -162,6 +162,16 @@ theorem vectorMeasure_integral_mul_complex_const (μ : VectorMeasure X ℂ)
   exact vectorMeasure_integral_mul_complex_indicator_const μ MeasurableSet.univ
     (measure_ne_top _ _) x
 
+theorem vectorMeasure_integral_mul_complex_add (μ : VectorMeasure X ℂ) {f g : X → ℂ}
+    (hf : Integrable f μ.variation) (hg : Integrable g μ.variation) :
+    VectorMeasure.integral μ (f + g) (ContinuousLinearMap.mul ℝ ℂ) =
+      VectorMeasure.integral μ f (ContinuousLinearMap.mul ℝ ℂ) +
+        VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ) := by
+  rw [← setToFun_mul_complex_variation_eq_integral μ hf,
+    ← setToFun_mul_complex_variation_eq_integral μ hg,
+    ← setToFun_mul_complex_variation_eq_integral μ (hf.add hg)]
+  exact setToFun_add (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) hf hg
+
 theorem complexMeasure_re_toComplexMeasure_add_im_toComplexMeasure_eq (μ : VectorMeasure X ℂ) :
     ((ComplexMeasure.re μ).toComplexMeasure 0) +
       ((0 : SignedMeasure X).toComplexMeasure (ComplexMeasure.im μ)) = μ := by
@@ -277,6 +287,34 @@ theorem toComplexMeasureZero_variation_le (μ : Measure X) [IsFiniteMeasure μ] 
       abs_of_nonneg (show 0 ≤ μ.real s from measureReal_nonneg)]
   calc
     ‖μ.toComplexMeasureZero s‖ₑ = ENNReal.ofReal ‖μ.toComplexMeasureZero s‖ := by
+      exact (ofReal_norm _).symm
+    _ ≤ ENNReal.ofReal (μ.real s) := ENNReal.ofReal_le_ofReal hnorm
+    _ = μ s := ENNReal.ofReal_toReal (measure_ne_top μ s)
+
+/-- The purely-imaginary complex vector measure `s ↦ i·μ(s)` attached to a finite measure `μ`. -/
+noncomputable abbrev toComplexMeasureImagZero (μ : Measure X) [IsFiniteMeasure μ] :
+    VectorMeasure X ℂ :=
+  (0 : SignedMeasure X).toComplexMeasure μ.toSignedMeasure
+
+theorem toComplexMeasureImagZero_apply (μ : Measure X) [IsFiniteMeasure μ] {s : Set X}
+    (hs : MeasurableSet s) :
+    μ.toComplexMeasureImagZero s = (μ.real s : ℂ) * Complex.I := by
+  classical
+  change ({ re := (0 : ℝ), im := if MeasurableSet s then μ.real s else 0 } : ℂ) =
+    (μ.real s : ℂ) * Complex.I
+  rw [if_pos hs]
+  apply Complex.ext <;> simp
+
+theorem toComplexMeasureImagZero_variation_le (μ : Measure X) [IsFiniteMeasure μ] :
+    μ.toComplexMeasureImagZero.variation ≤ μ := by
+  refine variation_le_of_forall_enorm_le ?_
+  intro s hs
+  have hnorm : ‖μ.toComplexMeasureImagZero s‖ ≤ μ.real s := by
+    rw [toComplexMeasureImagZero_apply μ hs]
+    rw [Complex.norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs,
+      abs_of_nonneg (show 0 ≤ μ.real s from measureReal_nonneg)]
+  calc
+    ‖μ.toComplexMeasureImagZero s‖ₑ = ENNReal.ofReal ‖μ.toComplexMeasureImagZero s‖ := by
       exact (ofReal_norm _).symm
     _ ≤ ENNReal.ofReal (μ.real s) := ENNReal.ofReal_le_ofReal hnorm
     _ = μ s := ENNReal.ofReal_toReal (measure_ne_top μ s)
@@ -403,6 +441,243 @@ theorem vectorMeasure_integral_restrict_toComplexMeasureZero_sub_mul_eq_setInteg
           setToFun νc.variation (cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) hdomν g := by
           exact setToFun_sub_measure hdomμ hdomν hμc_g hνc_g
 
+theorem dominatedFinMeasAdditive_cbmApplyMeasure_toComplexMeasureImagZero_mul_complex
+    (μ : Measure X) [IsFiniteMeasure μ] :
+    DominatedFinMeasAdditive μ
+      (cbmApplyMeasure μ.toComplexMeasureImagZero (ContinuousLinearMap.mul ℝ ℂ) :
+        Set X → ℂ →L[ℝ] ℂ) 1 := by
+  refine ⟨fun _s _t hs ht _ _ hdisj =>
+    cbmApplyMeasure_union _ _ hs ht hdisj, fun s hs _hsf => ?_⟩
+  have hnormμ : ‖μ.toComplexMeasureImagZero s‖ ≤ μ.real s := by
+    rw [Measure.toComplexMeasureImagZero_apply μ hs]
+    rw [Complex.norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs,
+      abs_of_nonneg (show 0 ≤ μ.real s from measureReal_nonneg)]
+  calc
+    ‖cbmApplyMeasure μ.toComplexMeasureImagZero (ContinuousLinearMap.mul ℝ ℂ) s‖
+        ≤ ‖(ContinuousLinearMap.mul ℝ ℂ : ℂ →L[ℝ] ℂ →L[ℝ] ℂ)‖ *
+            ‖μ.toComplexMeasureImagZero s‖ :=
+      norm_cbmApplyMeasure_le μ.toComplexMeasureImagZero (ContinuousLinearMap.mul ℝ ℂ) s
+    _ ≤ 1 * ‖μ.toComplexMeasureImagZero s‖ := by
+      exact mul_le_mul_of_nonneg_right (ContinuousLinearMap.opNorm_mul_le ℝ ℂ) (norm_nonneg _)
+    _ ≤ 1 * μ.real s :=
+      mul_le_mul_of_nonneg_left hnormμ zero_le_one
+
+/-- The variation of the imaginary measure `i·μ` equals the variation of the real measure `μ`
+(seen as a complex vector measure): scaling the values by `i` is norm-preserving. -/
+theorem toComplexMeasureImagZero_variation_eq (μ : Measure X) [IsFiniteMeasure μ] :
+    μ.toComplexMeasureImagZero.variation = μ.toComplexMeasureZero.variation := by
+  have hnorm : ∀ s, MeasurableSet s →
+      ‖μ.toComplexMeasureImagZero s‖ = ‖μ.toComplexMeasureZero s‖ := by
+    intro s hs
+    rw [Measure.toComplexMeasureImagZero_apply μ hs, Measure.toComplexMeasureZero_apply μ hs,
+      Complex.norm_mul, Complex.norm_I, mul_one]
+  refine le_antisymm (variation_le_of_forall_enorm_le fun s hs => ?_)
+    (variation_le_of_forall_enorm_le fun s hs => ?_)
+  · rw [show ‖μ.toComplexMeasureImagZero s‖ₑ = ‖μ.toComplexMeasureZero s‖ₑ by
+      rw [← ofReal_norm, ← ofReal_norm, hnorm s hs]]
+    exact enorm_measure_le_variation μ.toComplexMeasureZero s
+  · rw [show ‖μ.toComplexMeasureZero s‖ₑ = ‖μ.toComplexMeasureImagZero s‖ₑ by
+      rw [← ofReal_norm, ← ofReal_norm, hnorm s hs]]
+    exact enorm_measure_le_variation μ.toComplexMeasureImagZero s
+
+/-- Key bridge: integrating against the imaginary measure `i·μ` equals integrating `i·g`
+against the real measure, with the `i` riding the integrand (never the `ℝ`-only measure-smul). -/
+theorem vectorMeasure_integral_toComplexMeasureImagZero_eq_toComplexMeasureZero_smul
+    (μ : Measure X) [IsFiniteMeasure μ] {g : X → ℂ} (hg : Integrable g μ) :
+    VectorMeasure.integral μ.toComplexMeasureImagZero g (ContinuousLinearMap.mul ℝ ℂ) =
+      VectorMeasure.integral μ.toComplexMeasureZero (Complex.I • g)
+        (ContinuousLinearMap.mul ℝ ℂ) := by
+  haveI hfin_im : IsFiniteMeasure μ.toComplexMeasureImagZero.variation :=
+    ⟨lt_of_le_of_lt (Measure.toComplexMeasureImagZero_variation_le μ Set.univ)
+      (measure_lt_top μ Set.univ)⟩
+  haveI hfin_re : IsFiniteMeasure μ.toComplexMeasureZero.variation :=
+    ⟨lt_of_le_of_lt (Measure.toComplexMeasureZero_variation_le μ Set.univ)
+      (measure_lt_top μ Set.univ)⟩
+  have hvar_im := Measure.toComplexMeasureImagZero_variation_le μ
+  have hvar_eq := toComplexMeasureImagZero_variation_eq μ
+  set B := ContinuousLinearMap.mul ℝ ℂ with hB
+  set P : (X → ℂ) → Prop := fun g =>
+    VectorMeasure.integral μ.toComplexMeasureImagZero g B =
+      VectorMeasure.integral μ.toComplexMeasureZero (Complex.I • g) B with hP
+  suffices hsuff : ∀ ⦃g : X → ℂ⦄, Integrable g μ.toComplexMeasureImagZero.variation → P g by
+    exact hsuff (hg.mono_measure hvar_im)
+  intro g hg
+  refine Integrable.induction P ?_ ?_ ?_ ?_ hg
+  · -- base case: `g = t.indicator (fun _ => c)`
+    intro c t ht htfin
+    have htfin_im : μ.toComplexMeasureImagZero.variation t ≠ ∞ := htfin.ne
+    have htfin_re : μ.toComplexMeasureZero.variation t ≠ ∞ := (measure_lt_top _ _).ne
+    have hsmul : (Complex.I • t.indicator (fun _ => c) : X → ℂ) =
+        t.indicator (fun _ => Complex.I * c) := by
+      ext x
+      by_cases hx : x ∈ t <;> simp [Set.indicator_of_mem, Set.indicator_of_notMem, hx, smul_eq_mul]
+    change VectorMeasure.integral μ.toComplexMeasureImagZero (t.indicator fun _ => c) B =
+      VectorMeasure.integral μ.toComplexMeasureZero (Complex.I • t.indicator fun _ => c) B
+    rw [hsmul, hB,
+      vectorMeasure_integral_mul_complex_indicator_const μ.toComplexMeasureImagZero ht htfin_im c,
+      vectorMeasure_integral_mul_complex_indicator_const μ.toComplexMeasureZero ht htfin_re
+        (Complex.I * c),
+      Measure.toComplexMeasureImagZero_apply μ ht, Measure.toComplexMeasureZero_apply μ ht]
+    ring
+  · -- additivity
+    intro f₁ f₂ _ hf₁ hf₂ hPf₁ hPf₂
+    have hf₁re : Integrable f₁ μ.toComplexMeasureZero.variation := hvar_eq ▸ hf₁
+    have hf₂re : Integrable f₂ μ.toComplexMeasureZero.variation := hvar_eq ▸ hf₂
+    change VectorMeasure.integral μ.toComplexMeasureImagZero (f₁ + f₂) B =
+      VectorMeasure.integral μ.toComplexMeasureZero (Complex.I • (f₁ + f₂)) B
+    rw [smul_add, hB,
+      vectorMeasure_integral_mul_complex_add μ.toComplexMeasureImagZero hf₁ hf₂,
+      vectorMeasure_integral_mul_complex_add μ.toComplexMeasureZero
+        (hf₁re.smul Complex.I) (hf₂re.smul Complex.I)]
+    exact congr_arg₂ (· + ·) hPf₁ hPf₂
+  · -- closedness
+    have hdomim := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+      μ.toComplexMeasureImagZero
+    have hLHS : Continuous fun f : X →₁[μ.toComplexMeasureImagZero.variation] ℂ =>
+        VectorMeasure.integral μ.toComplexMeasureImagZero (⇑f) B := by
+      refine (continuous_setToFun hdomim).congr fun f => ?_
+      exact setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureImagZero
+        (L1.integrable_coeFn f)
+    have hdomre := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+      μ.toComplexMeasureZero
+    have hdomre_up : DominatedFinMeasAdditive μ.toComplexMeasureImagZero.variation
+        (cbmApplyMeasure μ.toComplexMeasureZero B) 1 := hvar_eq ▸ hdomre
+    have hRHS : Continuous fun f : X →₁[μ.toComplexMeasureImagZero.variation] ℂ =>
+        VectorMeasure.integral μ.toComplexMeasureZero (Complex.I • (⇑f)) B := by
+      have hcont : Continuous fun f : X →₁[μ.toComplexMeasureImagZero.variation] ℂ =>
+          Complex.I • setToFun μ.toComplexMeasureImagZero.variation
+            (cbmApplyMeasure μ.toComplexMeasureZero B) hdomre_up (⇑f) :=
+        (continuous_setToFun hdomre_up).const_smul Complex.I
+      refine hcont.congr fun f => ?_
+      have hfre : Integrable (⇑f) μ.toComplexMeasureZero.variation :=
+        hvar_eq ▸ (L1.integrable_coeFn f)
+      rw [← setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureZero (hfre.smul Complex.I)]
+      have hstep : setToFun μ.toComplexMeasureImagZero.variation
+            (cbmApplyMeasure μ.toComplexMeasureZero B) hdomre_up (⇑f) =
+          setToFun μ.toComplexMeasureZero.variation
+            (cbmApplyMeasure μ.toComplexMeasureZero B)
+            (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+              μ.toComplexMeasureZero) (⇑f) := by
+        exact setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top
+          (by simp [one_smul, hvar_eq])
+          hdomre_up
+          (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ.toComplexMeasureZero)
+          _ (L1.integrable_coeFn f)
+      rw [hstep, setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureZero hfre,
+        ← setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureZero hfre]
+      exact (setToFun_smul (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation
+        μ.toComplexMeasureZero) (fun c s x => by
+          simp only [cbmApplyMeasure_apply, ContinuousLinearMap.mul_apply', smul_eq_mul]
+          ring) Complex.I (⇑f)).symm
+    exact isClosed_eq hLHS hRHS
+  · -- a.e. congruence
+    intro f₁ f₂ hf₁₂ hf₁ hPf₁
+    have hf₂ : Integrable f₂ μ.toComplexMeasureImagZero.variation := hf₁.congr hf₁₂
+    have hf₁₂re : Complex.I • f₁ =ᵐ[μ.toComplexMeasureZero.variation] Complex.I • f₂ := by
+      rw [← hvar_eq]
+      filter_upwards [hf₁₂] with x hx
+      simp [hx]
+    have hf₁im : Integrable f₁ μ.toComplexMeasureImagZero.variation := hf₁
+    have hf₂re : Integrable (Complex.I • f₂) μ.toComplexMeasureZero.variation :=
+      (hvar_eq ▸ hf₂).smul Complex.I
+    have hf₁re : Integrable (Complex.I • f₁) μ.toComplexMeasureZero.variation :=
+      (hvar_eq ▸ hf₁).smul Complex.I
+    change VectorMeasure.integral μ.toComplexMeasureImagZero f₂ B =
+      VectorMeasure.integral μ.toComplexMeasureZero (Complex.I • f₂) B
+    rw [← setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureImagZero hf₂,
+      ← setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureZero hf₂re,
+      setToFun_congr_ae _ hf₁₂.symm,
+      setToFun_congr_ae _ hf₁₂re.symm,
+      setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureImagZero hf₁im,
+      setToFun_mul_complex_variation_eq_integral μ.toComplexMeasureZero hf₁re]
+    exact hPf₁
+
+theorem vectorMeasure_integral_toComplexMeasureImagZero_mul_eq_integral
+    (μ : Measure X) [IsFiniteMeasure μ] {g : X → ℂ} (hg : Integrable g μ) :
+    VectorMeasure.integral μ.toComplexMeasureImagZero g (ContinuousLinearMap.mul ℝ ℂ) =
+      Complex.I * ∫ x, g x ∂μ := by
+  rw [vectorMeasure_integral_toComplexMeasureImagZero_eq_toComplexMeasureZero_smul μ hg]
+  rw [vectorMeasure_integral_toComplexMeasureZero_mul_eq_integral μ (hg.smul Complex.I)]
+  simp only [Pi.smul_apply]
+  rw [integral_smul, smul_eq_mul]
+
+theorem vectorMeasure_integral_restrict_toComplexMeasureImagZero_mul_eq_setIntegral
+    (μ : Measure X) {s : Set X} [IsFiniteMeasure (μ.restrict s)]
+    {g : X → ℂ} (hg : IntegrableOn g s μ) :
+    VectorMeasure.integral (μ.restrict s).toComplexMeasureImagZero g
+        (ContinuousLinearMap.mul ℝ ℂ) =
+      Complex.I * ∫ x in s, g x ∂μ := by
+  simpa using
+    vectorMeasure_integral_toComplexMeasureImagZero_mul_eq_integral (μ.restrict s) hg.integrable
+
+theorem vectorMeasure_integral_restrict_toComplexMeasureImagZero_sub_mul_eq_setIntegral_sub
+    (μ ν : Measure X) {s : Set X}
+    [IsFiniteMeasure (μ.restrict s)] [IsFiniteMeasure (ν.restrict s)]
+    {g : X → ℂ} (hμg : IntegrableOn g s μ) (hνg : IntegrableOn g s ν) :
+    VectorMeasure.integral
+        ((μ.restrict s).toComplexMeasureImagZero - (ν.restrict s).toComplexMeasureImagZero)
+        g (ContinuousLinearMap.mul ℝ ℂ) =
+      Complex.I * ((∫ x in s, g x ∂μ) - ∫ x in s, g x ∂ν) := by
+  let μc : VectorMeasure X ℂ := (μ.restrict s).toComplexMeasureImagZero
+  let νc : VectorMeasure X ℂ := (ν.restrict s).toComplexMeasureImagZero
+  let ξ : VectorMeasure X ℂ := μc - νc
+  have hμc_var_le : μc.variation ≤ μ.restrict s := by
+    simpa [μc] using Measure.toComplexMeasureImagZero_variation_le (μ.restrict s)
+  have hνc_var_le : νc.variation ≤ ν.restrict s := by
+    simpa [νc] using Measure.toComplexMeasureImagZero_variation_le (ν.restrict s)
+  have hμc_g : Integrable g μc.variation := hμg.integrable.mono_measure hμc_var_le
+  have hνc_g : Integrable g νc.variation := hνg.integrable.mono_measure hνc_var_le
+  have hsum_g : Integrable g (μc.variation + νc.variation) := hμc_g.add_measure hνc_g
+  have hξ_var_le : ξ.variation ≤ μc.variation + νc.variation := by
+    simpa [ξ] using VectorMeasure.variation_sub_le (μ := μc) (ν := νc)
+  have hξ_g : Integrable g ξ.variation := hsum_g.mono_measure hξ_var_le
+  have hdomξ := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation ξ
+  have hdomξ_sum : DominatedFinMeasAdditive (μc.variation + νc.variation)
+      (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) 1 :=
+    DominatedFinMeasAdditive.of_measure_le hξ_var_le hdomξ zero_le_one
+  have hdomμ := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μc
+  have hdomν := dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation νc
+  have hdom_sub :=
+    DominatedFinMeasAdditive.sub_measure μc.variation νc.variation hdomμ hdomν
+  have hT_eq : ∀ t : Set X, MeasurableSet t →
+      (μc.variation + νc.variation) t < (∞ : ℝ≥0∞) →
+        cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ) t =
+          (cbmApplyMeasure μc (ContinuousLinearMap.mul ℝ ℂ) -
+            cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) t := by
+    intro t ht _hfin
+    ext z
+    simp [ξ, cbmApplyMeasure_apply, sub_eq_add_neg, mul_add]
+  change VectorMeasure.integral ξ g (ContinuousLinearMap.mul ℝ ℂ) =
+    Complex.I * ((∫ x in s, g x ∂μ) - ∫ x in s, g x ∂ν)
+  rw [← setToFun_mul_complex_variation_eq_integral ξ hξ_g]
+  have hμrhs : (∫ x in s, g x ∂μ) =
+      Complex.I⁻¹ * VectorMeasure.integral μc g (ContinuousLinearMap.mul ℝ ℂ) := by
+    rw [vectorMeasure_integral_restrict_toComplexMeasureImagZero_mul_eq_setIntegral μ hμg]
+    rw [← mul_assoc, inv_mul_cancel₀ Complex.I_ne_zero, one_mul]
+  have hνrhs : (∫ x in s, g x ∂ν) =
+      Complex.I⁻¹ * VectorMeasure.integral νc g (ContinuousLinearMap.mul ℝ ℂ) := by
+    rw [vectorMeasure_integral_restrict_toComplexMeasureImagZero_mul_eq_setIntegral ν hνg]
+    rw [← mul_assoc, inv_mul_cancel₀ Complex.I_ne_zero, one_mul]
+  rw [hμrhs, hνrhs, ← mul_sub, ← mul_assoc, mul_inv_cancel₀ Complex.I_ne_zero, one_mul]
+  change setToFun ξ.variation (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) hdomξ g =
+    VectorMeasure.integral μc g (ContinuousLinearMap.mul ℝ ℂ) -
+      VectorMeasure.integral νc g (ContinuousLinearMap.mul ℝ ℂ)
+  rw [← setToFun_mul_complex_variation_eq_integral μc hμc_g]
+  rw [← setToFun_mul_complex_variation_eq_integral νc hνc_g]
+  calc
+    setToFun ξ.variation (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) hdomξ g =
+        setToFun (μc.variation + νc.variation)
+          (cbmApplyMeasure ξ (ContinuousLinearMap.mul ℝ ℂ)) hdomξ_sum g := by
+          exact (setToFun_congr_measure_of_integrable 1 ENNReal.one_ne_top
+            (by simpa [one_smul] using hξ_var_le) hdomξ_sum hdomξ g hsum_g).symm
+    _ = setToFun (μc.variation + νc.variation)
+          (cbmApplyMeasure μc (ContinuousLinearMap.mul ℝ ℂ) -
+            cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) hdom_sub g := by
+          exact setToFun_congr_left' hdomξ_sum hdom_sub hT_eq g
+    _ = setToFun μc.variation (cbmApplyMeasure μc (ContinuousLinearMap.mul ℝ ℂ)) hdomμ g -
+          setToFun νc.variation (cbmApplyMeasure νc (ContinuousLinearMap.mul ℝ ℂ)) hdomν g := by
+          exact setToFun_sub_measure hdomμ hdomν hμc_g hνc_g
+
 theorem vectorMeasure_restrict_variation_le (μ : VectorMeasure X ℂ) {s : Set X}
     (hs : MeasurableSet s) : (μ.restrict s).variation ≤ μ.variation := by
   refine variation_le_of_forall_enorm_le fun E hE => ?_
@@ -442,16 +717,6 @@ theorem continuous_setToFun_indicator {m : Measure X} {T : Set X → ℂ →L[�
     exact (setToFun_congr_ae hT (coeFn_indicatorL1 hs f)).symm
   rw [heq]
   exact (continuous_setToFun hT).comp (lipschitzWith_indicatorL1 hs).continuous
-
-theorem vectorMeasure_integral_mul_complex_add (μ : VectorMeasure X ℂ) {f g : X → ℂ}
-    (hf : Integrable f μ.variation) (hg : Integrable g μ.variation) :
-    VectorMeasure.integral μ (f + g) (ContinuousLinearMap.mul ℝ ℂ) =
-      VectorMeasure.integral μ f (ContinuousLinearMap.mul ℝ ℂ) +
-        VectorMeasure.integral μ g (ContinuousLinearMap.mul ℝ ℂ) := by
-  rw [← setToFun_mul_complex_variation_eq_integral μ hf,
-    ← setToFun_mul_complex_variation_eq_integral μ hg,
-    ← setToFun_mul_complex_variation_eq_integral μ (hf.add hg)]
-  exact setToFun_add (dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ) hf hg
 
 theorem vectorMeasure_integral_indicator_eq_restrict (μ : VectorMeasure X ℂ)
     [IsFiniteMeasure μ.variation] {s : Set X} (hs : MeasurableSet s) {g : X → ℂ}

--- a/PrimeNumberTheoremAnd/StieltjesFubini.lean
+++ b/PrimeNumberTheoremAnd/StieltjesFubini.lean
@@ -1,0 +1,155 @@
+import Architect
+import Mathlib.Analysis.Convolution
+import Mathlib.Analysis.Fourier.RiemannLebesgueLemma
+import Mathlib.Analysis.Normed.Group.Tannery
+import Mathlib.Analysis.SumIntegralComparisons
+import Mathlib.NumberTheory.Chebyshev
+import Mathlib.NumberTheory.LSeries.PrimesInAP
+import Mathlib.NumberTheory.MulChar.Lemmas
+import Mathlib.Topology.EMetricSpace.BoundedVariation
+import PrimeNumberTheoremAnd.Fourier
+import PrimeNumberTheoremAnd.Mathlib.Analysis.Asymptotics.Asymptotics
+import PrimeNumberTheoremAnd.SmoothExistence
+
+open MeasureTheory Set Filter Complex ContinuousLinearMap
+
+lemma p_sub_p (p : StieltjesFunction ℝ) {a b : ℝ} (hab : a ≤ b) :
+    (p b - p a : ℂ) = ∫ _x in Ioc a b, (1 : ℂ) ∂p.measure := by
+  have H1 : ∫ _x in Ioc a b, (1 : ℂ) ∂p.measure = (p.measure (Ioc a b)).toReal := by
+    rw [integral_const]
+    simp [measureReal_def]
+  have h_meas : p.measure (Ioc a b) = ENNReal.ofReal (p b - p a) := p.measure_Ioc a b
+  rw [H1, h_meas, ENNReal.toReal_ofReal (sub_nonneg.mpr (p.mono hab))]
+  push_cast
+  rfl
+
+lemma FubiniIntegrabilityGap (p : StieltjesFunction ℝ) (a b : ℝ) (f : ℝ → ℂ)
+    (hf : Continuous f) (hab : a ≤ b) (F : ℝ → ℝ → ℂ)
+    (hF : F = fun x t ↦ if x ∈ Ioc a t then f t else 0) :
+    Integrable (Function.uncurry fun t x ↦ F x t)
+      ((volume.restrict (Ioc a b)).prod (p.measure.restrict (Ioc a b))) := by
+  let S : Set (ℝ × ℝ) := { tx | a < tx.2 ∧ tx.2 ≤ tx.1 }
+  have hS_meas : MeasurableSet S := by
+    have h1 : MeasurableSet { tx : ℝ × ℝ | a < tx.2 } :=
+      measurableSet_lt measurable_const measurable_snd
+    have h2 : MeasurableSet { tx : ℝ × ℝ | tx.2 ≤ tx.1 } :=
+      measurableSet_le measurable_snd measurable_fst
+    exact h1.inter h2
+  have hF_eq : (Function.uncurry fun t x ↦ F x t) = S.indicator (fun tx ↦ f tx.1) := by
+    ext tx
+    simp only [Function.uncurry, hF, S, Set.indicator_apply, Set.mem_setOf_eq, Set.mem_Ioc]
+  have h_cont : Continuous (fun tx : ℝ × ℝ ↦ f tx.1) := hf.comp continuous_fst
+  have hF_meas : StronglyMeasurable (Function.uncurry fun t x ↦ F x t) := by
+    rw [hF_eq]
+    exact (h_cont.stronglyMeasurable.indicator hS_meas)
+  have h_comp : IsCompact (Icc a b) := isCompact_Icc
+  have h_cont_norm : ContinuousOn (fun x ↦ ‖f x‖) (Icc a b) := hf.continuousOn.norm
+  obtain ⟨C, hC⟩ : ∃ C, ∀ x ∈ Icc a b, ‖f x‖ ≤ C := by
+    have : BddAbove ((fun x ↦ ‖f x‖) '' Icc a b) :=
+      h_comp.bddAbove_image h_cont_norm
+    rcases this with ⟨C, hC⟩
+    use C
+    intro x hx
+    exact hC (Set.mem_image_of_mem _ hx)
+  haveI h_fin_p : IsFiniteMeasure (p.measure.restrict (Ioc a b)) := ⟨by simp [p.measure_Ioc]⟩
+  haveI h_fin_vol : IsFiniteMeasure (volume.restrict (Ioc a b)) := ⟨by simp⟩
+  have h_int_const :
+      Integrable (fun _ : ℝ × ℝ ↦ (C : ℂ))
+        ((volume.restrict (Ioc a b)).prod (p.measure.restrict (Ioc a b))) := by
+    apply integrable_const
+  apply h_int_const.mono hF_meas.aestronglyMeasurable
+  have h_prod_restrict :
+      (volume.restrict (Ioc a b)).prod (p.measure.restrict (Ioc a b)) =
+        (volume.prod p.measure).restrict (Ioc a b ×ˢ Ioc a b) :=
+    Measure.prod_restrict (Ioc a b) (Ioc a b)
+  rw [h_prod_restrict]
+  have h_meas_prod : MeasurableSet (Ioc a b ×ˢ Ioc a b) :=
+    measurableSet_Ioc.prod measurableSet_Ioc
+  filter_upwards [ae_restrict_mem h_meas_prod] with tx htx
+  rw [hF_eq]
+  simp only [Set.indicator_apply]
+  have h_norm_C : ‖(C : ℂ)‖ = C := by
+    have hC_pos : 0 ≤ C := (norm_nonneg (f a)).trans (hC a (left_mem_Icc.mpr hab))
+    have h1 : ‖(C : ℂ)‖ = ‖C‖ := Complex.norm_real C
+    have h2 : ‖C‖ = C := Real.norm_of_nonneg hC_pos
+    rw [h1, h2]
+  rw [h_norm_C]
+  split_ifs with h_S
+  · exact hC tx.1 ⟨htx.1.1.le, htx.1.2⟩
+  · simp only [norm_zero]
+    exact (norm_nonneg (f a)).trans (hC a (left_mem_Icc.mpr hab))
+
+theorem integral_stieltjes_fubini_swap (p : StieltjesFunction ℝ) (a b : ℝ) (hab : a ≤ b)
+    (f : ℝ → ℂ) (hf : Continuous f) :
+    ∫ t in a..b, (p t - p a : ℂ) * f t =
+      ∫ x in Ioc a b, (∫ t in x..b, f t) ∂p.measure := by
+  rw [intervalIntegral.integral_of_le hab]
+  have h_inner : ∀ t ∈ Ioc a b,
+      (p t - p a : ℂ) * f t = ∫ x in Ioc a t, f t ∂p.measure := by
+    intro t ht
+    have H_smul :
+        (∫ x in Ioc a t, (1 : ℂ) ∂p.measure) * f t =
+          f t • (∫ x in Ioc a t, (1 : ℂ) ∂p.measure) := mul_comm _ _
+    rw [p_sub_p p ht.1.le, H_smul, ← integral_smul]
+    simp
+  have H :
+      ∫ t in Ioc a b, (p t - p a : ℂ) * f t =
+        ∫ t in Ioc a b, ∫ x in Ioc a t, f t ∂p.measure ∂volume := by
+    apply integral_congr_ae
+    filter_upwards [ae_restrict_mem measurableSet_Ioc] with t ht
+    exact h_inner t ht
+  let F : ℝ → ℝ → ℂ := fun x t ↦ if x ∈ Ioc a t then f t else 0
+  have H_F_LHS : ∀ t ∈ Ioc a b,
+      ∫ x in Ioc a t, f t ∂p.measure = ∫ x in Ioc a b, F x t ∂p.measure := by
+    intro t ht
+    have : (fun x ↦ F x t) = (Ioc a t).indicator (fun _ ↦ f t) := by
+      ext x
+      simp only [F, indicator_apply]
+    rw [this, integral_indicator measurableSet_Ioc]
+    have h_inter : Ioc a t ∩ Ioc a b = Ioc a t :=
+      inter_eq_left.mpr (Ioc_subset_Ioc le_rfl ht.2)
+    rw [Measure.restrict_restrict measurableSet_Ioc, h_inter]
+  have H_F_RHS : ∀ x ∈ Ioc a b,
+      ∫ t in Ioc a b, F x t ∂volume = ∫ t in Ioc x b, f t ∂volume := by
+    intro x hx
+    have : ∫ t in Ioc a b, F x t ∂volume = ∫ t in Icc x b, f t ∂volume := by
+      have : (fun t ↦ F x t) = (Ici x).indicator (fun t ↦ f t) := by
+        ext t
+        have heq : x ∈ Ioc a t ↔ t ∈ Ici x := by
+          simp only [mem_Ioc, mem_Ici]
+          exact and_iff_right hx.1
+        simp only [F, indicator_apply, heq]
+      rw [this, integral_indicator measurableSet_Ici]
+      have h_inter : Ici x ∩ Ioc a b = Icc x b := by
+        ext t
+        simp only [mem_inter_iff, mem_Icc, mem_Ioc, mem_Ici]
+        constructor
+        · rintro ⟨hxt, ⟨hat, htb⟩⟩
+          exact ⟨hxt, htb⟩
+        · rintro ⟨hxt, htb⟩
+          exact ⟨hxt, ⟨hx.1.trans_le hxt, htb⟩⟩
+      rw [Measure.restrict_restrict measurableSet_Ici, h_inter]
+    rw [this]
+    exact integral_Icc_eq_integral_Ioc
+  have H_swap :
+      ∫ t in Ioc a b, ∫ x in Ioc a b, F x t ∂p.measure ∂volume =
+        ∫ x in Ioc a b, ∫ t in Ioc a b, F x t ∂volume ∂p.measure := by
+    apply integral_integral_swap
+    exact FubiniIntegrabilityGap p a b f hf hab F rfl
+  have H_LHS :
+      ∫ t in Ioc a b, (p t - p a : ℂ) * f t =
+        ∫ t in Ioc a b, ∫ x in Ioc a b, F x t ∂p.measure ∂volume := by
+    rw [H]
+    apply integral_congr_ae
+    filter_upwards [ae_restrict_mem measurableSet_Ioc] with t ht
+    exact H_F_LHS t ht
+  have H_RHS :
+      ∫ x in Ioc a b, ∫ t in Ioc x b, f t ∂volume ∂p.measure =
+        ∫ x in Ioc a b, ∫ t in Ioc a b, F x t ∂volume ∂p.measure := by
+    apply integral_congr_ae
+    filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
+    exact (H_F_RHS x hx).symm
+  rw [H_LHS, H_swap, ← H_RHS]
+  apply integral_congr_ae
+  filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
+  exact (intervalIntegral.integral_of_le hx.2).symm

--- a/PrimeNumberTheoremAnd/StieltjesFubini.lean
+++ b/PrimeNumberTheoremAnd/StieltjesFubini.lean
@@ -12,6 +12,7 @@ import PrimeNumberTheoremAnd.Mathlib.Analysis.Asymptotics.Asymptotics
 import PrimeNumberTheoremAnd.SmoothExistence
 
 open MeasureTheory Set Filter Complex ContinuousLinearMap
+open scoped ENNReal
 
 lemma p_sub_p (p : StieltjesFunction ℝ) {a b : ℝ} (hab : a ≤ b) :
     (p b - p a : ℂ) = ∫ _x in Ioc a b, (1 : ℂ) ∂p.measure := by
@@ -153,3 +154,80 @@ theorem integral_stieltjes_fubini_swap (p : StieltjesFunction ℝ) (a b : ℝ) (
   apply integral_congr_ae
   filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
   exact (intervalIntegral.integral_of_le hx.2).symm
+
+theorem integral_stieltjes_by_parts_sub_base (p : StieltjesFunction ℝ) (a b : ℝ)
+    (hab : a ≤ b) (g g' : ℝ → ℂ) (hg : Continuous g) (hg' : Continuous g')
+    (hderiv : ∀ x ∈ Icc a b, HasDerivAt g (g' x) x) :
+    ∫ x in Ioc a b, g x ∂p.measure =
+      g b * (p b - p a : ℂ) - ∫ t in a..b, (p t - p a : ℂ) * g' t := by
+  have hswap := integral_stieltjes_fubini_swap p a b hab g' hg'
+  have hinner : ∀ x ∈ Ioc a b, ∫ t in x..b, g' t = g b - g x := by
+    intro x hx
+    refine intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hx.2 hg.continuousOn ?_ ?_
+    · intro y hy
+      exact hderiv y ⟨hx.1.le.trans hy.1.le, hy.2.le⟩
+    · exact hg'.intervalIntegrable x b
+  have hswap' :
+      ∫ t in a..b, (p t - p a : ℂ) * g' t =
+        ∫ x in Ioc a b, (g b - g x) ∂p.measure := by
+    rw [hswap]
+    apply integral_congr_ae
+    filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
+    exact hinner x hx
+  have hfinite : p.measure (Ioc a b) ≠ ∞ := by
+    simp [p.measure_Ioc]
+  have hg_int : Integrable g (p.measure.restrict (Ioc a b)) := by
+    have h_comp : IsCompact (Icc a b) := isCompact_Icc
+    have h_cont_norm : ContinuousOn (fun x => ‖g x‖) (Icc a b) := hg.continuousOn.norm
+    obtain ⟨C, hC⟩ : ∃ C, ∀ x ∈ Icc a b, ‖g x‖ ≤ C := by
+      have : BddAbove ((fun x => ‖g x‖) '' Icc a b) :=
+        h_comp.bddAbove_image h_cont_norm
+      rcases this with ⟨C, hC⟩
+      exact ⟨C, fun x hx => hC (mem_image_of_mem _ hx)⟩
+    exact Measure.integrableOn_of_bounded hfinite hg.aestronglyMeasurable
+      (M := C) (by
+        filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
+        exact hC x ⟨hx.1.le, hx.2⟩)
+  haveI : IsFiniteMeasure (p.measure.restrict (Ioc a b)) := ⟨by simp⟩
+  have hconst_int : Integrable (fun _ : ℝ => g b) (p.measure.restrict (Ioc a b)) :=
+    integrable_const _
+  have hsplit :
+      ∫ x in Ioc a b, (g b - g x) ∂p.measure =
+        g b * (p b - p a : ℂ) - ∫ x in Ioc a b, g x ∂p.measure := by
+    rw [integral_sub hconst_int hg_int, integral_const]
+    simp [measureReal_def, p.measure_Ioc, ENNReal.toReal_ofReal,
+      sub_nonneg.mpr (p.mono hab), mul_comm]
+  rw [hswap', hsplit]
+  ring
+
+theorem integral_signed_stieltjes_by_parts_sub_base (p q : StieltjesFunction ℝ) (a b : ℝ)
+    (hab : a ≤ b) (g g' : ℝ → ℂ) (hg : Continuous g) (hg' : Continuous g')
+    (hderiv : ∀ x ∈ Icc a b, HasDerivAt g (g' x) x)
+    (hp_int : IntervalIntegrable (fun t => (p t - p a : ℂ) * g' t) volume a b)
+    (hq_int : IntervalIntegrable (fun t => (q t - q a : ℂ) * g' t) volume a b) :
+    (∫ x in Ioc a b, g x ∂p.measure) - (∫ x in Ioc a b, g x ∂q.measure) =
+      g b * ((p b - p a : ℂ) - (q b - q a : ℂ)) -
+        ∫ t in a..b, ((p t - p a : ℂ) - (q t - q a : ℂ)) * g' t := by
+  have hp := integral_stieltjes_by_parts_sub_base p a b hab g g' hg hg' hderiv
+  have hq := integral_stieltjes_by_parts_sub_base q a b hab g g' hg hg' hderiv
+  rw [hp, hq]
+  let A := g b * (p b - p a : ℂ)
+  let B := g b * (q b - q a : ℂ)
+  let Ip := ∫ t in a..b, (p t - p a : ℂ) * g' t
+  let Iq := ∫ t in a..b, (q t - q a : ℂ) * g' t
+  have hI :
+      Ip - Iq =
+        ∫ t in a..b, ((p t - p a : ℂ) - (q t - q a : ℂ)) * g' t := by
+    dsimp [Ip, Iq]
+    rw [← intervalIntegral.integral_sub]
+    · apply intervalIntegral.integral_congr
+      intro t ht
+      ring
+    · exact hp_int
+    · exact hq_int
+  change (A - Ip) - (B - Iq) =
+    g b * ((p b - p a : ℂ) - (q b - q a : ℂ)) -
+      ∫ t in a..b, ((p t - p a : ℂ) - (q t - q a : ℂ)) * g' t
+  rw [show (A - Ip) - (B - Iq) = (A - B) - (Ip - Iq) by ring, hI]
+  dsimp [A, B]
+  ring

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -12,6 +12,7 @@ import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.Integral
 import PrimeNumberTheoremAnd.Mathlib.Analysis.Asymptotics.Asymptotics
 import PrimeNumberTheoremAnd.Fourier
 import PrimeNumberTheoremAnd.SmoothExistence
+import PrimeNumberTheoremAnd.StieltjesFubini
 import Mathlib.Analysis.Convolution
 
 set_option lang.lemmaCmd true
@@ -436,6 +437,209 @@ theorem tendsto_vectorMeasure_integral_Ioc_fourierChar
   rw [← setToFun_mul_complex_variation_eq_integral hvar.vectorMeasure hf_int]
   exact hset.congr' (Eventually.of_forall fun n =>
     setToFun_mul_complex_variation_eq_integral hvar.vectorMeasure (hfs_int n))
+
+/-- The Fourier transform written through the bounded-continuous kernel `e u`. -/
+theorem fourierIntegral_eq_integral_e (g : ℝ → ℂ) (u : ℝ) :
+    𝓕 g u = ∫ v, (e u v) * g v := by
+  rw [Real.fourier_eq]
+  simp only [e_apply, RCLike.inner_apply', conj_trivial]
+  congr 1
+  ext v
+  rw [Circle.smul_def, neg_mul, smul_eq_mul]
+
+/-- Interval integrability of `fun t => (p t - p c : ℂ)` for a Stieltjes function `p`. -/
+theorem intervalIntegrable_stieltjes_sub_const (p : StieltjesFunction ℝ) (a b c : ℝ) :
+    IntervalIntegrable (fun t => (p t - p c : ℂ)) volume a b := by
+  have hmono : Monotone (fun t => p t - p c) := fun x y hxy => by
+    simpa using sub_le_sub_right (p.mono hxy) (p c)
+  have hreal : IntervalIntegrable (fun t => p t - p c) volume a b :=
+    hmono.intervalIntegrable
+  rw [intervalIntegrable_iff] at hreal ⊢
+  have := Complex.ofRealCLM.integrable_comp hreal
+  simpa [Function.comp] using this
+
+/-- Master integration-by-parts limit: for a real integrable function of bounded variation `g`
+with Stieltjes decomposition `g.rightLim = p - q`, the windowed Stieltjes integral difference of
+`e u` converges to `2π u i · 𝓕 (g.rightLim) u`. -/
+theorem tendsto_setIntegral_stieltjes_sub_ibp {g : ℝ → ℝ}
+    (hg : BoundedVariationOn g Set.univ) (hgi : Integrable g volume) (u : ℝ)
+    {p q : StieltjesFunction ℝ} (hpq : ∀ x : ℝ, Function.rightLim g x = p x - q x) :
+    Tendsto
+      (fun n : ℕ => (∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂p.measure) -
+        ∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂q.measure)
+      atTop
+      (𝓝 ((((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) *
+        𝓕 (fun x => ((Function.rightLim g x : ℝ) : ℂ)) u)) := by
+  classical
+  set G : ℝ → ℂ := fun x => ((Function.rightLim g x : ℝ) : ℂ) with hG
+  have hrl_bv : BoundedVariationOn (Function.rightLim g) Set.univ := hg.rightLim
+  have hrl_int : Integrable (Function.rightLim g) volume := hgi.congr hg.ae_eq_rightLim_real
+  have hG_int : Integrable G volume := by
+    simpa [hG, Function.comp] using (Complex.ofRealCLM.integrable_comp hrl_int)
+  have hrl_top : Tendsto (Function.rightLim g) atTop (𝓝 0) :=
+    hrl_bv.tendsto_atTop_zero_of_integrable hrl_int
+  have hrl_bot : Tendsto (Function.rightLim g) atBot (𝓝 0) :=
+    hrl_bv.tendsto_atBot_zero_of_integrable hrl_int
+  set g' : ℝ → ℂ := fun x => -2 * π * u * I * e u x with hg'def
+  have hg'_cont : Continuous g' := by rw [hg'def]; continuity
+  have he1 : ∀ x : ℝ, ‖(e u x : ℂ)‖ ≤ 1 := by
+    intro x
+    calc ‖(e u x : ℂ)‖ ≤ ‖e u‖ := (e u).norm_coe_le_norm x
+      _ ≤ 1 := (BoundedContinuousFunction.norm_le zero_le_one).2 (fun y => by simp [e_apply])
+  have hg'_bdd : ∀ x : ℝ, ‖g' x‖ ≤ 2 * π * |u| := by
+    intro x
+    have hconst : ‖((-2 * π * u : ℝ) : ℂ) * I‖ = 2 * π * |u| := by
+      rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real, Real.norm_eq_abs]
+      rw [abs_mul, abs_mul, abs_neg]
+      simp [abs_of_pos Real.pi_pos]
+    have hrw : g' x = (((-2 * π * u : ℝ) : ℂ) * I) * e u x := by
+      rw [hg'def]; push_cast; ring
+    rw [hrw, norm_mul, hconst]
+    calc 2 * π * |u| * ‖(e u x : ℂ)‖ ≤ 2 * π * |u| * 1 := by
+          apply mul_le_mul_of_nonneg_left (he1 x)
+          positivity
+      _ = 2 * π * |u| := by ring
+  have hGg'_int : Integrable (fun t => G t * g' t) volume :=
+    hG_int.mul_bdd hg'_cont.aestronglyMeasurable (ae_of_all _ hg'_bdd)
+  have hibp_n : ∀ n : ℕ,
+      (∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂p.measure) -
+        ∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂q.measure =
+      e u (n : ℝ) * ((p (n : ℝ) - p (-(n : ℝ)) : ℂ) - (q (n : ℝ) - q (-(n : ℝ)) : ℂ)) -
+        ∫ t in (-(n : ℝ))..(n : ℝ),
+          ((p t - p (-(n : ℝ)) : ℂ) - (q t - q (-(n : ℝ)) : ℂ)) * g' t := by
+    intro n
+    have hab : (-(n : ℝ)) ≤ (n : ℝ) := by
+      have : (0:ℝ) ≤ (n : ℝ) := by positivity
+      linarith
+    have hp_int := intervalIntegrable_stieltjes_sub_const p (-(n:ℝ)) (n:ℝ) (-(n:ℝ))
+    have hq_int := intervalIntegrable_stieltjes_sub_const q (-(n:ℝ)) (n:ℝ) (-(n:ℝ))
+    have hp_int' : IntervalIntegrable (fun t => (p t - p (-(n:ℝ)) : ℂ) * g' t) volume
+        (-(n:ℝ)) (n:ℝ) := hp_int.mul_continuousOn hg'_cont.continuousOn
+    have hq_int' : IntervalIntegrable (fun t => (q t - q (-(n:ℝ)) : ℂ) * g' t) volume
+        (-(n:ℝ)) (n:ℝ) := hq_int.mul_continuousOn hg'_cont.continuousOn
+    exact integral_signed_stieltjes_by_parts_sub_base p q (-(n:ℝ)) (n:ℝ) hab (e u) g'
+      (e u).continuous hg'_cont (fun x _ => hasDerivAt_e) hp_int' hq_int'
+  have hclean : ∀ n : ℕ,
+      (∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂p.measure) -
+        ∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂q.measure =
+      e u (n : ℝ) * G (n : ℝ) - G (-(n : ℝ)) * e u (-(n : ℝ)) -
+        ∫ t in (-(n : ℝ))..(n : ℝ), G t * g' t := by
+    intro n
+    rw [hibp_n n]
+    have hGdiff : ∀ x : ℝ, (p x - p (-(n:ℝ)) : ℂ) - (q x - q (-(n:ℝ)) : ℂ)
+        = G x - G (-(n:ℝ)) := by
+      intro x
+      simp only [hG]
+      rw [hpq x, hpq (-(n:ℝ))]
+      push_cast
+      ring
+    have hsplit : ∫ t in (-(n : ℝ))..(n : ℝ),
+          ((p t - p (-(n : ℝ)) : ℂ) - (q t - q (-(n : ℝ)) : ℂ)) * g' t =
+        (∫ t in (-(n : ℝ))..(n : ℝ), G t * g' t) -
+          G (-(n:ℝ)) * (e u (n:ℝ) - e u (-(n:ℝ))) := by
+      have hftc : ∫ t in (-(n : ℝ))..(n : ℝ), g' t = e u (n:ℝ) - e u (-(n:ℝ)) := by
+        have := intervalIntegral.integral_eq_sub_of_hasDerivAt
+          (f := e u) (f' := g') (a := -(n:ℝ)) (b := (n:ℝ))
+          (fun x _ => hasDerivAt_e) (hg'_cont.intervalIntegrable _ _)
+        simpa using this
+      rw [← hftc, ← intervalIntegral.integral_const_mul (G (-(n:ℝ))) g']
+      rw [← intervalIntegral.integral_sub]
+      · apply intervalIntegral.integral_congr
+        intro t _
+        simp only []
+        rw [hGdiff t]
+        ring
+      · exact hGg'_int.intervalIntegrable
+      · exact (continuous_const.mul hg'_cont).intervalIntegrable _ _
+    rw [hsplit, hGdiff (n:ℝ)]
+    ring
+  rw [tendsto_congr hclean]
+  have hint_id : (∫ t, G t * g' t) = (-((2 * Real.pi * u : ℝ) : ℂ) * I) * 𝓕 G u := by
+    have hrw2 : ∀ t : ℝ, G t * g' t = (-((2 * Real.pi * u : ℝ) : ℂ) * I) * (e u t * G t) := by
+      intro t
+      rw [hg'def]
+      push_cast
+      ring
+    calc (∫ t, G t * g' t) = ∫ t, (-((2 * Real.pi * u : ℝ) : ℂ) * I) * (e u t * G t) := by
+          exact integral_congr_ae (ae_of_all _ hrw2)
+      _ = (-((2 * Real.pi * u : ℝ) : ℂ) * I) * ∫ t, e u t * G t := by
+          rw [integral_const_mul]
+      _ = (-((2 * Real.pi * u : ℝ) : ℂ) * I) * 𝓕 G u := by
+          rw [fourierIntegral_eq_integral_e G u]
+  have hn_top : Tendsto (fun n : ℕ => (n : ℝ)) atTop atTop := tendsto_natCast_atTop_atTop
+  have hn_bot : Tendsto (fun n : ℕ => (-(n : ℝ))) atTop atBot :=
+    tendsto_neg_atBot_iff.mpr hn_top
+  have hlim1 : Tendsto (fun n : ℕ => e u (n : ℝ) * G (n : ℝ)) atTop (𝓝 0) := by
+    have hGtop : Tendsto (fun n : ℕ => G (n : ℝ)) atTop (𝓝 0) := by
+      have : Tendsto G atTop (𝓝 ((0:ℝ):ℂ)) :=
+        (Complex.continuous_ofReal.tendsto 0).comp hrl_top
+      simpa [hG] using this.comp hn_top
+    have hbound : Tendsto (fun n : ℕ => ‖G (n : ℝ)‖) atTop (𝓝 0) :=
+      tendsto_zero_iff_norm_tendsto_zero.mp hGtop
+    refine squeeze_zero_norm (fun n => ?_) hbound
+    rw [norm_mul]
+    exact mul_le_of_le_one_left (norm_nonneg _) (he1 _)
+  have hlim2 : Tendsto (fun n : ℕ => G (-(n : ℝ)) * e u (-(n : ℝ))) atTop (𝓝 0) := by
+    have hGbot : Tendsto (fun n : ℕ => G (-(n : ℝ))) atTop (𝓝 0) := by
+      have : Tendsto G atBot (𝓝 ((0:ℝ):ℂ)) :=
+        (Complex.continuous_ofReal.tendsto 0).comp hrl_bot
+      simpa [hG] using this.comp hn_bot
+    have hbound : Tendsto (fun n : ℕ => ‖G (-(n : ℝ))‖) atTop (𝓝 0) :=
+      tendsto_zero_iff_norm_tendsto_zero.mp hGbot
+    refine squeeze_zero_norm (fun n => ?_) hbound
+    rw [norm_mul]
+    exact mul_le_of_le_one_right (norm_nonneg _) (he1 _)
+  have hlim3 : Tendsto (fun n : ℕ => ∫ t in (-(n : ℝ))..(n : ℝ), G t * g' t) atTop
+      (𝓝 (∫ t, G t * g' t)) :=
+    intervalIntegral_tendsto_integral hGg'_int hn_bot hn_top
+  have hsum := (hlim1.sub hlim2).sub hlim3
+  simp only [sub_zero, zero_sub] at hsum
+  rw [hint_id] at hsum
+  convert hsum using 2
+  ring
+
+/-- General convergence of the windowed indicator integral against an arbitrary
+finite-variation complex vector measure. -/
+theorem tendsto_vectorMeasure_integral_Ioc_e
+    (μ : MeasureTheory.VectorMeasure ℝ ℂ) [IsFiniteMeasure μ.variation] (u : ℝ) :
+    Tendsto
+      (fun n : ℕ => VectorMeasure.integral μ
+        ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ))
+        (ContinuousLinearMap.mul ℝ ℂ))
+      atTop
+      (𝓝 (VectorMeasure.integral μ (e u) (ContinuousLinearMap.mul ℝ ℂ))) := by
+  set μv : Measure ℝ := μ.variation
+  let T : Set ℝ → ℂ →L[ℝ] ℂ := cbmApplyMeasure μ (ContinuousLinearMap.mul ℝ ℂ)
+  let hT : DominatedFinMeasAdditive μv T 1 :=
+    dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation μ
+  have hf_int : Integrable (e u : ℝ → ℂ) μv :=
+    BoundedContinuousFunction.integrable μv (e u)
+  have hfs_int : ∀ n : ℕ,
+      Integrable ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ)) μv := fun n =>
+    hf_int.indicator measurableSet_Ioc
+  have hcover : AECover μv atTop (fun n : ℕ => Set.Ioc (-(n : ℝ)) (n : ℝ)) :=
+    aecover_Ioc
+      (tendsto_neg_atBot_iff.mpr
+        (tendsto_natCast_atTop_atTop : Tendsto (fun n : ℕ => (n : ℝ)) atTop atTop))
+      (tendsto_natCast_atTop_atTop : Tendsto (fun n : ℕ => (n : ℝ)) atTop atTop)
+  have hset :
+      Tendsto
+        (fun n : ℕ => setToFun μv T hT
+          ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ)))
+        atTop
+        (𝓝 (setToFun μv T hT (e u : ℝ → ℂ))) := by
+    refine tendsto_setToFun_of_dominated_convergence hT (fun _ : ℝ => ‖e u‖) ?_ ?_ ?_ ?_
+    · intro n
+      exact ((e u).continuous.aestronglyMeasurable).indicator measurableSet_Ioc
+    · exact integrable_const _
+    · intro n
+      refine ae_of_all μv fun x => ?_
+      exact (norm_indicator_le_norm_self (e u : ℝ → ℂ) x).trans
+        (BoundedContinuousFunction.norm_coe_le_norm (e u) x)
+    · exact hcover.ae_tendsto_indicator (e u : ℝ → ℂ)
+  rw [← setToFun_mul_complex_variation_eq_integral μ hf_int]
+  exact hset.congr' (Eventually.of_forall fun n =>
+    setToFun_mul_complex_variation_eq_integral μ (hfs_int n))
 
 def vectorMeasure_integral_fourierChar_eq_IBP (ψ : ℝ → ℂ) (hψ : Integrable ψ)
     (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) : Prop :=

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -351,6 +351,42 @@ def vectorMeasure_integral_eq_re_add_I_im (ψ : ℝ → ℂ) (_hψ : Integrable 
         ((0 : SignedMeasure ℝ).toComplexMeasure (ComplexMeasure.im hvar.vectorMeasure))
         (e u) (ContinuousLinearMap.mul ℝ ℂ)
 
+theorem vectorMeasure_integral_eq_re_add_I_im_proof (ψ : ℝ → ℂ) (hψ : Integrable ψ)
+    (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) :
+    vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u := by
+  have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) := by
+    have hvariation :
+        (hvar.vectorMeasure).variation Set.univ ≤ eVariationOn ψ Set.univ :=
+      hvar.vectorMeasure_variation_univ_le_eVariationOn
+    exact ne_top_of_le_ne_top hvar hvariation
+  letI : IsFiniteMeasure (hvar.vectorMeasure).variation :=
+    IsFiniteMeasure.mk (lt_top_iff_ne_top.mpr hμ_ne_top)
+  have hg : Integrable (e u : ℝ → ℂ) (hvar.vectorMeasure).variation :=
+    BoundedContinuousFunction.integrable (hvar.vectorMeasure).variation (e u)
+  exact vectorMeasure_integral_eq_re_add_I_im_of_integrable hvar.vectorMeasure hg
+
+theorem vectorMeasure_integral_Ioc_fourierChar_eq_re_add_I_im
+    (ψ : ℝ → ℂ) (hvar : BoundedVariationOn ψ Set.univ) (u a b : ℝ) :
+    VectorMeasure.integral hvar.vectorMeasure ((Set.Ioc a b).indicator (e u : ℝ → ℂ))
+        (ContinuousLinearMap.mul ℝ ℂ) =
+      VectorMeasure.integral
+          ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0)
+          ((Set.Ioc a b).indicator (e u : ℝ → ℂ)) (ContinuousLinearMap.mul ℝ ℂ) +
+        VectorMeasure.integral
+          ((0 : SignedMeasure ℝ).toComplexMeasure (ComplexMeasure.im hvar.vectorMeasure))
+          ((Set.Ioc a b).indicator (e u : ℝ → ℂ)) (ContinuousLinearMap.mul ℝ ℂ) := by
+  have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) := by
+    have hvariation :
+        (hvar.vectorMeasure).variation Set.univ ≤ eVariationOn ψ Set.univ :=
+      hvar.vectorMeasure_variation_univ_le_eVariationOn
+    exact ne_top_of_le_ne_top hvar hvariation
+  letI : IsFiniteMeasure (hvar.vectorMeasure).variation :=
+    IsFiniteMeasure.mk (lt_top_iff_ne_top.mpr hμ_ne_top)
+  have he : Integrable (e u : ℝ → ℂ) (hvar.vectorMeasure).variation :=
+    BoundedContinuousFunction.integrable (hvar.vectorMeasure).variation (e u)
+  exact vectorMeasure_integral_eq_re_add_I_im_of_integrable hvar.vectorMeasure
+    (he.indicator measurableSet_Ioc)
+
 def vectorMeasure_integral_fourierChar_eq_IBP (ψ : ℝ → ℂ) (hψ : Integrable ψ)
     (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) : Prop :=
   vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u →
@@ -401,10 +437,10 @@ and the claim then follows from the triangle inequality. -/)
   (discussion := 562)]
 theorem prelim_decay_2 (ψ : ℝ → ℂ) (hψ : Integrable ψ) (hvar : BoundedVariationOn ψ Set.univ)
     (u : ℝ) (hu : u ≠ 0)
-    (hreim : vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u)
     (hibp : vectorMeasure_integral_fourierChar_eq_IBP ψ hψ hvar u) :
     ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤ (eVariationOn ψ Set.univ).toReal / (2 * π * ‖u‖) := by
-  exact prelim_decay_2_of_vectorMeasure_fourier_identity ψ hvar u hu (hibp hreim)
+  exact prelim_decay_2_of_vectorMeasure_fourier_identity ψ hvar u hu
+    (hibp (vectorMeasure_integral_eq_re_add_I_im_proof ψ hψ hvar u))
 
 noncomputable def AbsolutelyContinuous (f : ℝ → ℂ) : Prop := (∀ᵐ x, DifferentiableAt ℝ f x) ∧
   ∀ a b : ℝ, f b - f a = ∫ t in a..b, deriv f t

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -7,6 +7,7 @@ import Mathlib.NumberTheory.LSeries.PrimesInAP
 import Mathlib.NumberTheory.MulChar.Lemmas
 import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 import Mathlib.Topology.EMetricSpace.BoundedVariation
+import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.Integral
 import PrimeNumberTheoremAnd.Mathlib.Analysis.Asymptotics.Asymptotics
 import PrimeNumberTheoremAnd.Fourier
@@ -312,25 +313,25 @@ theorem prelim_decay (ψ : ℝ → ℂ) (u : ℝ) : ‖𝓕 (ψ : ℝ → ℂ) u
   VectorFourier.norm_fourierIntegral_le_integral_norm ..
 
 lemma boundedVariationOn_norm_vectorMeasure_integral_fourierChar_le_eVariationOn
-    {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ)
-    (hvariation : (hvar.vectorMeasure).variation Set.univ ≤ eVariationOn ψ Set.univ)
-    (u : ℝ) :
+    {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) :
     ‖VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)‖ ≤
       (eVariationOn ψ Set.univ).toReal := by
+  have hvariation : (hvar.vectorMeasure).variation Set.univ ≤ eVariationOn ψ Set.univ :=
+    hvar.vectorMeasure_variation_univ_le_eVariationOn
   have hψ_ne_top : eVariationOn ψ Set.univ ≠ (∞ : ℝ≥0∞) := hvar
   have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) :=
     ne_top_of_le_ne_top hψ_ne_top hvariation
   letI : IsFiniteMeasure (hvar.vectorMeasure).variation :=
     IsFiniteMeasure.mk (lt_top_iff_ne_top.mpr hμ_ne_top)
-  have hbound : ∀ x, ‖(e u) x‖ ≤ (1 : ℝ) := by
-    intro x
+  have he_norm : ‖e u‖ ≤ (1 : ℝ) := (BoundedContinuousFunction.norm_le zero_le_one).2 fun x ↦ by
     simp [e_apply]
-  have hbase := VectorMeasure.norm_integral_mul_complex_le_of_norm_le hvar.vectorMeasure
-    (BoundedContinuousFunction.integrable (hvar.vectorMeasure).variation (e u)) zero_le_one
-    hbound (measure_ne_top (hvar.vectorMeasure).variation Set.univ)
+  have hbase := VectorMeasure.norm_integral_mul_complex_boundedContinuousFunction_le
+    hvar.vectorMeasure (e u)
   calc
     ‖VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)‖
-        ≤ 1 * ((hvar.vectorMeasure).variation Set.univ).toReal := hbase
+        ≤ ‖e u‖ * ((hvar.vectorMeasure).variation Set.univ).toReal := hbase
+    _ ≤ 1 * ((hvar.vectorMeasure).variation Set.univ).toReal :=
+      mul_le_mul_of_nonneg_right he_norm ENNReal.toReal_nonneg
     _ = ((hvar.vectorMeasure).variation Set.univ).toReal := one_mul _
     _ ≤ (eVariationOn ψ Set.univ).toReal := ENNReal.toReal_mono hψ_ne_top hvariation
 

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -387,6 +387,56 @@ theorem vectorMeasure_integral_Ioc_fourierChar_eq_re_add_I_im
   exact vectorMeasure_integral_eq_re_add_I_im_of_integrable hvar.vectorMeasure
     (he.indicator measurableSet_Ioc)
 
+theorem tendsto_vectorMeasure_integral_Ioc_fourierChar
+    (ψ : ℝ → ℂ) (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) :
+    Tendsto
+      (fun n : ℕ => VectorMeasure.integral hvar.vectorMeasure
+        ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ))
+        (ContinuousLinearMap.mul ℝ ℂ))
+      atTop
+      (𝓝 (VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ))) := by
+  have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) := by
+    have hvariation :
+        (hvar.vectorMeasure).variation Set.univ ≤ eVariationOn ψ Set.univ :=
+      hvar.vectorMeasure_variation_univ_le_eVariationOn
+    exact ne_top_of_le_ne_top hvar hvariation
+  letI : IsFiniteMeasure (hvar.vectorMeasure).variation :=
+    IsFiniteMeasure.mk (lt_top_iff_ne_top.mpr hμ_ne_top)
+  let μv : Measure ℝ := (hvar.vectorMeasure).variation
+  let T : Set ℝ → ℂ →L[ℝ] ℂ :=
+    cbmApplyMeasure hvar.vectorMeasure (ContinuousLinearMap.mul ℝ ℂ)
+  let hT : DominatedFinMeasAdditive μv T 1 :=
+    dominatedFinMeasAdditive_cbmApplyMeasure_mul_complex_variation hvar.vectorMeasure
+  have hf_int : Integrable (e u : ℝ → ℂ) μv :=
+    BoundedContinuousFunction.integrable μv (e u)
+  have hfs_int : ∀ n : ℕ,
+      Integrable ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ)) μv := by
+    intro n
+    exact hf_int.indicator measurableSet_Ioc
+  have hcover : AECover μv atTop (fun n : ℕ => Set.Ioc (-(n : ℝ)) (n : ℝ)) :=
+    aecover_Ioc
+      (tendsto_neg_atBot_iff.mpr
+        (tendsto_natCast_atTop_atTop : Tendsto (fun n : ℕ => (n : ℝ)) atTop atTop))
+      (tendsto_natCast_atTop_atTop : Tendsto (fun n : ℕ => (n : ℝ)) atTop atTop)
+  have hset :
+      Tendsto
+        (fun n : ℕ => setToFun μv T hT
+          ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ)))
+        atTop
+        (𝓝 (setToFun μv T hT (e u : ℝ → ℂ))) := by
+    refine tendsto_setToFun_of_dominated_convergence hT (fun _ : ℝ => ‖e u‖) ?_ ?_ ?_ ?_
+    · intro n
+      exact ((e u).continuous.aestronglyMeasurable).indicator measurableSet_Ioc
+    · exact integrable_const _
+    · intro n
+      refine ae_of_all μv fun x => ?_
+      exact (norm_indicator_le_norm_self (e u : ℝ → ℂ) x).trans
+        (BoundedContinuousFunction.norm_coe_le_norm (e u) x)
+    · exact hcover.ae_tendsto_indicator (e u : ℝ → ℂ)
+  rw [← setToFun_mul_complex_variation_eq_integral hvar.vectorMeasure hf_int]
+  exact hset.congr' (Eventually.of_forall fun n =>
+    setToFun_mul_complex_variation_eq_integral hvar.vectorMeasure (hfs_int n))
+
 def vectorMeasure_integral_fourierChar_eq_IBP (ψ : ℝ → ℂ) (hψ : Integrable ψ)
     (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) : Prop :=
   vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u →

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -335,6 +335,12 @@ lemma boundedVariationOn_norm_vectorMeasure_integral_fourierChar_le_eVariationOn
     _ = ((hvar.vectorMeasure).variation Set.univ).toReal := one_mul _
     _ ≤ (eVariationOn ψ Set.univ).toReal := ENNReal.toReal_mono hψ_ne_top hvariation
 
+lemma fourierIntegral_eq_rightLim_of_boundedVariationOn
+    {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) :
+  𝓕 (ψ : ℝ → ℂ) u = 𝓕 (ψ.rightLim : ℝ → ℂ) u := by
+  exact congr_fun (VectorFourier.fourierIntegral_congr_ae 𝐞 volume (innerₗ ℝ)
+    (BoundedVariationOn.ae_eq_rightLim_complex hvar)) u
+
 lemma prelim_decay_2_of_vectorMeasure_fourier_identity
     (ψ : ℝ → ℂ) (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) (hu : u ≠ 0)
     (hbridge :

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -641,11 +641,279 @@ theorem tendsto_vectorMeasure_integral_Ioc_e
   exact hset.congr' (Eventually.of_forall fun n =>
     setToFun_mul_complex_variation_eq_integral μ (hfs_int n))
 
+/-! ### Discharge of the IBP bridge for `prelim_decay_2`
+
+The Fourier identity `2π i u · 𝓕ψ(u) = ∫ e(-tu) dψ(t)` is obtained by splitting the complex
+vector measure `dψ` into its real and imaginary parts, running the real Lebesgue-Stieltjes
+integration by parts on each (via `tendsto_setIntegral_stieltjes_sub_ibp`), and recombining. The
+imaginary part rides the integrand through `toComplexMeasureImagZero`, avoiding the `ℝ`-only
+`setToFun_smul_left`. -/
+
+/-- Restriction commutes with `s ↦ s + i·0`. -/
+theorem signedMeasure_toComplexMeasure_zero_restrict_comm {X : Type*} [MeasurableSpace X]
+    (s : SignedMeasure X) {i : Set X} (hi : MeasurableSet i) :
+    (SignedMeasure.toComplexMeasure s 0).restrict i =
+      SignedMeasure.toComplexMeasure (s.restrict i) 0 := by
+  ext j hj
+  rw [VectorMeasure.restrict_apply _ hi hj, SignedMeasure.toComplexMeasure_apply,
+    SignedMeasure.toComplexMeasure_apply, VectorMeasure.restrict_apply _ hi hj]; rfl
+
+/-- `s ↦ s + i·0` is additive in the real part. -/
+theorem signedMeasure_toComplexMeasure_zero_sub {X : Type*} [MeasurableSpace X]
+    (s t : SignedMeasure X) :
+    SignedMeasure.toComplexMeasure (s - t) 0 =
+      (SignedMeasure.toComplexMeasure s 0) - (SignedMeasure.toComplexMeasure t 0) := by
+  ext j hj
+  rw [VectorMeasure.sub_apply, SignedMeasure.toComplexMeasure_apply,
+    SignedMeasure.toComplexMeasure_apply, SignedMeasure.toComplexMeasure_apply,
+    VectorMeasure.sub_apply]
+  apply Complex.ext <;> simp
+
+/-- Restriction commutes with `t ↦ 0 + i·t`. -/
+theorem zero_toComplexMeasure_restrict_comm {X : Type*} [MeasurableSpace X]
+    (s : SignedMeasure X) {i : Set X} (hi : MeasurableSet i) :
+    (SignedMeasure.toComplexMeasure 0 s).restrict i =
+      SignedMeasure.toComplexMeasure 0 (s.restrict i) := by
+  ext j hj
+  rw [VectorMeasure.restrict_apply _ hi hj, SignedMeasure.toComplexMeasure_apply,
+    SignedMeasure.toComplexMeasure_apply, VectorMeasure.restrict_apply _ hi hj]; rfl
+
+/-- `t ↦ 0 + i·t` is additive in the imaginary part. -/
+theorem zero_toComplexMeasure_sub {X : Type*} [MeasurableSpace X] (s t : SignedMeasure X) :
+    SignedMeasure.toComplexMeasure 0 (s - t) =
+      (SignedMeasure.toComplexMeasure 0 s) - (SignedMeasure.toComplexMeasure 0 t) := by
+  ext j hj
+  rw [VectorMeasure.sub_apply, SignedMeasure.toComplexMeasure_apply,
+    SignedMeasure.toComplexMeasure_apply, SignedMeasure.toComplexMeasure_apply,
+    VectorMeasure.sub_apply]
+  apply Complex.ext <;> simp
+
+/-- The real part of the bounded-variation vector measure of `ψ` is the vector measure of `Re ψ`. -/
+theorem re_vectorMeasure_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ)
+    (hψ : Integrable ψ) :
+    ComplexMeasure.re hvar.vectorMeasure =
+      (Complex.reCLM.lipschitz.comp_boundedVariationOn hvar).vectorMeasure := by
+  have := BoundedVariationOn.mapRange_re_vectorMeasure_eq hvar hψ
+  rw [ComplexMeasure.re]; simpa [VectorMeasure.mapRangeₗ] using this
+
+/-- The imaginary part of the bounded-variation vector measure of `ψ` is the vector measure
+of `Im ψ`. -/
+theorem im_vectorMeasure_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ)
+    (hψ : Integrable ψ) :
+    ComplexMeasure.im hvar.vectorMeasure =
+      (Complex.imCLM.lipschitz.comp_boundedVariationOn hvar).vectorMeasure := by
+  have := BoundedVariationOn.mapRange_im_vectorMeasure_eq hvar hψ
+  rw [ComplexMeasure.im]; simpa [VectorMeasure.mapRangeₗ] using this
+
+/-- Right-limit commutes with `Re`. -/
+theorem reψ_rightLim_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (x : ℝ) :
+    (fun y : ℝ => (ψ y).re).rightLim x = (ψ.rightLim x).re :=
+  tendsto_nhds_unique ((Complex.reCLM.lipschitz.comp_boundedVariationOn hvar).tendsto_rightLim x)
+    (Complex.continuous_re.continuousAt.tendsto.comp (hvar.tendsto_rightLim x))
+
+/-- Right-limit commutes with `Im`. -/
+theorem imψ_rightLim_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (x : ℝ) :
+    (fun y : ℝ => (ψ y).im).rightLim x = (ψ.rightLim x).im :=
+  tendsto_nhds_unique ((Complex.imCLM.lipschitz.comp_boundedVariationOn hvar).tendsto_rightLim x)
+    (Complex.continuous_im.continuousAt.tendsto.comp (hvar.tendsto_rightLim x))
+
+/-- Window restriction of the real-part complex measure as a difference of Stieltjes measures. -/
+theorem μre_restrict_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    {p q : StieltjesFunction ℝ}
+    (hpq : ∀ x : ℝ, (fun y : ℝ => (ψ y).re).rightLim x = p x - q x)
+    {a b : ℝ} (hab : a ≤ b) :
+    ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0).restrict (Set.Ioc a b) =
+      (p.measure.restrict (Set.Ioc a b)).toComplexMeasureZero -
+        (q.measure.restrict (Set.Ioc a b)).toComplexMeasureZero := by
+  rw [re_vectorMeasure_eq hvar hψ,
+    signedMeasure_toComplexMeasure_zero_restrict_comm _ measurableSet_Ioc,
+    BoundedVariationOn.vectorMeasure_restrict_eq_stieltjesFunction_sub_rightLim
+      (Complex.reCLM.lipschitz.comp_boundedVariationOn hvar) hpq hab,
+    signedMeasure_toComplexMeasure_zero_sub]
+
+/-- Window restriction of the imaginary-part complex measure as a difference of Stieltjes
+measures. -/
+theorem μim_restrict_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    {p q : StieltjesFunction ℝ}
+    (hpq : ∀ x : ℝ, (fun y : ℝ => (ψ y).im).rightLim x = p x - q x)
+    {a b : ℝ} (hab : a ≤ b) :
+    ((0 : SignedMeasure ℝ).toComplexMeasure (ComplexMeasure.im hvar.vectorMeasure)).restrict
+        (Set.Ioc a b) =
+      (p.measure.restrict (Set.Ioc a b)).toComplexMeasureImagZero -
+        (q.measure.restrict (Set.Ioc a b)).toComplexMeasureImagZero := by
+  rw [im_vectorMeasure_eq hvar hψ,
+    zero_toComplexMeasure_restrict_comm _ measurableSet_Ioc,
+    BoundedVariationOn.vectorMeasure_restrict_eq_stieltjesFunction_sub_rightLim
+      (Complex.imCLM.lipschitz.comp_boundedVariationOn hvar) hpq hab,
+    zero_toComplexMeasure_sub]
+
+/-- Finiteness of the real-part complex measure's variation. -/
+theorem μre_var_fin {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) :
+    IsFiniteMeasure ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0).variation := by
+  have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) :=
+    ne_top_of_le_ne_top hvar hvar.vectorMeasure_variation_univ_le_eVariationOn
+  have hle : ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0).variation ≤
+      (hvar.vectorMeasure).variation := complexMeasure_re_toComplexMeasure_variation_le _
+  exact ⟨lt_of_le_of_lt (hle Set.univ) (lt_top_iff_ne_top.mpr hμ_ne_top)⟩
+
+/-- Finiteness of the imaginary-part complex measure's variation. -/
+theorem μim_var_fin {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) :
+    IsFiniteMeasure ((0 : SignedMeasure ℝ).toComplexMeasure
+      (ComplexMeasure.im hvar.vectorMeasure)).variation := by
+  have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) :=
+    ne_top_of_le_ne_top hvar hvar.vectorMeasure_variation_univ_le_eVariationOn
+  have hle : ((0 : SignedMeasure ℝ).toComplexMeasure
+      (ComplexMeasure.im hvar.vectorMeasure)).variation ≤
+      (hvar.vectorMeasure).variation := complexMeasure_im_toComplexMeasure_variation_le _
+  exact ⟨lt_of_le_of_lt (hle Set.univ) (lt_top_iff_ne_top.mpr hμ_ne_top)⟩
+
+/-- Per-window real-part integral as a difference of Stieltjes set integrals of `e u`. -/
+theorem μre_window_integral {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    [IsFiniteMeasure ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0).variation]
+    {p q : StieltjesFunction ℝ}
+    (hpq : ∀ x : ℝ, (fun y : ℝ => (ψ y).re).rightLim x = p x - q x)
+    (u : ℝ) {a b : ℝ} (hab : a ≤ b) :
+    VectorMeasure.integral ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0)
+        ((Set.Ioc a b).indicator (e u : ℝ → ℂ)) (ContinuousLinearMap.mul ℝ ℂ) =
+      (∫ x in Set.Ioc a b, e u x ∂p.measure) - ∫ x in Set.Ioc a b, e u x ∂q.measure := by
+  have hint : Integrable (e u : ℝ → ℂ)
+      ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0).variation :=
+    BoundedContinuousFunction.integrable _ (e u)
+  have hp : IntegrableOn (e u : ℝ → ℂ) (Set.Ioc a b) p.measure :=
+    BoundedContinuousFunction.integrable (p.measure.restrict (Set.Ioc a b)) (e u)
+  have hq : IntegrableOn (e u : ℝ → ℂ) (Set.Ioc a b) q.measure :=
+    BoundedContinuousFunction.integrable (q.measure.restrict (Set.Ioc a b)) (e u)
+  rw [vectorMeasure_integral_indicator_eq_restrict _ measurableSet_Ioc hint,
+    μre_restrict_eq hvar hψ hpq hab]
+  exact vectorMeasure_integral_restrict_toComplexMeasureZero_sub_mul_eq_setIntegral_sub
+    p.measure q.measure hp hq
+
+/-- Per-window imaginary-part integral: `i` times a difference of Stieltjes set integrals. -/
+theorem μim_window_integral {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    [IsFiniteMeasure ((0 : SignedMeasure ℝ).toComplexMeasure
+      (ComplexMeasure.im hvar.vectorMeasure)).variation]
+    {p q : StieltjesFunction ℝ}
+    (hpq : ∀ x : ℝ, (fun y : ℝ => (ψ y).im).rightLim x = p x - q x)
+    (u : ℝ) {a b : ℝ} (hab : a ≤ b) :
+    VectorMeasure.integral ((0 : SignedMeasure ℝ).toComplexMeasure
+        (ComplexMeasure.im hvar.vectorMeasure))
+        ((Set.Ioc a b).indicator (e u : ℝ → ℂ)) (ContinuousLinearMap.mul ℝ ℂ) =
+      Complex.I * ((∫ x in Set.Ioc a b, e u x ∂p.measure) -
+        ∫ x in Set.Ioc a b, e u x ∂q.measure) := by
+  have hint : Integrable (e u : ℝ → ℂ)
+      ((0 : SignedMeasure ℝ).toComplexMeasure
+        (ComplexMeasure.im hvar.vectorMeasure)).variation :=
+    BoundedContinuousFunction.integrable _ (e u)
+  have hp : IntegrableOn (e u : ℝ → ℂ) (Set.Ioc a b) p.measure :=
+    BoundedContinuousFunction.integrable (p.measure.restrict (Set.Ioc a b)) (e u)
+  have hq : IntegrableOn (e u : ℝ → ℂ) (Set.Ioc a b) q.measure :=
+    BoundedContinuousFunction.integrable (q.measure.restrict (Set.Ioc a b)) (e u)
+  rw [vectorMeasure_integral_indicator_eq_restrict _ measurableSet_Ioc hint,
+    μim_restrict_eq hvar hψ hpq hab]
+  exact vectorMeasure_integral_restrict_toComplexMeasureImagZero_sub_mul_eq_setIntegral_sub
+    p.measure q.measure hp hq
+
+/-- The full real-part integral equals `2π i u · 𝓕(Re ψ)ʳˡ(u)` via the windowed IBP limit. -/
+theorem μre_integral_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    (u : ℝ) :
+    VectorMeasure.integral ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0) (e u)
+        (ContinuousLinearMap.mul ℝ ℂ) =
+      (((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) *
+        𝓕 (fun x => ((Function.rightLim (fun y : ℝ => (ψ y).re) x : ℝ) : ℂ)) u := by
+  haveI := μre_var_fin hvar
+  set μre : MeasureTheory.VectorMeasure ℝ ℂ :=
+    (ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0 with hμre
+  have hgbv : BoundedVariationOn (fun y : ℝ => (ψ y).re) Set.univ :=
+    Complex.reCLM.lipschitz.comp_boundedVariationOn hvar
+  have hgi : Integrable (fun y : ℝ => (ψ y).re) volume := Complex.reCLM.integrable_comp hψ
+  obtain ⟨p, q, hpq⟩ := BoundedVariationOn.exists_stieltjesFunction_sub_rightLim hgbv
+  have hwin := tendsto_vectorMeasure_integral_Ioc_e μre u
+  have hbridge : (fun n : ℕ => VectorMeasure.integral μre
+      ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ)) (ContinuousLinearMap.mul ℝ ℂ)) =
+    (fun n : ℕ => (∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂p.measure) -
+        ∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂q.measure) := by
+    funext n
+    have hnn : (0 : ℝ) ≤ (n : ℝ) := by positivity
+    have hab : (-(n : ℝ)) ≤ (n : ℝ) := by linarith
+    exact μre_window_integral hvar hψ hpq u hab
+  rw [hbridge] at hwin
+  exact tendsto_nhds_unique hwin (tendsto_setIntegral_stieltjes_sub_ibp hgbv hgi u hpq)
+
+/-- The full imaginary-part integral equals `i · 2π i u · 𝓕(Im ψ)ʳˡ(u)`. -/
+theorem μim_integral_eq {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    (u : ℝ) :
+    VectorMeasure.integral ((0 : SignedMeasure ℝ).toComplexMeasure
+        (ComplexMeasure.im hvar.vectorMeasure)) (e u) (ContinuousLinearMap.mul ℝ ℂ) =
+      Complex.I * ((((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) *
+        𝓕 (fun x => ((Function.rightLim (fun y : ℝ => (ψ y).im) x : ℝ) : ℂ)) u) := by
+  haveI := μim_var_fin hvar
+  set μim : MeasureTheory.VectorMeasure ℝ ℂ :=
+    (0 : SignedMeasure ℝ).toComplexMeasure (ComplexMeasure.im hvar.vectorMeasure) with hμim
+  have hgbv : BoundedVariationOn (fun y : ℝ => (ψ y).im) Set.univ :=
+    Complex.imCLM.lipschitz.comp_boundedVariationOn hvar
+  have hgi : Integrable (fun y : ℝ => (ψ y).im) volume := Complex.imCLM.integrable_comp hψ
+  obtain ⟨p, q, hpq⟩ := BoundedVariationOn.exists_stieltjesFunction_sub_rightLim hgbv
+  have hwin := tendsto_vectorMeasure_integral_Ioc_e μim u
+  have hbridge : (fun n : ℕ => VectorMeasure.integral μim
+      ((Set.Ioc (-(n : ℝ)) (n : ℝ)).indicator (e u : ℝ → ℂ)) (ContinuousLinearMap.mul ℝ ℂ)) =
+    (fun n : ℕ => Complex.I * ((∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂p.measure) -
+        ∫ x in Set.Ioc (-(n : ℝ)) (n : ℝ), e u x ∂q.measure)) := by
+    funext n
+    have hnn : (0 : ℝ) ≤ (n : ℝ) := by positivity
+    have hab : (-(n : ℝ)) ≤ (n : ℝ) := by linarith
+    exact μim_window_integral hvar hψ hpq u hab
+  rw [hbridge] at hwin
+  exact tendsto_nhds_unique hwin
+    ((tendsto_setIntegral_stieltjes_sub_ibp hgbv hgi u hpq).const_mul Complex.I)
+
+/-- Fourier recombination: `𝓕(Re ψ)ʳˡ + i·𝓕(Im ψ)ʳˡ = 𝓕 ψ`. -/
+theorem fourier_recombine {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ) (hψ : Integrable ψ)
+    (u : ℝ) :
+    𝓕 (fun x => ((Function.rightLim (fun y : ℝ => (ψ y).re) x : ℝ) : ℂ)) u +
+      Complex.I * 𝓕 (fun x => ((Function.rightLim (fun y : ℝ => (ψ y).im) x : ℝ) : ℂ)) u =
+    𝓕 (ψ : ℝ → ℂ) u := by
+  have hgbvre : BoundedVariationOn (fun y : ℝ => (ψ y).re) Set.univ :=
+    Complex.reCLM.lipschitz.comp_boundedVariationOn hvar
+  have hgbvim : BoundedVariationOn (fun y : ℝ => (ψ y).im) Set.univ :=
+    Complex.imCLM.lipschitz.comp_boundedVariationOn hvar
+  have hgire : Integrable (fun y : ℝ => (ψ y).re) volume := Complex.reCLM.integrable_comp hψ
+  have hgiim : Integrable (fun y : ℝ => (ψ y).im) volume := Complex.imCLM.integrable_comp hψ
+  have hReInt : Integrable (fun x => ((Function.rightLim (fun y : ℝ => (ψ y).re) x : ℝ) : ℂ))
+      volume := by
+    have : Integrable (Function.rightLim (fun y : ℝ => (ψ y).re)) volume :=
+      hgire.congr hgbvre.ae_eq_rightLim_real
+    simpa [Function.comp] using Complex.ofRealCLM.integrable_comp this
+  have hImInt : Integrable (fun x => ((Function.rightLim (fun y : ℝ => (ψ y).im) x : ℝ) : ℂ))
+      volume := by
+    have : Integrable (Function.rightLim (fun y : ℝ => (ψ y).im)) volume :=
+      hgiim.congr hgbvim.ae_eq_rightLim_real
+    simpa [Function.comp] using Complex.ofRealCLM.integrable_comp this
+  have hψrl : 𝓕 (ψ : ℝ → ℂ) u = 𝓕 (ψ.rightLim : ℝ → ℂ) u :=
+    fourierIntegral_eq_rightLim_of_boundedVariationOn hvar u
+  have hpt : (ψ.rightLim : ℝ → ℂ) = fun x =>
+      ((Function.rightLim (fun y : ℝ => (ψ y).re) x : ℝ) : ℂ) +
+        Complex.I * ((Function.rightLim (fun y : ℝ => (ψ y).im) x : ℝ) : ℂ) := by
+    funext x
+    rw [reψ_rightLim_eq hvar x, imψ_rightLim_eq hvar x, mul_comm]
+    exact (Complex.re_add_im (ψ.rightLim x)).symm
+  rw [hψrl, hpt, F_add hReInt (hImInt.const_mul Complex.I), F_mul]
+
 def vectorMeasure_integral_fourierChar_eq_IBP (ψ : ℝ → ℂ) (hψ : Integrable ψ)
     (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) : Prop :=
   vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u →
     (((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) * 𝓕 (ψ : ℝ → ℂ) u =
       VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)
+
+/-- The Lebesgue-Stieltjes integration-by-parts identity
+`2π i u · 𝓕ψ(u) = ∫ e(-tu) dψ(t)`, proved unconditionally by splitting `dψ` into real and
+imaginary parts. -/
+theorem vectorMeasure_integral_fourierChar_eq_IBP_proof (ψ : ℝ → ℂ) (hψ : Integrable ψ)
+    (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) :
+    vectorMeasure_integral_fourierChar_eq_IBP ψ hψ hvar u := by
+  intro hre_add
+  rw [hre_add, μre_integral_eq hvar hψ u, μim_integral_eq hvar hψ u]
+  rw [← fourier_recombine hvar hψ u]
+  ring
 
 lemma prelim_decay_2_of_vectorMeasure_fourier_identity
     (ψ : ℝ → ℂ) (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) (hu : u ≠ 0)
@@ -690,11 +958,11 @@ and the claim then follows from the triangle inequality. -/)
   (latexEnv := "lemma")
   (discussion := 562)]
 theorem prelim_decay_2 (ψ : ℝ → ℂ) (hψ : Integrable ψ) (hvar : BoundedVariationOn ψ Set.univ)
-    (u : ℝ) (hu : u ≠ 0)
-    (hibp : vectorMeasure_integral_fourierChar_eq_IBP ψ hψ hvar u) :
+    (u : ℝ) (hu : u ≠ 0) :
     ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤ (eVariationOn ψ Set.univ).toReal / (2 * π * ‖u‖) := by
   exact prelim_decay_2_of_vectorMeasure_fourier_identity ψ hvar u hu
-    (hibp (vectorMeasure_integral_eq_re_add_I_im_proof ψ hψ hvar u))
+    (vectorMeasure_integral_fourierChar_eq_IBP_proof ψ hψ hvar u
+      (vectorMeasure_integral_eq_re_add_I_im_proof ψ hψ hvar u))
 
 noncomputable def AbsolutelyContinuous (f : ℝ → ℂ) : Prop := (∀ᵐ x, DifferentiableAt ℝ f x) ∧
   ∀ a b : ℝ, f b - f a = ∫ t in a..b, deriv f t

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -5,7 +5,9 @@ import Mathlib.Analysis.SumIntegralComparisons
 import Mathlib.NumberTheory.Chebyshev
 import Mathlib.NumberTheory.LSeries.PrimesInAP
 import Mathlib.NumberTheory.MulChar.Lemmas
+import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 import Mathlib.Topology.EMetricSpace.BoundedVariation
+import PrimeNumberTheoremAnd.Mathlib.MeasureTheory.VectorMeasure.Integral
 import PrimeNumberTheoremAnd.Mathlib.Analysis.Asymptotics.Asymptotics
 import PrimeNumberTheoremAnd.Fourier
 import PrimeNumberTheoremAnd.SmoothExistence
@@ -22,6 +24,7 @@ open Real BigOperators ArithmeticFunction MeasureTheory Filter Set FourierTransf
   Asymptotics SchwartzMap
 open Complex hiding log
 open scoped Topology
+open scoped ENNReal
 open scoped ContDiff
 open scoped ComplexConjugate
 
@@ -307,6 +310,29 @@ lemma one_add_sq_pos (u : ℝ) : 0 < 1 + u ^ 2 := zero_lt_one.trans_le (by simpa
   (discussion := 561)]
 theorem prelim_decay (ψ : ℝ → ℂ) (u : ℝ) : ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤ ∫ t, ‖ψ t‖ :=
   VectorFourier.norm_fourierIntegral_le_integral_norm ..
+
+lemma boundedVariationOn_norm_vectorMeasure_integral_fourierChar_le_eVariationOn
+    {ψ : ℝ → ℂ} (hvar : BoundedVariationOn ψ Set.univ)
+    (hvariation : (hvar.vectorMeasure).variation Set.univ ≤ eVariationOn ψ Set.univ)
+    (u : ℝ) :
+    ‖VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)‖ ≤
+      (eVariationOn ψ Set.univ).toReal := by
+  have hψ_ne_top : eVariationOn ψ Set.univ ≠ (∞ : ℝ≥0∞) := hvar
+  have hμ_ne_top : (hvar.vectorMeasure).variation Set.univ ≠ (∞ : ℝ≥0∞) :=
+    ne_top_of_le_ne_top hψ_ne_top hvariation
+  letI : IsFiniteMeasure (hvar.vectorMeasure).variation :=
+    IsFiniteMeasure.mk (lt_top_iff_ne_top.mpr hμ_ne_top)
+  have hbound : ∀ x, ‖(e u) x‖ ≤ (1 : ℝ) := by
+    intro x
+    simp [e_apply]
+  have hbase := VectorMeasure.norm_integral_mul_complex_le_of_norm_le hvar.vectorMeasure
+    (BoundedContinuousFunction.integrable (hvar.vectorMeasure).variation (e u)) zero_le_one
+    hbound (measure_ne_top (hvar.vectorMeasure).variation Set.univ)
+  calc
+    ‖VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)‖
+        ≤ 1 * ((hvar.vectorMeasure).variation Set.univ).toReal := hbase
+    _ = ((hvar.vectorMeasure).variation Set.univ).toReal := one_mul _
+    _ ≤ (eVariationOn ψ Set.univ).toReal := ENNReal.toReal_mono hψ_ne_top hvariation
 
 @[blueprint "prelim-decay-2"
   (title := "Preliminary decay bound II")

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -335,6 +335,36 @@ lemma boundedVariationOn_norm_vectorMeasure_integral_fourierChar_le_eVariationOn
     _ = ((hvar.vectorMeasure).variation Set.univ).toReal := one_mul _
     _ ≤ (eVariationOn ψ Set.univ).toReal := ENNReal.toReal_mono hψ_ne_top hvariation
 
+lemma prelim_decay_2_of_vectorMeasure_fourier_identity
+    (ψ : ℝ → ℂ) (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) (hu : u ≠ 0)
+    (hbridge :
+      (((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) * 𝓕 (ψ : ℝ → ℂ) u =
+        VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)) :
+    ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤ (eVariationOn ψ Set.univ).toReal / (2 * π * ‖u‖) := by
+  have hvec := boundedVariationOn_norm_vectorMeasure_integral_fourierChar_le_eVariationOn
+    hvar u
+  have hscalar_norm : ‖(((2 * Real.pi * u : ℝ) : ℂ) * Complex.I)‖ =
+      2 * Real.pi * ‖u‖ := by
+    rw [Complex.norm_mul]
+    simp [Real.norm_eq_abs, abs_of_pos Real.pi_pos]
+  have hpos : 0 < 2 * Real.pi * ‖u‖ := by
+    positivity
+  have hmul_le : (2 * Real.pi * ‖u‖) * ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤
+      (eVariationOn ψ Set.univ).toReal := by
+    calc
+      (2 * Real.pi * ‖u‖) * ‖𝓕 (ψ : ℝ → ℂ) u‖
+          = ‖(((2 * Real.pi * u : ℝ) : ℂ) * Complex.I)‖ *
+              ‖𝓕 (ψ : ℝ → ℂ) u‖ := by
+            rw [hscalar_norm]
+      _ = ‖((((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) * 𝓕 (ψ : ℝ → ℂ) u)‖ := by
+            exact (Complex.norm_mul (((2 * Real.pi * u : ℝ) : ℂ) * Complex.I)
+              (𝓕 (ψ : ℝ → ℂ) u)).symm
+      _ = ‖VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)‖ := by
+            rw [hbridge]
+      _ ≤ (eVariationOn ψ Set.univ).toReal := hvec
+  exact (le_div_iff₀ hpos).mpr (by
+    simpa [mul_comm, mul_left_comm, mul_assoc] using hmul_le)
+
 @[blueprint "prelim-decay-2"
   (title := "Preliminary decay bound II")
   (statement := /--

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -341,6 +341,22 @@ lemma fourierIntegral_eq_rightLim_of_boundedVariationOn
   exact congr_fun (VectorFourier.fourierIntegral_congr_ae 𝐞 volume (innerₗ ℝ)
     (BoundedVariationOn.ae_eq_rightLim_complex hvar)) u
 
+def vectorMeasure_integral_eq_re_add_I_im (ψ : ℝ → ℂ) (_hψ : Integrable ψ)
+    (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) : Prop :=
+  VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ) =
+    VectorMeasure.integral
+        ((ComplexMeasure.re hvar.vectorMeasure).toComplexMeasure 0)
+        (e u) (ContinuousLinearMap.mul ℝ ℂ) +
+      VectorMeasure.integral
+        ((0 : SignedMeasure ℝ).toComplexMeasure (ComplexMeasure.im hvar.vectorMeasure))
+        (e u) (ContinuousLinearMap.mul ℝ ℂ)
+
+def vectorMeasure_integral_fourierChar_eq_IBP (ψ : ℝ → ℂ) (hψ : Integrable ψ)
+    (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) : Prop :=
+  vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u →
+    (((2 * Real.pi * u : ℝ) : ℂ) * Complex.I) * 𝓕 (ψ : ℝ → ℂ) u =
+      VectorMeasure.integral hvar.vectorMeasure (e u) (ContinuousLinearMap.mul ℝ ℂ)
+
 lemma prelim_decay_2_of_vectorMeasure_fourier_identity
     (ψ : ℝ → ℂ) (hvar : BoundedVariationOn ψ Set.univ) (u : ℝ) (hu : u ≠ 0)
     (hbridge :
@@ -384,8 +400,11 @@ and the claim then follows from the triangle inequality. -/)
   (latexEnv := "lemma")
   (discussion := 562)]
 theorem prelim_decay_2 (ψ : ℝ → ℂ) (hψ : Integrable ψ) (hvar : BoundedVariationOn ψ Set.univ)
-    (u : ℝ) (hu : u ≠ 0) :
-    ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤ (eVariationOn ψ Set.univ).toReal / (2 * π * ‖u‖) := by sorry
+    (u : ℝ) (hu : u ≠ 0)
+    (hreim : vectorMeasure_integral_eq_re_add_I_im ψ hψ hvar u)
+    (hibp : vectorMeasure_integral_fourierChar_eq_IBP ψ hψ hvar u) :
+    ‖𝓕 (ψ : ℝ → ℂ) u‖ ≤ (eVariationOn ψ Set.univ).toReal / (2 * π * ‖u‖) := by
+  exact prelim_decay_2_of_vectorMeasure_fourier_identity ψ hvar u hu (hibp hreim)
 
 noncomputable def AbsolutelyContinuous (f : ℝ → ℂ) : Prop := (∀ᵐ x, DifferentiableAt ℝ f x) ∧
   ∀ a b : ℝ, f b - f a = ∫ t in a..b, deriv f t


### PR DESCRIPTION
Closed: see maintainer direction 

"This particular task should wait until the Stieltjes integral theory (see https://github.com/leanprover-community/mathlib-at-ICERM26/tree/stieltjes) lands in Mathlib."


This is an attempt at #562 — it fills `prelim_decay_2` in `Wiener.lean`: the `1/|u|` decay of the Fourier transform of a bounded-variation function,

```
‖𝓕 ψ u‖ ≤ (eVariationOn ψ Set.univ).toReal / (2 * π * ‖u‖)
```

for integrable `ψ` of bounded variation and `u ≠ 0`.

The proof is the Fourier–Stieltjes integration by parts `2πiu · 𝓕ψ(u) = ∫ e(-tu) dψ(t)`, then bounding the right side by the total variation. Establishing that identity needs vector-measure-integral, bounded-variation, and Stieltjes-measure infrastructure that mathlib does not yet have, added under `PrimeNumberTheoremAnd/Mathlib/MeasureTheory/`.

It is on the larger side for that reason. The added infrastructure is general (a complex vector-measure integral, a BV→Stieltjes bridge, a finite Stieltjes IBP) and could be split into its own PR — or eventually upstreamed — if that reads better.

Sorry-free; `prelim_decay_2` uses only the standard axioms.

Developed with Claude Code CLI