### PR TITLE
fix: align Dusart lemma_5_10b with 1-indexed prime numbering

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -734,7 +734,7 @@ theorem lemma_5_10a {k : ℕ} (hk : k ≥ 4) : nth_prime' k ≤ k * Real.log (nt
   -/)
   (latexEnv := "lemma")]
 theorem lemma_5_10b {k : ℕ} (hk : k ≥ 2) :
-    Real.log (nth_prime' (k - 1)) ≤ Real.log k + Real.log (Real.log k) + 1 := by sorry
+    Real.log (nth_prime' k) ≤ Real.log k + Real.log (Real.log k) + 1 := by sorry
 
 @[blueprint "Massias_Robin_thm_Bv"
   (title := "Massias and Robin Theorem B (v)")


### PR DESCRIPTION
## Summary
- `lemma_5_10b` used `nth_prime' (k - 1)` after #1566, but `nth_prime' k` already denotes Dusart's $p_k$.
- The statement therefore bounded $\log p_{k-1}$ while the RHS used paper index $k$.

## Root cause
Double subtraction: `nth_prime' n = nth_prime (n-1)` already converts to 1-indexed primes.

## Why this fix is correct
For $k=2$ the lemma should read $\log p_2 = \log 3 \le \log 2 + \log\log 2 + 1$, not $\log p_1 = \log 2$. Same convention as `lemma_5_10a` on main.

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IEANTN.Dusart`

Fixes #1129 (part b).

Made with [Cursor](https://cursor.com)