### PR TITLE
IEANTN: principal-value sin/u kernel split + windowed sin-div bound (2/5 of #1558)

### DIFF
--- a/PrimeNumberTheoremAnd/LaplaceInversion.lean
+++ b/PrimeNumberTheoremAnd/LaplaceInversion.lean
@@ -470,3 +470,643 @@ theorem tendsto_integral_sin_mul_smul_atTop {f : ℝ → E} (hf : Integrable f) 
   rw [show (Real.sin (T * v) : ℂ) = Complex.sin ((T * v : ℝ) : ℂ) by simp]
   field_simp
   simpa [mul_comm, mul_left_comm, mul_assoc] using (Complex.two_sin ((T * v : ℝ) : ℂ))
+
+theorem sin_div_kernel_sub_eq_sin_smul_quotient
+    (f : ℝ → E) (x T u : ℝ) :
+    (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+        (f (x - u) - f x) =
+      (Real.sin (T * u) : ℂ) •
+        (if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x)) := by
+  by_cases hu : u = 0
+  · simp [hu]
+  · rw [if_neg hu, if_neg hu, ← smul_assoc]
+    congr 1
+    simp only [div_eq_mul_inv]
+    ring
+
+theorem local_quotient_eq_dslope
+    (f : ℝ → E) (x : ℝ) {u : ℝ} (hu : u ≠ 0) :
+    ((-1 / π : ℂ) • dslope f x (x - u)) =
+      (if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x)) := by
+  rw [if_neg hu]
+  have hne : x - u ≠ x := by
+    intro h
+    have : u = 0 := by linarith
+    exact hu this
+  rw [dslope_of_ne f hne]
+  rw [slope_def_module]
+  let r : ℝ := (x - u - x)⁻¹
+  change (-1 / π : ℂ) • (r • (f (x - u) - f x)) =
+    (1 / (π * u) : ℂ) • (f (x - u) - f x)
+  rw [← smul_comm r ((-1 / π : ℂ))]
+  rw [RCLike.real_smul_eq_coe_smul (K := ℂ) (E := E)]
+  rw [← smul_assoc]
+  congr 1
+  dsimp [r]
+  push_cast
+  field_simp [hu, Real.pi_ne_zero]
+  ring
+
+/-- Differentiability at the target point makes the local sine-error quotient
+interval-integrable on every positive window. -/
+theorem intervalIntegrable_local_quotient_of_differentiableAt
+    {f : ℝ → E} {x R : ℝ} (hR : 0 < R)
+    (hf_cont : ContinuousOn f (Set.Icc (x - R) (x + R)))
+    (hf_diff : DifferentiableAt ℝ f x) :
+    IntervalIntegrable
+      (fun u : ℝ =>
+        if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x))
+      volume (-R) R := by
+  let qds : ℝ → E := fun u => (-1 / π : ℂ) • dslope f x (x - u)
+  have hmem : Set.Icc (x - R) (x + R) ∈ nhds x := by
+    exact Icc_mem_nhds (by linarith) (by linarith)
+  have hds : ContinuousOn (dslope f x) (Set.Icc (x - R) (x + R)) :=
+    (continuousOn_dslope hmem).2 ⟨hf_cont, hf_diff⟩
+  have hmap : MapsTo (fun u : ℝ => x - u) (Set.Icc (-R) R) (Set.Icc (x - R) (x + R)) := by
+    intro u hu
+    rw [Set.mem_Icc] at hu ⊢
+    constructor <;> linarith
+  have hcomp : ContinuousOn (fun u : ℝ => dslope f x (x - u)) (Set.Icc (-R) R) := by
+    exact hds.comp (by fun_prop) hmap
+  have hqds_cont : ContinuousOn qds (Set.Icc (-R) R) :=
+    hcomp.const_smul (-1 / π : ℂ)
+  have hle : -R ≤ R := by linarith
+  have hqds_int : IntervalIntegrable qds volume (-R) R :=
+    ContinuousOn.intervalIntegrable_of_Icc hle hqds_cont
+  refine hqds_int.congr_ae ?_
+  rw [Filter.EventuallyEq]
+  rw [ae_restrict_iff' measurableSet_uIoc]
+  filter_upwards [show ∀ᵐ u : ℝ, u ≠ 0 by simp [ae_iff, measure_singleton]]
+    with u hu _hu_mem
+  dsimp [qds]
+  exact local_quotient_eq_dslope (E := E) f x hu
+
+/-- Local quotient integrability gives interval-integrability of the finite
+sine-kernel error term. -/
+theorem intervalIntegrable_sin_div_kernel_error_of_intervalIntegrable_quotient
+    {f : ℝ → E} {x R : ℝ}
+    (hq : IntervalIntegrable
+      (fun u : ℝ =>
+        if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x))
+      volume (-R) R)
+    (T : ℝ) :
+    IntervalIntegrable
+      (fun u : ℝ =>
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          (f (x - u) - f x))
+      volume (-R) R := by
+  let q : ℝ → E := fun u =>
+    if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x)
+  have hsinq : IntervalIntegrable (fun u : ℝ => (Real.sin (T * u) : ℂ) • q u)
+      volume (-R) R := by
+    refine hq.continuousOn_smul ?_
+    fun_prop
+  refine hsinq.congr ?_
+  intro u _hu
+  dsimp [q]
+  exact (sin_div_kernel_sub_eq_sin_smul_quotient (E := E) f x T u).symm
+
+/-- Local quotient integrability gives the finite-window Riemann-Lebesgue
+cancellation for the sine-kernel error term. -/
+theorem tendsto_intervalIntegral_sin_div_kernel_error_of_intervalIntegrable_quotient
+    {f : ℝ → E} {x R : ℝ} (hR : 0 < R)
+    (hq : IntervalIntegrable
+      (fun u : ℝ =>
+        if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x))
+      volume (-R) R) :
+    Filter.Tendsto
+      (fun T : ℝ =>
+        ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            (f (x - u) - f x))
+      Filter.atTop (nhds 0) := by
+  let q : ℝ → E := fun u =>
+    if u = 0 then 0 else (1 / (π * u) : ℂ) • (f (x - u) - f x)
+  let qWindow : ℝ → E := Set.Ioc (-R) R |>.indicator q
+  have hle : -R ≤ R := by linarith
+  have hqIoc : IntegrableOn q (Set.Ioc (-R) R) := by
+    simpa [q] using (intervalIntegrable_iff_integrableOn_Ioc_of_le hle).1 hq
+  have hqWindow : Integrable qWindow := by
+    exact hqIoc.integrable_indicator measurableSet_Ioc
+  have hlim := tendsto_integral_sin_mul_smul_atTop (E := E) hqWindow
+  refine hlim.congr' ?_
+  filter_upwards with T
+  have hinterval :
+      (∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            (f (x - u) - f x)) =
+        ∫ u in (-R)..R, (Real.sin (T * u) : ℂ) • q u := by
+    apply intervalIntegral.integral_congr
+    intro u _hu
+    dsimp [q]
+    exact sin_div_kernel_sub_eq_sin_smul_quotient (E := E) f x T u
+  rw [hinterval, intervalIntegral.integral_of_le hle]
+  dsimp [qWindow]
+  rw [← integral_indicator measurableSet_Ioc]
+  congr with u
+  by_cases hu : u ∈ Set.Ioc (-R) R
+  · simp [Set.indicator_of_mem hu]
+  · simp [Set.indicator_of_notMem hu]
+
+/-- The removable sine kernel is bounded by its height. -/
+theorem norm_sin_div_kernel_le_abs_height (T u : ℝ) :
+    ‖(if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ))‖ ≤
+      |T| / π := by
+  by_cases hu : u = 0
+  · rw [if_pos hu]
+    simpa using (div_nonneg (abs_nonneg T) Real.pi_pos.le)
+  · rw [if_neg hu]
+    rw [norm_div, norm_mul, Complex.norm_real, Complex.norm_real, Complex.norm_real]
+    simp only [Real.norm_eq_abs]
+    have hsin : |Real.sin (T * u)| ≤ |T| * |u| := by
+      simpa [abs_mul] using (Real.abs_sin_le_abs (x := T * u))
+    calc
+      |Real.sin (T * u)| / (|π| * |u|)
+          ≤ (|T| * |u|) / (|π| * |u|) :=
+            div_le_div_of_nonneg_right hsin
+              (mul_nonneg (abs_nonneg _) (abs_nonneg _))
+      _ = |T| / π := by
+        rw [abs_of_pos Real.pi_pos]
+        field_simp [abs_pos.mpr hu, Real.pi_ne_zero]
+
+/-- The sine kernel times an integrable source remains integrable. -/
+theorem integrable_sin_div_kernel_smul_of_integrable
+    {f : ℝ → E} (hf : Integrable f) (x T : ℝ) :
+    Integrable
+      (fun u : ℝ =>
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          f (x - u)) := by
+  have hfx : Integrable (fun u : ℝ => f (x - u)) := hf.comp_sub_left x
+  let C : ℂ := (|T| / π : ℝ)
+  have hC_nonneg : 0 ≤ |T| / π := div_nonneg (abs_nonneg T) Real.pi_pos.le
+  have hboundInt : Integrable (fun u : ℝ => C • f (x - u)) := hfx.smul C
+  refine hboundInt.mono ?_ ?_
+  · have hscalar_meas : Measurable
+        (fun u : ℝ =>
+          if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) := by
+      refine Measurable.ite measurableSet_eq measurable_const ?_
+      fun_prop
+    exact hscalar_meas.aestronglyMeasurable.smul hfx.aestronglyMeasurable
+  · filter_upwards with u
+    rw [norm_smul, norm_smul]
+    have hCnorm : ‖C‖ = |T| / π := by
+      rw [show C = ((|T| / π : ℝ) : ℂ) by rfl, Complex.norm_real, Real.norm_eq_abs,
+        abs_of_nonneg hC_nonneg]
+    rw [hCnorm]
+    exact mul_le_mul (norm_sin_div_kernel_le_abs_height T u) le_rfl
+      (norm_nonneg _) hC_nonneg
+
+/-- Outside `(-R, R]`, a positive radius is a lower bound for `|u|`. -/
+lemma le_abs_of_notMem_Ioc_neg_pos {R u : ℝ} (hR : 0 < R)
+    (hu : u ∉ Set.Ioc (-R) R) :
+    R ≤ |u| := by
+  rw [Set.mem_Ioc] at hu
+  by_cases hleft : -R < u
+  · have hRu : R < u := lt_of_not_ge (fun huR : u ≤ R => hu ⟨hleft, huR⟩)
+    exact le_trans hRu.le (le_abs_self u)
+  · have hule : u ≤ -R := le_of_not_gt hleft
+    have hneg : R ≤ -u := by linarith
+    have hu_nonpos : u ≤ 0 := by linarith
+    exact hneg.trans_eq (abs_of_nonpos hu_nonpos).symm
+
+/-- The fixed-window tail quotient is bounded by an integrable translate. -/
+lemma norm_tail_quotient_le
+    {f : ℝ → E} (x : ℝ) {R : ℝ} (hR : 0 < R) (u : ℝ) :
+    ‖(Set.Ioc (-R) R)ᶜ.indicator
+        (fun u : ℝ => (if u = 0 then (0 : ℂ) else (1 / (π * u) : ℂ)) •
+          f (x - u)) u‖ ≤
+      (1 / (π * R)) * ‖f (x - u)‖ := by
+  by_cases huSet : u ∈ (Set.Ioc (-R) R)ᶜ
+  · rw [Set.indicator_of_mem huSet]
+    have hu_not : u ∉ Set.Ioc (-R) R := by simpa using huSet
+    have hR_abs : R ≤ |u| := le_abs_of_notMem_Ioc_neg_pos hR hu_not
+    have hu_ne : u ≠ 0 := by
+      intro h0
+      apply hu_not
+      have hzmem : (0 : ℝ) ∈ Set.Ioc (-R) R := by
+        exact ⟨by linarith, hR.le⟩
+      simpa [h0] using hzmem
+    rw [if_neg hu_ne, norm_smul]
+    have hscalar : ‖(1 / (π * u) : ℂ)‖ ≤ 1 / (π * R) := by
+      rw [norm_div, norm_one, norm_mul, Complex.norm_real, Complex.norm_real]
+      simp only [Real.norm_eq_abs, one_div]
+      rw [abs_of_pos Real.pi_pos]
+      have hden : π * R ≤ π * |u| :=
+        mul_le_mul_of_nonneg_left hR_abs Real.pi_pos.le
+      have hden_pos : 0 < π * R := mul_pos Real.pi_pos hR
+      simpa [mul_comm, mul_left_comm, mul_assoc] using inv_anti₀ hden_pos hden
+    exact mul_le_mul hscalar le_rfl (norm_nonneg _)
+      (div_nonneg zero_le_one (mul_pos Real.pi_pos hR).le)
+  · rw [Set.indicator_of_notMem huSet]
+    simpa using mul_nonneg (div_nonneg zero_le_one (mul_pos Real.pi_pos hR).le)
+      (norm_nonneg (f (x - u)))
+
+/-- The fixed-window tail quotient is integrable for every integrable source. -/
+theorem integrable_tail_quotient_of_integrable
+    {f : ℝ → E} (hf : Integrable f) (x : ℝ) {R : ℝ} (hR : 0 < R) :
+    Integrable ((Set.Ioc (-R) R)ᶜ.indicator
+      (fun u : ℝ => (if u = 0 then (0 : ℂ) else (1 / (π * u) : ℂ)) •
+        f (x - u))) := by
+  have hfx : Integrable (fun u : ℝ => f (x - u)) := hf.comp_sub_left x
+  let C : ℂ := (1 / (π * R) : ℝ)
+  have hC_nonneg : 0 ≤ 1 / (π * R) :=
+    div_nonneg zero_le_one (mul_pos Real.pi_pos hR).le
+  have hboundInt : Integrable (fun u : ℝ => C • f (x - u)) := hfx.smul C
+  refine hboundInt.mono ?_ ?_
+  · have hscalar_meas : Measurable
+        (fun u : ℝ => if u = 0 then (0 : ℂ) else (1 / (π * u) : ℂ)) := by
+      refine Measurable.ite measurableSet_eq measurable_const ?_
+      fun_prop
+    exact (hscalar_meas.aestronglyMeasurable.smul hfx.aestronglyMeasurable).indicator
+      measurableSet_Ioc.compl
+  · filter_upwards with u
+    rw [norm_smul]
+    have hCnorm : ‖C‖ = 1 / (π * R) := by
+      rw [show C = ((1 / (π * R) : ℝ) : ℂ) by rfl, Complex.norm_real, Real.norm_eq_abs,
+        abs_of_nonneg hC_nonneg]
+    rw [hCnorm]
+    exact norm_tail_quotient_le (E := E) x hR u
+
+/-- Pointwise tail algebra for the sine kernel. -/
+lemma tail_indicator_sin_div_eq_sin_smul_quotient
+    (f : ℝ → E) (x T : ℝ) {R : ℝ} (hR : 0 < R) (u : ℝ) :
+    (Set.Ioc (-R) R)ᶜ.indicator
+        (fun u : ℝ =>
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            f (x - u)) u =
+      (Real.sin (T * u) : ℂ) •
+        (Set.Ioc (-R) R)ᶜ.indicator
+          (fun u : ℝ => (if u = 0 then (0 : ℂ) else (1 / (π * u) : ℂ)) •
+            f (x - u)) u := by
+  by_cases huSet : u ∈ (Set.Ioc (-R) R)ᶜ
+  · rw [Set.indicator_of_mem huSet, Set.indicator_of_mem huSet]
+    have hu_not : u ∉ Set.Ioc (-R) R := by simpa using huSet
+    have hu_ne : u ≠ 0 := by
+      intro h0
+      apply hu_not
+      have hzmem : (0 : ℝ) ∈ Set.Ioc (-R) R := by
+        exact ⟨by linarith, hR.le⟩
+      simpa [h0] using hzmem
+    rw [if_neg hu_ne, if_neg hu_ne, ← smul_assoc]
+    congr 1
+    simp only [div_eq_mul_inv]
+    ring
+  · rw [Set.indicator_of_notMem huSet, Set.indicator_of_notMem huSet, smul_zero]
+
+/-- The fixed-window tail of the sine kernel tends to zero for integrable
+sources. -/
+theorem tendsto_sin_div_kernel_tail_of_integrable
+    {f : ℝ → E} (hf : Integrable f) {x R : ℝ} (hR : 0 < R) :
+    Filter.Tendsto
+      (fun T : ℝ =>
+        (∫ u : ℝ,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            f (x - u)) -
+          ∫ u in (-R)..R,
+            (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+              f (x - u))
+      Filter.atTop (nhds 0) := by
+  let qTail : ℝ → E := (Set.Ioc (-R) R)ᶜ.indicator
+    (fun u : ℝ => (if u = 0 then (0 : ℂ) else (1 / (π * u) : ℂ)) •
+      f (x - u))
+  have hqTail : Integrable qTail := by
+    simpa [qTail] using integrable_tail_quotient_of_integrable (E := E) hf x hR
+  have hlim := tendsto_integral_sin_mul_smul_atTop (E := E) hqTail
+  refine hlim.congr' ?_
+  filter_upwards with T
+  let k : ℝ → E := fun u =>
+    (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f (x - u)
+  have hk : Integrable k :=
+    integrable_sin_div_kernel_smul_of_integrable (E := E) hf x T
+  have hle : -R ≤ R := by linarith
+  symm
+  calc
+    (∫ u : ℝ,
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          f (x - u)) -
+        ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            f (x - u)
+        = ∫ u in (Set.Ioc (-R) R)ᶜ, k u := by
+          rw [intervalIntegral.integral_of_le hle]
+          have hdecomp := integral_add_compl (s := Set.Ioc (-R) R) measurableSet_Ioc hk
+          dsimp [k] at hdecomp
+          rw [← hdecomp]
+          abel
+    _ = ∫ u : ℝ, (Set.Ioc (-R) R)ᶜ.indicator k u := by
+          rw [integral_indicator measurableSet_Ioc.compl]
+    _ = ∫ u : ℝ, (Real.sin (T * u) : ℂ) • qTail u := by
+          apply integral_congr_ae
+          filter_upwards with u
+          dsimp [k, qTail]
+          exact tail_indicator_sin_div_eq_sin_smul_quotient (E := E) f x T hR u
+
+/-- Uniform fixed-window tail bound for the sine kernel. Outside `(-R, R]`,
+the denominator gives a `1 / (π R)` bound, independent of the height and
+translation. -/
+theorem norm_sin_div_kernel_tail_le_integral_norm
+    {f : ℝ → E} (hf : Integrable f) (x T : ℝ) {R : ℝ} (hR : 0 < R) :
+    ‖(∫ u : ℝ,
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          f (x - u)) -
+        ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            f (x - u)‖ ≤
+      (1 / (π * R)) * ∫ u : ℝ, ‖f u‖ := by
+  let k : ℝ → E := fun u =>
+    (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f (x - u)
+  have hk : Integrable k :=
+    integrable_sin_div_kernel_smul_of_integrable (E := E) hf x T
+  have hle : -R ≤ R := by linarith
+  have htail_eq :
+      (∫ u : ℝ,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            f (x - u)) -
+          ∫ u in (-R)..R,
+            (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+              f (x - u) =
+        ∫ u in (Set.Ioc (-R) R)ᶜ, k u := by
+    rw [intervalIntegral.integral_of_le hle]
+    have hdecomp := integral_add_compl (s := Set.Ioc (-R) R) measurableSet_Ioc hk
+    dsimp [k] at hdecomp
+    rw [← hdecomp]
+    abel
+  rw [htail_eq]
+  let C : ℝ := 1 / (π * R)
+  have hC_nonneg : 0 ≤ C := by
+    dsimp [C]
+    positivity
+  have hfx : Integrable (fun u : ℝ => f (x - u)) := hf.comp_sub_left x
+  have hbound_int : Integrable (fun u : ℝ => C * ‖f (x - u)‖) :=
+    hfx.norm.const_mul C
+  have hmono : ∀ᵐ u ∂(volume.restrict (Set.Ioc (-R) R)ᶜ),
+      ‖k u‖ ≤ C * ‖f (x - u)‖ := by
+    filter_upwards [MeasureTheory.self_mem_ae_restrict measurableSet_Ioc.compl] with u hucomp
+    dsimp [k, C]
+    have hu_not : u ∉ Set.Ioc (-R) R := by simpa using hucomp
+    have hR_abs : R ≤ |u| := le_abs_of_notMem_Ioc_neg_pos hR hu_not
+    have hu_ne : u ≠ 0 := by
+      intro h0
+      apply hu_not
+      have hzmem : (0 : ℝ) ∈ Set.Ioc (-R) R := ⟨by linarith, hR.le⟩
+      simpa [h0] using hzmem
+    rw [if_neg hu_ne, norm_smul]
+    have hscalar : ‖(Real.sin (T * u) / (π * u) : ℂ)‖ ≤ C := by
+      dsimp [C]
+      rw [norm_div, norm_mul, Complex.norm_real, Complex.norm_real, Complex.norm_real]
+      simp only [Real.norm_eq_abs]
+      rw [abs_of_pos Real.pi_pos]
+      have hsin : |Real.sin (T * u)| ≤ 1 := Real.abs_sin_le_one (T * u)
+      have hden : π * R ≤ π * |u| :=
+        mul_le_mul_of_nonneg_left hR_abs Real.pi_pos.le
+      have hden_pos : 0 < π * R := mul_pos Real.pi_pos hR
+      calc
+        |Real.sin (T * u)| / (π * |u|) ≤ 1 / (π * |u|) := by
+          exact div_le_div_of_nonneg_right hsin
+            (mul_nonneg Real.pi_pos.le (abs_nonneg u))
+        _ ≤ 1 / (π * R) := by
+          simpa [one_div] using inv_anti₀ hden_pos hden
+    exact mul_le_mul hscalar le_rfl (norm_nonneg _) hC_nonneg
+  have hnorm_le : ‖∫ u in (Set.Ioc (-R) R)ᶜ, k u‖ ≤
+      ∫ u in (Set.Ioc (-R) R)ᶜ, C * ‖f (x - u)‖ := by
+    calc
+      ‖∫ u in (Set.Ioc (-R) R)ᶜ, k u‖
+          ≤ ∫ u in (Set.Ioc (-R) R)ᶜ, ‖k u‖ := norm_integral_le_integral_norm _
+      _ ≤ ∫ u in (Set.Ioc (-R) R)ᶜ, C * ‖f (x - u)‖ := by
+        exact integral_mono_ae (hk.norm.mono_measure Measure.restrict_le_self)
+          (hbound_int.mono_measure Measure.restrict_le_self) hmono
+  have hset_le : (∫ u in (Set.Ioc (-R) R)ᶜ, C * ‖f (x - u)‖) ≤
+      ∫ u : ℝ, C * ‖f (x - u)‖ := by
+    exact integral_mono_measure Measure.restrict_le_self
+      (Filter.Eventually.of_forall fun _u => mul_nonneg hC_nonneg (norm_nonneg _)) hbound_int
+  have htranslate : (∫ u : ℝ, C * ‖f (x - u)‖) = C * ∫ u : ℝ, ‖f u‖ := by
+    rw [integral_const_mul]
+    congr 1
+    calc
+      (∫ u : ℝ, ‖f (x - u)‖) = ∫ u : ℝ, ‖f (x + u)‖ := by
+        simpa [sub_eq_add_neg] using
+          integral_neg_eq_self (f := fun u : ℝ => ‖f (x + u)‖) (μ := volume)
+      _ = ∫ u : ℝ, ‖f u‖ := by
+        simpa using integral_add_left_eq_self (μ := volume) (fun u : ℝ => ‖f u‖) x
+  exact hnorm_le.trans (hset_le.trans_eq htranslate)
+
+/-- Finite symmetric-window split for the `sin (T * u) / (π * u)` kernel.
+This is the valid algebraic surface for the principal-value mass term before
+taking an improper limit. -/
+theorem intervalIntegral_sin_div_kernel_split
+    [CompleteSpace E]
+    (f : ℝ → E) (x T R : ℝ)
+    (hconst : IntervalIntegrable
+      (fun u : ℝ =>
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f x)
+      volume (-R) R)
+    (herr : IntervalIntegrable
+      (fun u : ℝ =>
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          (f (x - u) - f x))
+      volume (-R) R) :
+    (∫ u in (-R)..R,
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          f (x - u)) =
+      (∫ u in (-R)..R,
+        if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f x +
+        ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            (f (x - u) - f x) := by
+  calc
+    (∫ u in (-R)..R,
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          f (x - u))
+        = ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f x +
+            (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+              (f (x - u) - f x) := by
+          apply intervalIntegral.integral_congr
+          intro u _hu
+          change
+            (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+                f (x - u) =
+              (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f x +
+                (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+                  (f (x - u) - f x)
+          rw [show f (x - u) = f x + (f (x - u) - f x) by abel]
+          rw [smul_add]
+          congr 1
+          abel_nf
+    _ = (∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f x) +
+        ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            (f (x - u) - f x) := by
+          rw [intervalIntegral.integral_add hconst herr]
+    _ = (∫ u in (-R)..R,
+        if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • f x +
+        ∫ u in (-R)..R,
+          (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+            (f (x - u) - f x) := by
+          rw [intervalIntegral.integral_smul_const]
+
+/-- A scalar finite-window Dirichlet mass limit immediately gives the
+corresponding vector-valued mass limit. -/
+theorem tendsto_intervalIntegral_sin_div_kernel_smul_of_scalar_mass
+    (z : E) {R : ℝ}
+    (hmass : Filter.Tendsto
+      (fun T : ℝ =>
+        ∫ u in (-R)..R,
+          if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ))
+      Filter.atTop (nhds (1 : ℂ))) :
+    Filter.Tendsto
+      (fun T : ℝ =>
+        (∫ u in (-R)..R,
+          if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • z)
+      Filter.atTop (nhds z) := by
+  simpa using hmass.smul_const z
+
+/-- Scaling reduces the finite-window mass of `sin (T * u) / (π * u)` to the
+normalized symmetric sine integral at height `T * R`. -/
+theorem intervalIntegral_sin_div_kernel_scalar_mass_eq_scaled (T R : ℝ) :
+    (∫ u in (-R)..R,
+      if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) =
+      (1 / (π : ℂ)) *
+        ∫ v in (T * (-R))..(T * R),
+          if v = 0 then (0 : ℂ) else (Real.sin v / v : ℂ) := by
+  let g : ℝ → ℂ := fun v => if v = 0 then (0 : ℂ) else (Real.sin v / v : ℂ)
+  have hpoint : (fun u : ℝ =>
+      if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) =
+      fun u : ℝ => (1 / (π : ℂ)) * (T • g (T * u)) := by
+    funext u
+    by_cases hT : T = 0
+    · simp [hT, g]
+    by_cases hu : u = 0
+    · simp [hu, g]
+    have hTu : T * u ≠ 0 := mul_ne_zero hT hu
+    simp [g, hu, hTu]
+    field_simp [Real.pi_ne_zero, hT, hu]
+  calc
+    (∫ u in (-R)..R,
+      if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ))
+        = ∫ u in (-R)..R, (1 / (π : ℂ)) * (T • g (T * u)) := by
+          rw [hpoint]
+    _ = (1 / (π : ℂ)) * ∫ u in (-R)..R, T • g (T * u) := by
+          rw [intervalIntegral.integral_const_mul]
+    _ = (1 / (π : ℂ)) * (T • ∫ u in (-R)..R, g (T * u)) := by
+          rw [intervalIntegral.integral_smul]
+    _ = (1 / (π : ℂ)) * ∫ v in (T * (-R))..(T * R), g v := by
+          rw [intervalIntegral.smul_integral_comp_mul_left]
+    _ = (1 / (π : ℂ)) *
+        ∫ v in (T * (-R))..(T * R),
+          if v = 0 then (0 : ℂ) else (Real.sin v / v : ℂ) := by
+          rfl
+
+/-- The sine-over-argument kernel is interval-integrable on finite intervals;
+the value at zero is irrelevant by the removable singularity of `Real.sinc`. -/
+theorem intervalIntegrable_sin_div_kernel (a b : ℝ) :
+    IntervalIntegrable
+      (fun v : ℝ => if v = 0 then (0 : ℂ) else (Real.sin v / v : ℂ))
+      volume a b := by
+  let g : ℝ → ℂ := fun v => (Real.sinc v : ℂ)
+  have hg : IntervalIntegrable g volume a b := by
+    exact (Complex.continuous_ofReal.comp Real.continuous_sinc).intervalIntegrable a b
+  refine hg.congr_ae ?_
+  refine ae_restrict_of_ae ?_
+  filter_upwards [show ∀ᵐ v : ℝ ∂volume, v ≠ 0 by simp [ae_iff, measure_singleton]]
+    with v hv
+  simp [g, Real.sinc_of_ne_zero hv, hv]
+
+/-- The scaled sine kernel is interval-integrable on finite intervals; its value
+at zero is again irrelevant. -/
+theorem intervalIntegrable_scaled_sin_div_kernel (T a b : ℝ) :
+    IntervalIntegrable
+      (fun u : ℝ => if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ))
+      volume a b := by
+  let g : ℝ → ℂ := fun u => (((T / π : ℝ) * Real.sinc (T * u) : ℝ) : ℂ)
+  have hg : IntervalIntegrable g volume a b := by
+    apply Continuous.intervalIntegrable
+    dsimp [g]
+    fun_prop
+  refine hg.congr_ae ?_
+  refine ae_restrict_of_ae ?_
+  filter_upwards [show ∀ᵐ u : ℝ ∂volume, u ≠ 0 by simp [ae_iff, measure_singleton]]
+    with u hu
+  by_cases hT : T = 0
+  · simp [g, hT, hu]
+  · have hTu : T * u ≠ 0 := mul_ne_zero hT hu
+    simp [g, hu, Real.sinc_of_ne_zero hTu]
+    field_simp [Real.pi_ne_zero, hT, hu]
+
+/-- Multiplying the finite sine kernel by a constant vector preserves
+interval-integrability. -/
+theorem intervalIntegrable_sin_div_kernel_smul_const
+    (z : E) (T a b : ℝ) :
+    IntervalIntegrable
+      (fun u : ℝ =>
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) • z)
+      volume a b := by
+  have h := intervalIntegrable_scaled_sin_div_kernel T a b
+  constructor
+  · exact h.1.smul_const z
+  · exact h.2.smul_const z
+
+/-- Windowed bound for finite-height Fourier inversion. The mass term, local
+principal-value window, and far-field tail are separated so applications can
+supply uniform bounds for the first two and use the built-in tail estimate. -/
+theorem norm_fourierInvTrunc_le_of_windowed_sin_div_bounds
+    [CompleteSpace E]
+    {f : ℝ → E} (hf : Integrable f) {x T R B L M : ℝ}
+    (hT : 0 ≤ T) (hR : 0 < R)
+    (hfx : ‖f x‖ ≤ B)
+    (hmass : ‖∫ u in (-R)..R,
+      if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)‖ ≤ M)
+    (herr : IntervalIntegrable
+      (fun u : ℝ =>
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          (f (x - u) - f x)) volume (-R) R)
+    (hlocal : ‖∫ u in (-R)..R,
+        (if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)) •
+          (f (x - u) - f x)‖ ≤ L) :
+    ‖fourierInvTrunc (𝓕 f) x T‖ ≤
+      M * B + L + (1 / (π * R)) * ∫ u : ℝ, ‖f u‖ := by
+  let K : ℝ → ℂ := fun u =>
+    if u = 0 then (0 : ℂ) else (Real.sin (T * u) / (π * u) : ℂ)
+  have hwhole : fourierInvTrunc (𝓕 f) x T = ∫ u : ℝ, K u • f (x - u) := by
+    rw [fourierInvTrunc_fourier_eq_sinc_kernel (E := E) hf x T hT]
+    simpa [K] using normalized_sinc_kernel_integral_comp_sub_left_sin_div_ae (E := E) f x T
+  have hconst : IntervalIntegrable (fun u : ℝ => K u • f x) volume (-R) R := by
+    simpa [K] using intervalIntegrable_sin_div_kernel_smul_const (E := E) (f x) T (-R) R
+  have hsplit := intervalIntegral_sin_div_kernel_split (E := E) f x T R hconst
+    (by simpa [K] using herr)
+  have hwindow_bound : ‖∫ u in (-R)..R, K u • f (x - u)‖ ≤ M * B + L := by
+    calc
+      ‖∫ u in (-R)..R, K u • f (x - u)‖
+          = ‖(∫ u in (-R)..R, K u) • f x +
+              ∫ u in (-R)..R, K u • (f (x - u) - f x)‖ := by
+            rw [show (∫ u in (-R)..R, K u • f (x - u)) =
+                (∫ u in (-R)..R, K u) • f x +
+                ∫ u in (-R)..R, K u • (f (x - u) - f x) by simpa [K] using hsplit]
+      _ ≤ ‖(∫ u in (-R)..R, K u) • f x‖ +
+            ‖∫ u in (-R)..R, K u • (f (x - u) - f x)‖ := norm_add_le _ _
+      _ ≤ M * B + L := by
+        have hM_nonneg : 0 ≤ M := le_trans (norm_nonneg _) hmass
+        have hterm : ‖(∫ u in (-R)..R, K u) • f x‖ ≤ M * B := by
+          rw [norm_smul]
+          exact mul_le_mul (by simpa [K] using hmass) hfx (norm_nonneg _) hM_nonneg
+        have hloc : ‖∫ u in (-R)..R, K u • (f (x - u) - f x)‖ ≤ L := by
+          simpa [K] using hlocal
+        linarith
+  have htail := norm_sin_div_kernel_tail_le_integral_norm (E := E) hf x T hR
+  rw [hwhole]
+  let W : E := ∫ u in (-R)..R, K u • f (x - u)
+  let Tail : E := (∫ u : ℝ, K u • f (x - u)) - W
+  have hdecomp : (∫ u : ℝ, K u • f (x - u)) = W + Tail := by
+    dsimp [W, Tail]
+    abel
+  calc
+    ‖∫ u : ℝ, K u • f (x - u)‖ = ‖W + Tail‖ := by rw [hdecomp]
+    _ ≤ ‖W‖ + ‖Tail‖ := norm_add_le _ _
+    _ ≤ (M * B + L) + (1 / (π * R)) * ∫ u : ℝ, ‖f u‖ := by
+      have hW : ‖W‖ ≤ M * B + L := by simpa [W] using hwindow_bound
+      have hTail : ‖Tail‖ ≤ (1 / (π * R)) * ∫ u : ℝ, ‖f u‖ := by
+        dsimp [Tail, W, K]
+        simpa [K] using htail
+      linarith
+    _ = M * B + L + (1 / (π * R)) * ∫ u : ℝ, ‖f u‖ := by ring


### PR DESCRIPTION
This continues the #1558 split (after #1573, the bilateral-Laplace foundation) by carving the next self-contained slice of `PrimeNumberTheoremAnd/LaplaceInversion.lean`: the principal-value `sin u / u` kernel split and the windowed `sin`-div bound the inversion core rests on.

As with #1573, the source PR #1558 was too large for a PR involving AI generated Lean code. The file is acyclic bottom-up, so each prefix compiles standalone against `upstream/main`; this slice sits directly on the merged foundation and adds nothing below it. This is PR 2 of 5; the remaining three (the `sinc = π/2` evaluation, the windowed-Fourier inversion core, and the cpow inversion payload) follow as separate components.

The slice introduces the kernel-subtraction identity `sin_div_kernel_sub_eq_sin_smul_quotient` and the local-quotient form `local_quotient_eq_dslope`, the `sin`-div kernel integrability and convergence family, the tail-quotient bricks (`norm_tail_quotient_le`, `integrable_tail_quotient_of_integrable`, `tendsto_sin_div_kernel_tail_of_integrable`, `norm_sin_div_kernel_tail_le_integral_norm`), the interval split `intervalIntegral_sin_div_kernel_split`, and closes with the windowed bound `norm_fourierInvTrunc_le_of_windowed_sin_div_bounds`.

Rob

Tags:
AI
