### PR TITLE
fix: align Dusart lemma_5_10a with 1-indexed prime numbering

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -725,7 +725,8 @@ theorem theorem_5_9b {x : ℝ} (hx : x ≥ 2278382) : ∃ E,
   We have for $k \geq 4$, $p_k \leq k \log p_k$.  (Note: in Lean primes are indexed from $0$, so we have to subtract $1$ from the index.)
   -/)
   (latexEnv := "lemma")]
-theorem lemma_5_10a {k : ℕ} (hk : k ≥ 4) : nth_prime' k ≤ k * Real.log (nth_prime' k) := by sorry
+theorem lemma_5_10a {k : ℕ} (hk : k ≥ 4) :
+    nth_prime' (k - 1) ≤ k * Real.log (nth_prime' (k - 1)) := by sorry
 
 @[blueprint "Dusart_lemma_5_10b"
   (title := "Dusart Lemma 5.10")


### PR DESCRIPTION
Fixes #1129

## Bug
`lemma_5_10a` used `nth_prime' k` with paper index `k ≥ 4`, but `nth_prime'` is 0-indexed. At `k = 4` this claims `11 ≤ 4 log 11`, which is false.

## Root cause
Dusart's `p_k` is 1-indexed; the formalization used the paper index directly as the `nth_prime'` argument.

## Why this fix is correct
The k-th prime in the paper is `nth_prime' (k - 1)`. For `k = 4` this gives `p_4 = 7` and `7 ≤ 4 log 7`, matching Lemma 5.10. Same convention as the merged fix for `lemma_5_10b` in #1566.

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IEANTN.Dusart`

Made with [Cursor](https://cursor.com)