### PR TITLE
chore: Fix warnings

### DIFF
--- a/PrimeNumberTheoremAnd/Consequences.lean
+++ b/PrimeNumberTheoremAnd/Consequences.lean
@@ -110,7 +110,7 @@ theorem WeakPNT'' : ψ ~[atTop] (fun x ↦ x) := by
       · convert! Tendsto.comp WeakPNT' tendsto_nat_floor_atTop
         infer_instance
       rw [eventually_iff]
-      simp only [ne_eq, cast_eq_zero, floor_eq_zero, not_lt, mem_atTop_sets, ge_iff_le,
+      simp only [ne_eq, cast_eq_zero, floor_eq_zero, not_lt, mem_atTop_sets,
         Set.mem_setOf_eq]
       use 1
       simp only [imp_self, implies_true]
@@ -118,7 +118,7 @@ theorem WeakPNT'' : ψ ~[atTop] (fun x ↦ x) := by
     rw [← isLittleO_neg_left]
     apply IsLittleO.of_bound
     intro ε hε
-    simp only [Pi.sub_apply, neg_sub, norm_eq_abs, eventually_atTop, ge_iff_le]
+    simp only [Pi.sub_apply, neg_sub, norm_eq_abs, eventually_atTop]
     use ε⁻¹
     intro b hb
     have hb' : 0 ≤ b := le_of_lt (lt_of_lt_of_le (inv_pos_of_pos hε) hb)
@@ -177,7 +177,7 @@ lemma Icc_zero_eq_insert (n : ℕ) : Icc 0 n = insert 0 (Icc 1 n) := by
 theorem chebyshev_asymptotic : θ ~[atTop] id := by
   refine WeakPNT''.add_isLittleO'' (IsBigO.trans_isLittleO (g := fun x ↦ 2 * x.sqrt * x.log) ?_ ?_)
   · rw [isBigO_iff']; refine ⟨1, one_pos, ?_⟩
-    simp only [one_mul, eventually_atTop, ge_iff_le]
+    simp only [one_mul, eventually_atTop]
     exact ⟨2, fun x hx ↦ by
       rw [Pi.sub_apply, norm_eq_abs, norm_eq_abs, abs_of_nonneg (by bound : 0 ≤ 2 * √x * log x)]
       exact (abs_of_nonneg (sub_nonneg.mpr (Chebyshev.theta_le_psi x))).symm ▸
@@ -239,7 +239,7 @@ theorem chebyshev_asymptotic' :
   · rw [isLittleO_iff]
     intro c hc
     specialize @H (c * ε) (mul_pos hc hε)
-    simp only [Pi.sub_apply, norm_eq_abs, mul_assoc, eventually_atTop, ge_iff_le, norm_mul,
+    simp only [Pi.sub_apply, norm_eq_abs, mul_assoc, eventually_atTop, norm_mul,
       abs_of_pos hε, f] at H ⊢
     exact H
   refine fun r => by simp [f]
@@ -251,7 +251,7 @@ theorem chebyshev_asymptotic'' :
       ∀ x > (0 : ℝ), θ x = x + x * (f x) := by
   obtain ⟨f, hf1, inte, hf2⟩ := chebyshev_asymptotic'
   refine ⟨fun t => f t / t, fun ε hε ↦ ?_, ?_, ?_⟩
-  · simp only [isLittleO_iff, norm_eq_abs, norm_mul, eventually_atTop, ge_iff_le,
+  · simp only [isLittleO_iff, norm_eq_abs, norm_mul, eventually_atTop,
       norm_div] at hf1 ⊢
     intro r hr
     replace hf1 := hf1 ε hε
@@ -1011,7 +1011,7 @@ theorem pn_pn_plus_one : ∃ c : ℕ → ℝ, c =o[atTop] (fun _ ↦ (1 : ℝ)) 
     rw [Filter.tendsto_congr' (f₂ := fun n ↦
         ((1 + k (n+1))*(n+1)*log (n+1) - (1 + k n)*n*log n) / ((1 + k n)*n*log n))]
     swap
-    · simp only [EventuallyEq, eventually_atTop, ge_iff_le]
+    · simp only [EventuallyEq, eventually_atTop]
       use 2; intro n hn
       rw [p_n_eq n (by linarith), p_n_eq (n+1) (by linarith)]
       grind
@@ -1127,8 +1127,7 @@ theorem pn_pn_plus_one : ∃ c : ℕ → ℝ, c =o[atTop] (fun _ ↦ (1 : ℝ)) 
         rw [Asymptotics.isLittleO_iff_tendsto] at k_o1
         · rw [NormedAddGroup.tendsto_nhds_zero] at k_o1
           specialize k_o1 ((1 : ℝ) / 2)
-          simp only [one_div, gt_iff_lt, inv_pos, ofNat_pos, div_one, norm_eq_abs, eventually_atTop,
-            ge_iff_le, forall_const] at k_o1
+          simp only [one_div, gt_iff_lt, inv_pos, ofNat_pos, div_one, norm_eq_abs, eventually_atTop, forall_const] at k_o1
           obtain ⟨a, ha⟩ := k_o1
           use (a + 3)
           refine ⟨by simp, ?_⟩
@@ -1208,7 +1207,7 @@ lemma bound_f_second_term (f : ℝ → ℝ) (hf : Tendsto f atTop (nhds 0)) (δ 
       linarith
 
   have f_small := NormedAddGroup.tendsto_nhds_zero.mp hf δ hδ
-  simp only [norm_eq_abs, eventually_atTop, ge_iff_le] at f_small
+  simp only [norm_eq_abs, eventually_atTop] at f_small
   obtain ⟨p, hp⟩ := f_small
 
   let a := ((max 1 p) : ℝ)
@@ -1239,7 +1238,7 @@ lemma bound_f_first_term {ε : ℝ} (hε : 0 < ε) (f : ℝ → ℝ)
       linarith
 
   have f_small := NormedAddGroup.tendsto_nhds_zero.mp hf δ hδ
-  simp only [norm_eq_abs, eventually_atTop, ge_iff_le] at f_small
+  simp only [norm_eq_abs, eventually_atTop] at f_small
   obtain ⟨p, hp⟩ := f_small
 
   let a := ((max 1 p) : ℝ)
@@ -1266,7 +1265,7 @@ lemma bound_f_first_term {ε : ℝ} (hε : 0 < ε) (f : ℝ → ℝ)
     linarith
 
   have mul_increase: a ≤ (1 + ε) * b := by
-    simp only [ge_iff_le, a] at hb
+    simp only [ a] at hb
     have a_le := pos_mul a b (1 + ε) a_pos (by linarith) (by linarith) (by linarith)
     linarith
 
@@ -1277,9 +1276,9 @@ lemma smaller_terms {ε : ℝ} (hε : 0 < ε) (f : ℝ → ℝ) (hf : Tendsto f 
     ∀ᶠ x : ℝ in atTop, (1 - δ) * ((1 + ε) * x / (Real.log ((1 + ε) * x))) <
       (1 + f ((1 + ε) * x)) * ((1 + ε) * x / (Real.log ((1 + ε) * x))) := by
   have first_term := bound_f_first_term hε f hf δ hδ
-  simp only [gt_iff_lt, eventually_atTop, ge_iff_le] at first_term
+  simp only [gt_iff_lt, eventually_atTop] at first_term
   obtain ⟨p, hp⟩ := first_term
-  simp only [eventually_atTop, ge_iff_le]
+  simp only [eventually_atTop]
   let a := max p 1
   have ha: ∀ (b : ℝ), a ≤ b → 1 - δ < 1 + f ((1 + ε) * b) := by
     intro b hb
@@ -1306,9 +1305,9 @@ lemma second_smaller_terms (f : ℝ → ℝ) (hf : Tendsto f atTop (nhds 0)) (δ
       (1 + δ) * (x / Real.log x) > (1 + f x) * (x / Real.log x) := by
   have first_term := bound_f_second_term f hf δ hδ
 
-  simp only [_root_.add_lt_add_iff_left, eventually_atTop, ge_iff_le] at first_term
+  simp only [_root_.add_lt_add_iff_left, eventually_atTop] at first_term
   obtain ⟨p, hp⟩ := first_term
-  simp only [gt_iff_lt, eventually_atTop, ge_iff_le]
+  simp only [gt_iff_lt, eventually_atTop]
   let a := max p 2
   have ha: ∀ (b : ℝ), a ≤ b → 1 + δ > 1 + f ( b) := by
     intro b hb
@@ -1341,7 +1340,7 @@ lemma x_log_x_atTop : Filter.Tendsto (fun x => x / Real.log x) Filter.atTop Filt
     · have log_div_x := Real.tendsto_pow_log_div_mul_add_atTop 1 0 1 (by simp)
       simp only [pow_one, one_mul, add_zero] at log_div_x
       exact log_div_x
-    · simp only [Set.mem_Ioi, eventually_atTop, ge_iff_le]
+    · simp only [Set.mem_Ioi, eventually_atTop]
       use 2
       intro x hx
       have log_pos: 0 < Real.log x := by
@@ -1375,8 +1374,8 @@ lemma tendsto_by_squeeze (ε : ℝ) (hε : ε > 0) :
     )
   · rw [Filter.EventuallyLE]
 
-    simp only [eventually_atTop, ge_iff_le] at first_helper
-    simp only [gt_iff_lt, eventually_atTop, ge_iff_le] at second_helper
+    simp only [eventually_atTop] at first_helper
+    simp only [gt_iff_lt, eventually_atTop] at second_helper
 
     obtain ⟨a1, ha1⟩ := first_helper
     obtain ⟨a2, ha2⟩ := second_helper
@@ -1392,7 +1391,7 @@ lemma tendsto_by_squeeze (ε : ℝ) (hε : ε > 0) :
       linarith
 
     apply lt_compare
-    simp only [ge_iff_le, sup_le_iff] at hb
+    simp only [ sup_le_iff] at hb
     specialize ha1 b hb.1
     specialize ha2 b hb.2
     field_simp
@@ -1556,7 +1555,7 @@ theorem prime_between {ε : ℝ} (hε : 0 < ε) :
   have squeeze := tendsto_by_squeeze (ε/2) (by linarith)
   rw [Filter.tendsto_iff_forall_eventually_mem] at squeeze
   specialize squeeze (Set.Ici 1) (by exact Ici_mem_atTop 1)
-  simp only [Set.mem_Ici, eventually_atTop, ge_iff_le] at squeeze
+  simp only [Set.mem_Ici, eventually_atTop] at squeeze
   obtain ⟨a, ha⟩ := squeeze
   rw [eventually_atTop]
   use (max a 1)

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW.lean
@@ -1663,7 +1663,7 @@ private lemma exp_half_mem_Icc_of_exp_mem (k : ℕ) (v b : ℝ)
   have hexpb_ge_e2k : exp (2 * (k : ℝ)) ≤ exp b := le_of_max_le_right hb_lb
   have hbk : b ≥ 2 * (k : ℝ) := by
     have := Real.exp_le_exp.mp hexpb_ge_e2k
-    push_cast at this ⊢; linarith
+    linarith
   have hu_ge_100 : (100 : ℝ) ≤ u := by
     dsimp [u]
     rw [← Real.exp_log (by norm_num : (0:ℝ) < 100)]

--- a/PrimeNumberTheoremAnd/IEANTN/CH2/CH2.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/CH2/CH2.lean
@@ -2719,7 +2719,7 @@ theorem norm_Phi_lambda_one_add_I_mul_le_of_neg (lam ε y : ℝ) (hlam : lam < 0
     rw [show -(1 + I * ↑y) = -1 - I * ↑y by ring]
     rw [show Phi_circ |lam| ε (-1 - I * ↑y) + -Phi_star |lam| ε (-1 - I * ↑y) =
         Phi_circ |lam| ε (-1 - I * ↑y) - Phi_star |lam| ε (-1 - I * ↑y) by ring]
-    convert shift_downwards_phi_diff |lam| ε hν y hpole using 2
+    convert shift_downwards_phi_diff |lam| ε hν y hpole using 3
     ring
   rw [hphi, norm_neg]
   exact (norm_Phi_star_neg_I_mul_le |lam| ε y hε).trans_eq (abs_of_nonneg hy)
@@ -3090,7 +3090,7 @@ private lemma isBoundedNoPolesOn_Phi_lambda_mul (l : LadderParams) {F : ℂ → 
       have h := (hMwh z hz).1
       change ‖l.zOf z * F z * (x₀ : ℂ) ^ z‖ ≤ Mwh at h
       rwa [mul_assoc, norm_mul] at h
-    show ‖Phi_lambda lam ε (l.zOf z) * F z * (x₀ : ℂ) ^ z‖ ≤ |Cl| * Mwh + |Cl| * Mh
+    change ‖Phi_lambda lam ε (l.zOf z) * F z * (x₀ : ℂ) ^ z‖ ≤ |Cl| * Mwh + |Cl| * Mh
     rw [mul_assoc]
     exact norm_mul_le_of_linear_growth (hCl (l.zOf z) (l.zOf_im_nonneg (hS hz).1))
       (hMh z hz).1 hwh_z

--- a/PrimeNumberTheoremAnd/IEANTN/CH2/CH2_part1.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/CH2/CH2_part1.lean
@@ -356,7 +356,7 @@ private lemma prop_2_3_fourier_integral_ici_eq
       rw [show (∫ v in Set.Ici (-log x / (2 * π)), (T : ℂ) * 𝓕 φ (T * v)) =
           (T : ℂ) * ∫ v in Set.Ici (-log x / (2 * π)), 𝓕 φ (T * v) from
         MeasureTheory.integral_const_mul _ _, setIntegral_Ici_const_mul hT]
-      congr 2; ring
+      congr 4; ring
     _ = (2 * π : ℂ) * ((∫ y, 𝓕 φ y) - ∫ y in Set.Iic (-T * log x / (2 * π)), 𝓕 φ y) := by
       congr 1
       rw [← MeasureTheory.setIntegral_univ, MeasureTheory.setIntegral_univ]

--- a/PrimeNumberTheoremAnd/IEANTN/Erdos392.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Erdos392.lean
@@ -3157,7 +3157,6 @@ theorem Solution_2 (ε : ℝ) (hε : ε > 0) :
     exact (pairProd_prod f.a.toList).symm
   · have ht_bound : ((pairProd f.a.toList).length : ℝ) ≤
         n / 2 - n / (2 * Real.log n) + ε * n / Real.log n := by
-      change ((pairProd f.a.toList).length : ℝ) ≤ _
       rw [pairProd_length f.a.toList, length_toList f.a]
       calc (((f.a.card + 1) / 2 : ℕ) : ℝ) ≤ (f.a.card + 1 : ℕ) / 2 := cast_div_le
         _ = (f.a.card : ℝ) / 2 + 1 / 2 := by simp only [cast_add, cast_one]; ring

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2.lean
@@ -314,7 +314,7 @@ lemma dawson_eq_integral (z : ℝ) :
   rw [hsub, ← intervalIntegral.integral_const_mul]
   apply intervalIntegral.integral_congr
   intro u _
-  show exp (-z ^ 2) * exp ((z - u) ^ 2) = exp (u ^ 2 - 2 * z * u)
+  change exp (-z ^ 2) * exp ((z - u) ^ 2) = exp (u ^ 2 - 2 * z * u)
   rw [← Real.exp_add]
   congr 1
   ring
@@ -3750,17 +3750,17 @@ private lemma exists_Eθ_pos {x₁ : ℝ} : ∃ x, x₁ ≤ x ∧ Eθ x > 0 := b
   have hθ_eq : theta a = theta b := by
     unfold theta;
     rw [ show ⌊a⌋₊ = N from ?_, show ⌊b⌋₊ = N from ?_ ];
-    · rw [ Nat.floor_eq_iff ] ; ring;
+    · rw [ Nat.floor_eq_iff ]
       · grind;
       · positivity;
     · exact Nat.floor_natCast _;
   by_cases ha : theta a = a;
-  · refine' ⟨ b, _, _ ⟩;
+  · refine ⟨ b, ?_, ?_ ⟩;
     · simp +zetaDelta at *;
       linarith [ Nat.lt_floor_add_one x₁ ];
-    · refine' div_pos ( abs_pos.mpr _ ) ( by positivity );
+    · refine div_pos ( abs_pos.mpr ?_ ) ( by positivity );
       grind +qlia;
-  · refine' ⟨ a, _, _ ⟩ <;> norm_num [ Eθ ];
+  · refine ⟨ a, ?_, ?_ ⟩ <;> norm_num [ Eθ ];
     · exact le_of_lt ( Nat.lt_of_floor_lt ( Nat.lt_succ_self _ ) );
     · exact div_pos ( abs_pos.mpr ( sub_ne_zero.mpr ha ) ) ( Nat.cast_pos.mpr ( Nat.succ_pos _ ) )
 
@@ -3801,16 +3801,18 @@ theorem theorem_6 {x₀ x₁ : ℝ} (x₂ : EReal) (h : x₁ ≥ max x₀ 14)
       · exact le_trans ( Real.exp_one_lt_d9.le ) ( by norm_num; linarith [ le_max_right x₀ 14 ] );
       · linarith;
     refine le_trans h_key ?_;
-    refine' add_le_add ( add_le_add ( add_le_add h_bound _ ) _ ) _;
+    refine add_le_add ( add_le_add ( add_le_add h_bound ?_ ) ?_ ) ?_;
     · convert mul_le_mul_of_nonneg_right ( mul_le_mul_of_nonneg_right h_log_div_self_antitone ( show 0 ≤ x₀ / log x₀ by exact div_nonneg ( by linarith ) ( Real.log_nonneg ( by linarith ) ) ) ) ( show 0 ≤ δ x₀ by exact delta_nonneg x₀ ) using 1 ; ring;
     · gcongr;
-      · refine' intervalIntegral.integral_nonneg _ _ <;> norm_num;
+      · refine intervalIntegral.integral_nonneg ?_ ?_ <;> norm_num;
         · linarith [ le_max_left x₀ 14, le_max_right x₀ 14 ];
         · exact fun u hu₁ hu₂ => div_nonneg ( Eθ_nonneg u ( by linarith ) ) ( sq_nonneg _ );
       · exact div_nonneg ( Real.log_nonneg ( by linarith [ le_max_right x₀ 14 ] ) ) ( by linarith [ le_max_right x₀ 14 ] );
     · convert mul_le_mul_of_nonneg_left h_bound_integral_last ( show 0 ≤ log x / x by exact div_nonneg ( Real.log_nonneg ( by linarith [ le_max_left x₀ 14, le_max_right x₀ 14 ] ) ) ( by linarith [ le_max_left x₀ 14, le_max_right x₀ 14 ] ) ) using 1 ; ring;
-  by_cases hc : x₂ ≤ Real.toEReal ( x₁ * Real.log x₁ ) <;> simp_all +decide [ επ_num, μ_num ];
-  · have h63 := theorem_6_3 ( by linarith : 14 ≤ x₁ ) x₂.toReal ( by
+  by_cases hc : x₂ ≤ Real.toEReal ( x₁ * Real.log x₁ )
+  · simp_all +decide only [ge_iff_le, sup_le_iff, Fin.Iio_last_eq_map, Finset.sum_map,
+    Fin.coe_castSuccEmb, Fin.coeSucc_eq_succ, one_div, EReal.coe_mul, επ_num, μ_num, ↓reduceIte]
+    have h63 := theorem_6_3 ( by linarith : 14 ≤ x₁ ) x₂.toReal ( by
       cases x₂ <;> norm_num at *;
       · linarith;
       · exact absurd hc ( by exact ne_of_lt ( EReal.coe_lt_top _ ) ) ) x hx₁ ( by
@@ -3821,19 +3823,31 @@ theorem theorem_6 {x₀ x₁ : ℝ} (x₂ : EReal) (h : x₁ ≥ max x₀ 14)
       · exact_mod_cast hc;
       · exact mul_nonneg ( by linarith ) ( Real.log_nonneg ( by linarith ) ) );
     unfold μ_num_1; ring_nf at *;
-    by_cases h : εθ_num x₁ = 0 <;> simp_all +decide [ mul_assoc, mul_comm, mul_left_comm ];
-    · have := exists_Eθ_pos ( x₁ := x₁ ) ; obtain ⟨ y, hy₁, hy₂ ⟩ := this; have := h_εθ_num ( Fin.last N ) ; simp_all +decide [ Real.exp_log ( by linarith : 0 < x₁ ) ] ;
+    by_cases h : εθ_num x₁ = 0
+    · simp_all +decide only [mul_comm, inv_pow, mul_assoc, mul_left_comm, zero_mul, mul_zero,
+      add_zero, zero_add, Finset.sum_sub_distrib, inv_zero, Fin.Iio_last_eq_map, Finset.sum_map,
+      Fin.coe_castSuccEmb, Fin.coeSucc_eq_succ, sub_self, ge_iff_le];
+      have := exists_Eθ_pos ( x₁ := x₁ ) ; obtain ⟨ y, hy₁, hy₂ ⟩ := this; have := h_εθ_num ( Fin.last N ) ;
+      simp_all +decide only [gt_iff_lt, Real.exp_log (by linarith : 0 < x₁), ge_iff_le] ;
       exact absurd ( this y hy₁ ) ( by norm_num [ h ] ; linarith );
-    · nlinarith [ show 0 < εθ_num x₁ from lt_of_le_of_ne ( by
+    · simp_all +decide [ mul_assoc, mul_comm, mul_left_comm ]
+      nlinarith [ show 0 < εθ_num x₁ from lt_of_le_of_ne ( by
                     have := h_εθ_num ( Fin.last N );
                     rw [ h_b_end, Real.exp_log ( by linarith ) ] at this; exact le_trans ( Eθ_nonneg _ ( by linarith ) ) ( this _ le_rfl ) ; ) ( Ne.symm h ) ];
-  · have h62 := theorem_6_2 ( by linarith : 14 ≤ x₁ ) x hx₁ ; simp_all +decide [ μ_num_2 ];
+  · simp_all +decide only [ge_iff_le, sup_le_iff, Fin.Iio_last_eq_map, Finset.sum_map,
+    Fin.coe_castSuccEmb, Fin.coeSucc_eq_succ, one_div, EReal.coe_mul, not_le, επ_num, μ_num]
+    have h62 := theorem_6_2 ( by linarith : 14 ≤ x₁ ) x hx₁
+    simp_all +decide only [one_div, μ_num_2, Fin.Iio_last_eq_map, Finset.sum_map,
+      Fin.coe_castSuccEmb, Fin.coeSucc_eq_succ, ge_iff_le];
     have hεθpos : 0 < εθ_num x₁ := by
       have := exists_Eθ_pos ( x₁ := x₁ ) ; obtain ⟨ y, hy₁, hy₂ ⟩ := this; have := h_εθ_num ( Fin.last N ) y; simp_all +decide [ Real.exp_log ( by linarith : 0 < x₁ ) ] ;
       linarith;
-    split_ifs <;> simp_all +decide [ mul_add, mul_assoc, mul_comm, mul_left_comm, div_eq_mul_inv ];
-    · exact absurd ‹_› ( not_le_of_gt hc );
-    · norm_num [ mul_left_comm ( εθ_num x₁ ), mul_assoc, hεθpos.ne' ];
+    split_ifs
+    · simp_all +decide only [div_eq_mul_inv, mul_inv_rev, mul_comm, mul_left_comm, mul_assoc,
+      mul_add, mul_one, ge_iff_le];
+      exact absurd ‹_› ( not_le_of_gt hc );
+    · simp_all +decide [ mul_add, mul_assoc, mul_comm, mul_left_comm, div_eq_mul_inv ];
+      norm_num [ mul_left_comm ( εθ_num x₁ ), mul_assoc, hεθpos.ne' ];
       nlinarith [ show 0 ≤ εθ_num x₁ by positivity ]
 
 @[blueprint

--- a/PrimeNumberTheoremAnd/IEANTN/KadiriZeroCounting.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/KadiriZeroCounting.lean
@@ -2058,7 +2058,7 @@ theorem weighted_cumulative_count_le (k : ℕ) :
     · have h1 : |(x.1 : ℂ).im| < (2 : ℝ) ^ (k + 1) := x.property
       rw [abs_of_neg hx2] at h1
       simpa [Complex.conj_im] using h1
-    · show riemannZeta ((starRingEnd ℂ) (x.1 : ℂ)) = 0
+    · change riemannZeta ((starRingEnd ℂ) (x.1 : ℂ)) = 0
       rw [riemannZeta_conj, x.1.property.2.2, map_zero]
   have hzero : (∑ x ∈ ((Finset.univ : Finset {ρ : NontrivialZeros // |(ρ : ℂ).im| < (2 : ℝ) ^ (k + 1)}).filter (fun x : {ρ : NontrivialZeros // |(ρ : ℂ).im| < (2 : ℝ) ^ (k + 1)} ↦ ¬ 0 < (x.1 : ℂ).im)).filter (fun x : {ρ : NontrivialZeros // |(ρ : ℂ).im| < (2 : ℝ) ^ (k + 1)} ↦ ¬ (x.1 : ℂ).im < 0),
       ((riemannZeta.order ((x : NontrivialZeros) : ℂ) : ℤ) : ℝ)) ≤

--- a/PrimeNumberTheoremAnd/IEANTN/Mertens.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Mertens.lean
@@ -599,7 +599,7 @@ theorem E₁Λ.bounded' : ∃ c > 0, ∀ x ≥ 1, |E₁Λ x| ≤ c := by
   (discussion := 1309)]
 theorem E₁Λ.bounded : E₁Λ =O[atTop] (fun _ ↦ (1:ℝ)) := by
   simp only [isBigO_iff, norm_eq_abs, norm_one, mul_one,
-    eventually_atTop, ge_iff_le]
+    eventually_atTop]
   exact ⟨log 4 + 4, 1, fun _ hx ↦ sum_mangoldt_div_eq_log hx⟩
 
 theorem one_eq_o_log : (fun _ ↦ (1:ℝ)) =o[atTop] (fun x ↦ log x) := by
@@ -901,7 +901,7 @@ theorem E₁p.bounded : ∃ c > 0, ∀ x ≥ 1, |E₁p x| ≤ c := by
   "Mertens-first-theorem-prime-bounded"]
 theorem sum_log_prime_div_eq_log' : E₁p =O[atTop] (fun _ ↦ (1:ℝ)) := by
     simp only [isBigO_iff, norm_eq_abs, one_mem, CStarRing.norm_of_mem_unitary, mul_one,
-      eventually_atTop, ge_iff_le, E₁p]
+      eventually_atTop, E₁p]
     exact ⟨ log 4 + 4, 1, fun _ ↦ sum_log_prime_div_eq_log ⟩
 
 @[blueprint
@@ -1999,7 +1999,7 @@ theorem sum_mangoldt_div_log_eq_log_log : ∃ C, ∀ x, 2 ≤ x →
   "Mertens-second-theorem-mangoldt-weak"]
 theorem sum_mangoldt_div_log_eq_log_log' : (fun x ↦ ∑ d ∈ Ioc 0 ⌊ x ⌋₊, (Λ d) / (d * log d) - log (log x)) =O[atTop] (fun _ ↦ (1:ℝ)) := by
     simp only [isBigO_iff, norm_eq_abs, one_mem, CStarRing.norm_of_mem_unitary, mul_one,
-      eventually_atTop, ge_iff_le]
+      eventually_atTop]
     obtain ⟨ C, _ ⟩ := sum_mangoldt_div_log_eq_log_log
     use C, 2
 
@@ -2150,7 +2150,7 @@ theorem E₂p.abs_le {x : ℝ} (hx : 2 ≤ x) :
 @[blueprint
   "Mertens-second-error-prime-abs-le"]
 theorem E₂p.bound : E₂p =O[atTop] (fun x ↦ 1 / log x) := by
-    simp only [one_div, isBigO_iff, norm_eq_abs, norm_inv, eventually_atTop, ge_iff_le]
+    simp only [one_div, isBigO_iff, norm_eq_abs, norm_inv, eventually_atTop]
     use log 4 + 6 + E₁, 2
     intro x hx
     convert E₂p.abs_le hx using 1
@@ -2187,7 +2187,7 @@ theorem sum_prime_div_eq_log_log : ∃ C, ∀ x, 2 ≤ x →
   "Mertens-second-theorem-prime-weak"]
 theorem sum_prime_div_eq_log_log' : (fun x ↦ ∑ p ∈ Ioc 0 ⌊x⌋₊ with p.Prime, (1:ℝ) / p - log (log x)) =O[atTop] (fun _ ↦ (1:ℝ)) := by
     simp only [isBigO_iff, norm_eq_abs, one_mem, CStarRing.norm_of_mem_unitary, mul_one,
-      eventually_atTop, ge_iff_le]
+      eventually_atTop]
     obtain ⟨ C, hC ⟩ := sum_prime_div_eq_log_log
     use C, 2
 
@@ -2449,7 +2449,7 @@ theorem E₃.abs_le : ∃ C, ∀ x, 2 ≤ x → |E₃ x| ≤ C / log x := by
 @[blueprint
   "Mertens-third-theorem-error-le"]
 theorem E₃.bound : E₃ =O[atTop] (fun x ↦ 1 / log x) := by
-    simp only [isBigO_iff, norm_eq_abs, eventually_atTop, ge_iff_le]
+    simp only [isBigO_iff, norm_eq_abs, eventually_atTop]
     obtain ⟨ C, hC ⟩ := E₃.abs_le
     use C, 2
     convert hC using 3 with x hx
@@ -2467,7 +2467,7 @@ theorem E₃.bound'' : (fun x ↦ ∏ p ∈ Ioc 0 ⌊ x ⌋₊ with p.Prime, (1 
    rw [isEquivalent_iff_tendsto_one]
    · convert Tendsto.congr' ?_ (Tendsto.rexp ((isLittleO_one_iff ℝ).mp E₃.bound')) using 2 with x
      · simp
-     simp only [EventuallyEq.iff_eventually, Pi.div_apply, eventually_atTop, ge_iff_le]; use 2; intro x hx
+     simp only [EventuallyEq.iff_eventually, Pi.div_apply, eventually_atTop]; use 2; intro x hx
      rw [prod_one_minus_div_prime_eq (by linarith)]
      have : 0 < log x := by apply log_pos; linarith
      field_simp

--- a/PrimeNumberTheoremAnd/IEANTN/ZetaAppendix.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/ZetaAppendix.lean
@@ -744,7 +744,7 @@ theorem bernsteinApproximation_monotone (n : ℕ) (f : C(I, ℝ)) (hf : Monotone
     Monotone (bernsteinApproximation n f) := by
   intro x y hxy
   simp only [bernsteinApproximation, smul_eq_mul, ContinuousMap.coe_sum, ContinuousMap.coe_mul,
-    ContinuousMap.coe_const, _root_.sum_apply, Pi.mul_apply, Function.const_apply]
+    ContinuousMap.coe_const]
   have hmono : ∀ i j : Fin (n + 1), i ≤ j → f (bernstein.z i) ≤ f (bernstein.z j) :=
     fun i j hij ↦ hf <| Subtype.mk_le_mk.mpr <| by simpa [bernstein.z] using by gcongr; aesop
   have hsum : ∑ i : Fin (n + 1), ∑ j : Fin (n + 1),
@@ -821,7 +821,7 @@ theorem bernsteinApproximation_monotone (n : ℕ) (f : C(I, ℝ)) (hf : Monotone
     one_mul, sub_neg]
   simp_all only [← mul_assoc, ← sum_comm, ← sum_mul, ← Finset.mul_sum _ _ _, bernstein.probability,
     mul_one]
-  simp only [ContinuousMap.coe_sum, ContinuousMap.coe_mul, ContinuousMap.coe_const,
+  simp only [
     Finset.sum_apply, Pi.mul_apply, Function.const_apply, mul_comm] at hsum
   linarith
 

--- a/PrimeNumberTheoremAnd/IEANTN/ZetaAppendix.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/ZetaAppendix.lean
@@ -2569,7 +2569,8 @@ lemma cosine_integral_by_parts_cpow {a b : ℝ} (ha : 0 < a) (hab : a < b)
         simpa [u, Set.uIcc_of_le hab.le] using
           (Complex.continuousOn_ofReal_cpow (r := -s) (a := a) (b := b) ha))
       (by
-        simp [v, Set.uIcc_of_le hab.le]
+        simp only [ofReal_sin, ofReal_mul, ofReal_ofNat, ofReal_add, ofReal_natCast, ofReal_one,
+          Set.uIcc_of_le hab.le, v]
         fun_prop)
       (by
         intro x hx
@@ -2591,7 +2592,8 @@ lemma cosine_integral_by_parts_cpow {a b : ℝ} (ha : 0 < a) (hab : a < b)
         exact hcont.intervalIntegrable)
       (by
         apply ContinuousOn.intervalIntegrable
-        simp [v', Set.uIcc_of_le hab.le]
+        simp only [ofReal_cos, ofReal_mul, ofReal_ofNat, ofReal_add, ofReal_natCast, ofReal_one,
+          Set.uIcc_of_le hab.le, v']
         fun_prop)
   have h_lhs :
       ∫ y in a..b, u y * v' y =
@@ -2809,7 +2811,8 @@ lemma deriv_kernel_integral_by_parts_cpow {a b : ℝ} (ha : 0 < a) (hab : a < b)
         simpa [u, Set.uIcc_of_le hab.le] using
           (Complex.continuousOn_deriv_ofReal_cpow_neg (s := s) (a := a) (b := b) ha))
       (by
-        simp [v, Set.uIcc_of_le hab.le]
+        simp only [ofReal_cos, ofReal_mul, ofReal_ofNat, ofReal_add, ofReal_natCast, ofReal_one,
+          Set.uIcc_of_le hab.le, v]
         fun_prop)
       (by
         intro x hx
@@ -2825,7 +2828,8 @@ lemma deriv_kernel_integral_by_parts_cpow {a b : ℝ} (ha : 0 < a) (hab : a < b)
         exact hcont.intervalIntegrable)
       (by
         apply ContinuousOn.intervalIntegrable
-        simp [v', Set.uIcc_of_le hab.le]
+        simp only [ofReal_sin, ofReal_mul, ofReal_ofNat, ofReal_add, ofReal_natCast, ofReal_one,
+          Set.uIcc_of_le hab.le, v']
         fun_prop)
   simpa [u, v, u', v'] using h_ibp
 
@@ -2955,7 +2959,7 @@ lemma hasSum_second_ibp_integral_series {a b : ℝ} (ha : 0 < a) (hab : a < b)
     refine ContinuousOn.aestronglyMeasurable_of_subset_isCompact ?_
       isCompact_uIcc measurableSet_uIoc Set.uIoc_subset_uIcc
     refine hH_cont.mul ?_
-    simp [W]
+    simp only [ofReal_cos, ofReal_mul, ofReal_ofNat, ofReal_add, ofReal_natCast, ofReal_one, W]
     fun_prop
   · intro n
     filter_upwards with y hy
@@ -3061,7 +3065,8 @@ lemma continuous_bernoulli2_primitive :
         (((-(Int.fract y ^ 2 - Int.fract y + 1 / 6) / 2) : ℝ) : ℂ)) := by
   let p : ℝ → ℂ := fun x ↦ (((-(x ^ 2 - x + 1 / 6) / 2) : ℝ) : ℂ)
   have hp_cont : ContinuousOn p (Set.Icc (0 : ℝ) 1) := by
-    simp [p]
+    simp only [one_div, neg_add_rev, neg_sub, ofReal_div, ofReal_add, ofReal_neg, ofReal_inv,
+      ofReal_ofNat, ofReal_sub, ofReal_pow, p]
     fun_prop
   have hp_end : p 0 = p 1 := by
     norm_num [p]
@@ -3076,7 +3081,7 @@ lemma intervalIntegrable_B1_complex {a b : ℝ} (ha : 0 ≤ a) (hab : a ≤ b) :
     change deriv Complex.ofReal t * ↑(B1 t) = ↑(B1 t)
     rw [Complex.deriv_ofReal]
     simp
-  · simp [Set.uIcc_of_le hab]
+  · simp only [_root_.deriv_ofReal, Set.uIcc_of_le hab]
     fun_prop
 
 lemma second_ibp_limit_eq_neg_B1_integral_on_unit {u v : ℝ}

--- a/PrimeNumberTheoremAnd/LaplaceInversion.lean
+++ b/PrimeNumberTheoremAnd/LaplaceInversion.lean
@@ -1747,7 +1747,7 @@ theorem integrableOn_exp_neg_mul_sinc (a : ℝ) (ha : 0 < a) :
     (volume.restrict (Set.Ioi 0))
   have h_exp : Integrable (fun x : ℝ => Real.exp (-a * x))
       (volume.restrict (Set.Ioi 0)) := by
-    show IntegrableOn (fun x : ℝ => Real.exp (-a * x)) (Set.Ioi 0)
+    change IntegrableOn (fun x : ℝ => Real.exp (-a * x)) (Set.Ioi 0)
     simpa [mul_comm] using exp_neg_integrableOn_Ioi (0 : ℝ) (b := a) ha
   refine h_exp.mono ?_ ?_
   · exact (by fun_prop : AEStronglyMeasurable
@@ -1984,12 +1984,12 @@ theorem integrable_exp_neg_mul_sin_prod_Ioi (a : ℝ) (ha : 0 < a) :
     change Integrable (fun u : ℝ => Real.exp (-u * x) * Real.sin x) ν
     have h_exp : Integrable (fun u : ℝ => Real.exp (-u * x)) ν := by
       dsimp [ν]
-      show IntegrableOn (fun u : ℝ => Real.exp (-u * x)) (Set.Ioi a)
+      change IntegrableOn (fun u : ℝ => Real.exp (-u * x)) (Set.Ioi a)
       simpa [mul_comm] using integrableOn_exp_mul_Ioi (a := -x) (neg_lt_zero.mpr hx) a
     exact h_exp.mul_const (Real.sin x)
   · have h_exp_a : Integrable (fun x : ℝ => Real.exp (-a * x)) μ := by
       dsimp [μ]
-      show IntegrableOn (fun x : ℝ => Real.exp (-a * x)) (Set.Ioi 0)
+      change IntegrableOn (fun x : ℝ => Real.exp (-a * x)) (Set.Ioi 0)
       simpa [mul_comm] using exp_neg_integrableOn_Ioi (0 : ℝ) (b := a) ha
     refine h_exp_a.mono ?_ ?_
     · exact hsm.norm.integral_prod_right'
@@ -1997,7 +1997,7 @@ theorem integrable_exp_neg_mul_sin_prod_Ioi (a : ℝ) (ha : 0 < a) :
       have hx0 : 0 < x := hx
       have h_exp_x : Integrable (fun y : ℝ => Real.exp (-y * x)) ν := by
         dsimp [ν]
-        show IntegrableOn (fun y : ℝ => Real.exp (-y * x)) (Set.Ioi a)
+        change IntegrableOn (fun y : ℝ => Real.exp (-y * x)) (Set.Ioi a)
         simpa [mul_comm] using integrableOn_exp_mul_Ioi (a := -x) (neg_lt_zero.mpr hx0) a
       have h_lhs : Integrable
           (fun y : ℝ => ‖Function.uncurry

--- a/PrimeNumberTheoremAnd/PerronFormula.lean
+++ b/PrimeNumberTheoremAnd/PerronFormula.lean
@@ -135,7 +135,7 @@ theorem tendsto_truncated_vertical_shift_with_simple_pole
         exact ⟨hσ.1, hσ.2⟩
       · rw [uIoo_of_lt (by linarith)]
         exact abs_lt.mp hTabs
-    · refine hf.mono (diff_subset_diff ?_ subset_rfl)
+    · refine hf.mono (sdiff_subset_sdiff ?_ subset_rfl)
       intro z hz
       rw [Rectangle] at hz
       simp only [sub_re, ofReal_re, mul_re, I_re, zero_mul, I_im, ofReal_im, mul_zero,
@@ -657,7 +657,7 @@ lemma isIntegrable (xpos : 0 < x) (σ_ne_zero : σ ≠ 0) (σ_ne_neg_one : σ �
     refine integrableOn_Ioi_rpow_of_lt (show (-2 : ℝ) < -1 by norm_num)
       (show (0 : ℝ) < 1 by norm_num) |>.congr_fun (fun y hy ↦ ?_) measurableSet_Ioi
     have hy0 : (0 : ℝ) < y := (show (0 : ℝ) < 1 by norm_num).trans hy
-    show (y : ℝ) ^ (-2 : ℝ) = 1 / y ^ 2
+    change (y : ℝ) ^ (-2 : ℝ) = 1 / y ^ 2
     rw [eq_div_iff (pow_ne_zero 2 hy0.ne'), ← rpow_natCast y 2, ← rpow_add hy0]
     norm_num
 

--- a/PrimeNumberTheoremAnd/StrongPNT.lean
+++ b/PrimeNumberTheoremAnd/StrongPNT.lean
@@ -2038,7 +2038,7 @@ lemma I1NewBound {SmoothingF : ℝ → ℝ}
                       integrableOn_Ioi_rpow_of_lt (by norm_num) (by linarith)
                     norm_num [div_eq_mul_inv] at *
                     exact MeasureTheory.Integrable.const_mul (h_integrable.congr_fun
-                      (fun x hx ↦ by simp only [neg_div]; rw [Real.rpow_neg (by linarith [hx.out])])
+                      (fun x hx ↦ by simp only []; rw [Real.rpow_neg (by linarith [hx.out])])
                       measurableSet_Ioi) _
                   refine h_integrable.mono' ?_ ?_
                   · refine ContinuousOn.aestronglyMeasurable ?_ measurableSet_Ioi

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -1389,9 +1389,7 @@ lemma cancel_main {C : ℝ} {f g : ℕ → ℝ} (hf : 0 ≤ f) (hg : 0 ≤ g)
     cumsum (f * g) n ≤ C * cumsum g n := by
   convert! cancel_aux' hf hg hf' hg' n using 1
   match n with
-  | n + 2 => simp only [cumsum_succ, show 2 + n - 1 = n + 1 from by omega,
-      show 2 + n - 1 - 1 = n from by omega, show 2 + n = n + 2 from by omega,
-      show 1 + n = n + 1 from by omega] ; push_cast ; ring
+  | n + 2 => simp only [cumsum_succ] ; push_cast ; ring
 
 lemma cancel_main' {C : ℝ} {f g : ℕ → ℝ} (hf : 0 ≤ f) (hf0 : f 0 = 0) (hg : 0 ≤ g)
     (hf' : ∀ n, cumsum f n ≤ C * n) (hg' : Antitone g) (n : ℕ) :


### PR DESCRIPTION
Fix lints/warnings.  Some of these were probably caused by the version bump but others were already here.  Lots of unused simp arguments which I used the Mathlib script for and then various other trivial changes.