### PR TITLE
fix: align Dusart lemma_5_10b with 1-indexed prime numbering

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -733,7 +733,8 @@ theorem lemma_5_10a {k : ℕ} (hk : k ≥ 4) : nth_prime' k ≤ k * Real.log (nt
   We have for $k \geq 2$, $\log p_k \leq \log k + \log \log k + 1$.
   -/)
   (latexEnv := "lemma")]
-theorem lemma_5_10b {k : ℕ} (hk : k ≥ 2) : Real.log (nth_prime' k) ≤ Real.log k + Real.log (Real.log k) + 1 := by sorry
+theorem lemma_5_10b {k : ℕ} (hk : k ≥ 2) :
+    Real.log (nth_prime' (k - 1)) ≤ Real.log k + Real.log (Real.log k) + 1 := by sorry
 
 @[blueprint "Massias_Robin_thm_Bv"
   (title := "Massias and Robin Theorem B (v)")


### PR DESCRIPTION
## Summary
`lemma_5_10b` used `nth_prime' k` for Dusart's 1-indexed $p_k$, matching the indexing bug in #1129 for `lemma_5_10a`.

## Bug
At $k=3$: `nth_prime' 3 = 7` but $p_3 = 5$, and $\log 7 > \log 3 + \log\log 3 + 1$, so the inequality fails.

## Fix
Use `nth_prime' (k - 1)` for paper index $k$, as in #1512 for part (a).

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IEANTN.Dusart`

Related to #1129.


Made with [Cursor](https://cursor.com)