### PR TITLE
Fourier-transform decay from an integrable derivative

### DIFF
--- a/PrimeNumberTheoremAnd/Fourier.lean
+++ b/PrimeNumberTheoremAnd/Fourier.lean
@@ -68,3 +68,119 @@ theorem fourierIntegral_self_add_deriv_deriv (f : W21) (u : ℝ) :
 
 @[simp] lemma deriv_ofReal : deriv ofReal = fun _ => 1 := by
   ext x ; exact ((hasDerivAt_id x).ofReal_comp).deriv
+
+/-- If, eventually in `T`, the integrand `f T` is bounded on `uIoc lo hi` by `B T`
+and `B T * |hi - lo| → 0`, then the interval integral `∫ x in lo..hi, f T x → 0`. -/
+lemma tendsto_intervalIntegral_zero_of_uniform_norm_bound
+    {f : ℝ → ℝ → ℂ} {lo hi : ℝ} {B : ℝ → ℝ}
+    (hB : Filter.Tendsto (fun T : ℝ => B T * |hi - lo|) Filter.atTop (nhds 0))
+    (hf : ∀ᶠ T in Filter.atTop, ∀ x ∈ Set.uIoc lo hi, ‖f T x‖ ≤ B T) :
+    Filter.Tendsto (fun T : ℝ => ∫ x in lo..hi, f T x) Filter.atTop (nhds 0) := by
+  rw [tendsto_zero_iff_norm_tendsto_zero]
+  refine squeeze_zero' (Eventually.of_forall fun T => norm_nonneg _) ?_ hB
+  filter_upwards [hf] with T hT
+  exact intervalIntegral.norm_integral_le_of_norm_le_const (fun x hx => hT x hx)
+
+/-- The decay `K * (log (T + 2) / (T + 2)) → 0` as `T → ∞`, for any constant `K`. -/
+lemma tendsto_const_mul_log_add_two_div_add_two_atTop (K : ℝ) :
+    Filter.Tendsto (fun T : ℝ => K * (Real.log (T + 2) / (T + 2)))
+      Filter.atTop (nhds 0) := by
+  have h0 : Filter.Tendsto (fun x : ℝ => Real.log x / x) Filter.atTop (nhds 0) := by
+    simpa using (Real.tendsto_pow_log_div_mul_add_atTop 1 0 1 (by norm_num : (1 : ℝ) ≠ 0))
+  have hshift : Filter.Tendsto (fun T : ℝ => Real.log (T + 2) / (T + 2))
+      Filter.atTop (nhds 0) := by
+    have := h0.comp (tendsto_atTop_add_const_right Filter.atTop 2 tendsto_id)
+    simpa [Function.comp_def] using this
+  simpa using hshift.const_mul K
+
+/-- Fourier-transform decay from an integrable derivative: for integrable,
+differentiable `g` with integrable derivative, `‖𝓕 g w‖ ≤ (∫ ‖deriv g x‖) / (2π·|w|)`. -/
+lemma norm_fourier_le_integral_deriv_div
+    (g : ℝ → ℂ) (hg : Integrable g) (hdiff : Differentiable ℝ g)
+    (hg' : Integrable (deriv g)) {w : ℝ} (hw : w ≠ 0) :
+    ‖𝓕 g w‖ ≤ (∫ x, ‖deriv g x‖ ∂volume) / ((2 * Real.pi) * |w|) := by
+  have hmul :
+      𝓕 (deriv g) w = (2 * Real.pi * Complex.I * (w : ℂ)) * 𝓕 g w := by
+    have h := congrFun (Real.fourier_deriv hg hdiff hg') w
+    simpa [smul_eq_mul, mul_assoc] using h
+  have h_fourier :
+      ‖𝓕 (deriv g) w‖ ≤ ∫ x, ‖deriv g x‖ ∂volume := by
+    exact VectorFourier.norm_fourierIntegral_le_integral_norm 𝐞 volume (innerₗ ℝ)
+      (deriv g) w
+  have hleft :
+      ((2 * Real.pi) * |w|) * ‖𝓕 g w‖ =
+        ‖(2 * Real.pi * Complex.I * (w : ℂ)) * 𝓕 g w‖ := by
+    have htwopi : ‖(2 * ↑Real.pi : ℂ)‖ = 2 * Real.pi := by
+      rw [norm_mul, Complex.norm_two, Complex.norm_of_nonneg Real.pi_pos.le]
+    have hwc : ‖(w : ℂ)‖ = |w| := by rw [norm_real, Real.norm_eq_abs]
+    rw [norm_mul, norm_mul, norm_mul, htwopi, norm_I, hwc]
+    ring
+  have hmain : ((2 * Real.pi) * |w|) * ‖𝓕 g w‖ ≤ ∫ x, ‖deriv g x‖ ∂volume := by
+    rw [hleft, ← hmul]
+    exact h_fourier
+  have hpos : 0 < (2 * Real.pi) * |w| := by
+    positivity
+  exact (le_div_iff₀ hpos).mpr (by simpa [mul_comm, mul_left_comm, mul_assoc] using hmain)
+
+/-- The oscillatory-integral form of the decay bound: for `0 < T`,
+`‖∫ g y · exp(T·i·y)‖ ≤ (∫ ‖deriv g x‖) / T`. -/
+lemma norm_oscillatory_integral_le_integral_deriv_div
+    (g : ℝ → ℂ) (hg : Integrable g) (hdiff : Differentiable ℝ g)
+    (hg' : Integrable (deriv g)) {T : ℝ} (hT : 0 < T) :
+    ‖∫ y, g y * exp ((T : ℂ) * Complex.I * (y : ℂ)) ∂volume‖ ≤
+      (∫ x, ‖deriv g x‖ ∂volume) / T := by
+  have hw : -T / (2 * Real.pi) ≠ 0 := by
+    exact div_ne_zero (neg_ne_zero.mpr hT.ne') (mul_ne_zero two_ne_zero Real.pi_ne_zero)
+  have hfourier := norm_fourier_le_integral_deriv_div g hg hdiff hg' hw
+  have heq :
+      (∫ y, g y * exp ((T : ℂ) * Complex.I * (y : ℂ)) ∂volume) =
+        𝓕 g (-T / (2 * Real.pi)) := by
+    rw [Real.fourier_real_eq_integral_exp_smul]
+    apply integral_congr_ae
+    filter_upwards with y
+    rw [smul_eq_mul]
+    rw [mul_comm (g y)]
+    congr 1
+    congr 1
+    push_cast
+    field_simp [Real.pi_ne_zero]
+  rw [heq]
+  refine hfourier.trans_eq ?_
+  congr 1
+  have hden : (2 * Real.pi) * |-T / (2 * Real.pi)| = T := by
+    have htwopi_pos : 0 < 2 * Real.pi := by positivity
+    have hneg : -T / (2 * Real.pi) < 0 := div_neg_of_neg_of_pos (neg_neg_of_pos hT) htwopi_pos
+    rw [abs_of_neg hneg]
+    field_simp [Real.pi_ne_zero]
+  rw [hden]
+
+/-- The `|T|` variant of the oscillatory-integral decay bound: for `T ≠ 0`,
+`‖∫ g y · exp(T·i·y)‖ ≤ (∫ ‖deriv g x‖) / |T|`. -/
+lemma norm_oscillatory_integral_le_integral_deriv_div_abs
+    (g : ℝ → ℂ) (hg : Integrable g) (hdiff : Differentiable ℝ g)
+    (hg' : Integrable (deriv g)) {T : ℝ} (hT : T ≠ 0) :
+    ‖∫ y, g y * exp ((T : ℂ) * Complex.I * (y : ℂ)) ∂volume‖ ≤
+      (∫ x, ‖deriv g x‖ ∂volume) / |T| := by
+  have hw : -T / (2 * Real.pi) ≠ 0 := by
+    exact div_ne_zero (neg_ne_zero.mpr hT) (mul_ne_zero two_ne_zero Real.pi_ne_zero)
+  have hfourier := norm_fourier_le_integral_deriv_div g hg hdiff hg' hw
+  have heq :
+      (∫ y, g y * exp ((T : ℂ) * Complex.I * (y : ℂ)) ∂volume) =
+        𝓕 g (-T / (2 * Real.pi)) := by
+    rw [Real.fourier_real_eq_integral_exp_smul]
+    apply integral_congr_ae
+    filter_upwards with y
+    rw [smul_eq_mul]
+    rw [mul_comm (g y)]
+    congr 1
+    congr 1
+    push_cast
+    field_simp [Real.pi_ne_zero]
+  rw [heq]
+  refine hfourier.trans_eq ?_
+  congr 1
+  have hden : (2 * Real.pi) * |-T / (2 * Real.pi)| = |T| := by
+    have htwopi_pos : 0 < 2 * Real.pi := by positivity
+    rw [abs_div, abs_neg, abs_of_pos htwopi_pos]
+    field_simp [Real.pi_ne_zero]
+  rw [hden]


### PR DESCRIPTION
## General lemmas about how fast a Fourier transform decays once the derivative is integrable

These are pulled out of the Kadiri eq.15 work so they can sit with the rest of the Fourier material in `Fourier.lean`.

The main one is `norm_fourier_le_integral_deriv_div`: for an integrable, differentiable `g` with integrable derivative, `‖𝓕 g w‖ ≤ (∫ ‖deriv g x‖) / (2π·|w|)`. It comes straight from `Real.fourier_deriv` together with the triangle bound on the Fourier integral. 

From it I record the two oscillatory-integral forms, `norm_oscillatory_integral_le_integral_deriv_div` and its `|T|` variant, which rewrite `∫ g y · exp(T·i·y)` as a value of `𝓕 g` and read off the `1/T` decay.

 There are also two filter facts the eq.15 estimate uses, `tendsto_intervalIntegral_zero_of_uniform_norm_bound` and `tendsto_const_mul_log_add_two_div_add_two_atTop`.

None of these mention Kadiri specifically, so I dropped the prefixes and the local namespace and put them with the existing `Real.fourier_deriv` lemmas in `Fourier.lean`; the eq.15 file then just uses them.

I am attempting to recover/separate the reusable tools from the past bloated AI PRs into more modular and clear sub pieces.

Tags:
AI
