### PR TITLE
feat(FKS2): Corollary 22 theorem

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/FKS2.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2.lean
@@ -4629,28 +4629,6 @@ theorem corollary_22_tail :
     Real.exp_nonneg _
   exact le_trans hmain (by gcongr)
 
-@[blueprint
-  "fks2-corollary-22"
-  (title := "FKS2 Corollary 22")
-  (statement := /--
-  One has
-  \[
-  |\pi(x) - \mathrm{Li}(x)| \leq 9.2211 x \sqrt{\log x} \exp(-0.8476 \sqrt{\log x})
-  \]
-  for all $x \geq 2$.
-  -/)
-  (proof := /-- We fix $R = 1$, $x_0 = 2$, $x_1 = e^{100}$, $A_\theta = 9.2211$, $B = 1.5$ and $C = 0.8476$. By Corollary \ref{fks2-corollary-14}, these are admissible for all $x \geq 2$, so we can apply Theorem \ref{fks2-theorem-3} and calculate that
-  \begin{equation}
-  \mu_{asymp}(40.78\ldots, e^{20000}) \leq 5.01516 \cdot 10^{-5}.
-  \end{equation}
-  This implies that $A_\pi = 121.103$ is admissible for all $x \geq e^{20000}$.
-
-  As in the proof of \cite[Lemmas 5.2 and 5.3]{FKS} one may verify that the numerical results obtainable from Theorem \ref{fks2-theorem-6}, using Corollary \ref{fks2-corollary-8}, may be interpolated as a step function to give a bound on $E_\pi(x)$ of the shape $\varepsilon_{\pi,asymp}(x)$. In this way we obtain that $A_\pi = 121.107$ is admissible for $x > 2$. Note that the subdivisions we use are essentially the same as used in \cite[Lemmas 5.2 and 5.3]{FKS}. In Table 5 we give a sampling of the relevant values, more of the values of $\varepsilon_{\pi,num}(x_1)$ can be found in Table 4. Far more detailed versions of these tables will be posted online in https://arxiv.org/src/2206.12557v1/anc/PrimeCountingTables.pdf.
-  -/)
-  (latexEnv := "corollary")
-  (discussion := 721)]
-theorem corollary_22 : Eπ.classicalBound 9.2211 1.5 0.8476 1 2 := sorry
-
 def table6 : List (List ℝ) := [[0.000120, 0.25, 1.00, 22.955],
                                  [0.826, 0.25, 1.00, 1.000],
                                  [1.41, 0.50, 1.50, 2.000],

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Floor/Cor22Floor.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Floor/Cor22Floor.lean
@@ -112,7 +112,7 @@ theorem cover_cmp :
 the affine cover verifies `0.8 + (5/3) * s^2 ≤ 9.2211 * s^3 * exp (-0.8476 * s)`,
 which rewrites to `4/5 + (5/3) * log x ≤ admissible_bound ... x`. -/
 theorem linear_le_curve {x : ℝ} (hx2 : 2 ≤ x) (hxe : x ≤ exp 10) :
-    4/5 + (5/3) * log x ≤ admissible_bound 9.2211 (3/2) 0.8476 1 x := by
+    4/5 + (5/3) * log x ≤ admissible_bound 9.2211 (3 / 2) 0.8476 1 x := by
   have hlogx_nn : 0 ≤ log x := log_nonneg (by linarith)
   have hlogx_lo : log 2 ≤ log x := log_le_log (by norm_num) hx2
   have hlogx_hi : log x ≤ 10 := by
@@ -156,7 +156,7 @@ theorem linear_le_curve {x : ℝ} (hx2 : 2 ≤ x) (hxe : x ≤ exp 10) :
 ungated — via the Chebyshev θ engine (Eθ bound), eq_30, and the affine-cover
 curve comparison. -/
 theorem corollary_22_floor :
-    ∀ x ∈ Set.Icc (2:ℝ) (exp 10), Eπ x ≤ admissible_bound 9.2211 (3/2) 0.8476 1 x := by
+    ∀ x ∈ Set.Icc (2:ℝ) (exp 10), Eπ x ≤ admissible_bound 9.2211 (3 / 2) 0.8476 1 x := by
   intro x hx
   obtain ⟨hx2, hxe⟩ := hx
   have hxpos : (0:ℝ) < x := by linarith
@@ -193,15 +193,15 @@ theorem corollary_22_floor :
     _ ≤ 4/5 + log x / x * (2 / log 2) * 1
           + log x / x * ((4/5) / (log 2) ^ 2 * (x - 2)) := by gcongr
     _ ≤ 4/5 + (5/3) * log x := by linarith [hbracket]
-    _ ≤ admissible_bound 9.2211 (3/2) 0.8476 1 x := linear_le_curve hx2 hxe
+    _ ≤ admissible_bound 9.2211 (3 / 2) 0.8476 1 x := linear_le_curve hx2 hxe
 
 /-- Full Corollary 22, reduced to the remaining mid-range table-data theorem.
 The small range is `corollary_22_floor`; the asymptotic tail is
 `FKS2.corollary_22_tail`. -/
 theorem corollary_22_of_midrange
     (hmid : ∀ x ∈ Set.Icc (exp 10) (exp 20000),
-      Eπ x ≤ admissible_bound 9.2211 (3/2) 0.8476 1 x) :
-    Eπ.classicalBound 9.2211 (3/2) 0.8476 1 2 := by
+      Eπ x ≤ admissible_bound 9.2211 (3 / 2) 0.8476 1 x) :
+    Eπ.classicalBound 9.2211 (3 / 2) 0.8476 1 2 := by
   intro x hx
   by_cases hsmall : x ≤ exp 10
   · exact corollary_22_floor x ⟨hx, hsmall⟩
@@ -215,7 +215,7 @@ theorem corollary_22_of_midrange
 mid-range, and the asymptotic tail. The remaining trust boundary is
 `Table4Ext.allCells_trusted`, used by `Table4Ext.Epi_le_admissible_on_midrange`. -/
 theorem corollary_22_from_table4Ext :
-    Eπ.classicalBound 9.2211 (3/2) 0.8476 1 2 :=
+    Eπ.classicalBound 9.2211 (3 / 2) 0.8476 1 2 :=
   corollary_22_of_midrange (by
     intro x hx
     have h := Table4Ext.Epi_le_admissible_on_midrange hx
@@ -224,3 +224,26 @@ theorem corollary_22_from_table4Ext :
 
 
 end FKS2.Floor
+
+namespace FKS2
+
+@[blueprint
+  "fks2-corollary-22"
+  (title := "FKS2 Corollary 22")
+  (statement := /--
+  One has
+  \[
+  |\pi(x) - \mathrm{Li}(x)| \leq 9.2211 x \sqrt{\log x} \exp(-0.8476 \sqrt{\log x})
+  \]
+  for all $x \geq 2$.
+  -/)
+  (proof := /-- This is assembled from the certified small range
+  `[2, exp 10]`, the extended Table 4 mid-range `[exp 10, exp 20000]`,
+  and the asymptotic tail from `exp 20000` onward. -/)
+  (latexEnv := "corollary")
+  (discussion := 721)]
+theorem corollary_22 : Eπ.classicalBound 9.2211 1.5 0.8476 1 2 := by
+  simpa [show (1.5 : ℝ) = 3 / 2 by norm_num] using
+    Floor.corollary_22_from_table4Ext
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -3,6 +3,7 @@ import Mathlib.Data.Rat.Cast.OfScientific
 import Mathlib.NumberTheory.Bertrand
 import PrimeNumberTheoremAnd.IEANTN.SecondaryDefinitions
 import PrimeNumberTheoremAnd.IEANTN.FKS2
+import PrimeNumberTheoremAnd.IEANTN.FKS2Floor.Cor22Floor
 import PrimeNumberTheoremAnd.IEANTN.Dusart
 import PrimeNumberTheoremAnd.IEANTN.TMEEMT
 
@@ -339,6 +340,5 @@ theorem theorem_1_4 : Eπ.vinogradovBound 0.028 0.801 0.1853 23 := sorry
 blueprint_comment /-- TODO: input other results from JY -/
 
 end JY
-
 
 


### PR DESCRIPTION
This PR closes the `sorry` in `FKS2.corollary_22` (Corollary 10.9.5), proving

|π(x) − Li(x)| ≤ 9.2211 · x · √(log x) · exp(−0.8476 √(log x))

for all `x ≥ 2`, i.e.

`FKS2.corollary_22 : Eπ.classicalBound 9.2211 1.5 0.8476 1 2`.

PR removes the direct `sorry` from the named Corollary 22 theorem and wires it to the assembled proof. Should #721 remain open pending a derivation of `Table4Ext.allCells_trusted`, or should it be closed at the current trusted-table-data level?


The proof is assembled from three previously established ranges:

* `[2, exp 10]`: `corollary_22_floor`, a fully sorry-free argument using the Chebyshev θ machinery, `eq_30`, and the affine-cover comparison.
* `[exp 10, exp 20000]`: `Table4Ext.Epi_le_admissible_on_midrange`, combining certified cell inequalities, interval chaining, and curve-transport lemmas.
* `[exp 20000, ∞)`: `corollary_22_tail`, obtained from `theorem_3` together with the evaluation `μ_asymp ≤ 5.01516e-5`.

The blueprint declaration is moved from `FKS2.lean` into `FKS2Floor/Cor22Floor.lean`, where the assembly theorem lives. The final theorem is obtained by applying `Floor.corollary_22_from_table4Ext` and rewriting `1.5` as `3/2`.

`#print axioms FKS2.corollary_22` still reports two `sorryAx` sources, both pre-existing boundaries rather than new assumptions in this PR:

  * `Table4Ext.allCells_trusted`: the per-row bounds `Eπ x ≤ ε(eᵇ)` from the FKS2 extended ancillary Table 4. This is the trusted table-data boundary introduced in #1563.
  * `FKS2.corollary_14`: the upstream `Eθ` classical bound feeding the tail; this belongs to #672.
