### PR TITLE
fix: use nth_prime' k in Dusart lemma_5_10a

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -722,11 +722,11 @@ theorem theorem_5_9b {x : ℝ} (hx : x ≥ 2278382) : ∃ E,
 @[blueprint "Dusart_lemma_5_10a"
   (title := "Dusart Lemma 5.10")
   (statement := /--
-  We have for $k \geq 4$, $p_k \leq k \log p_k$.  (Note: in Lean primes are indexed from $0$, so we have to subtract $1$ from the index.)
+  We have for $k \geq 4$, $p_k \leq k \log p_k$.
   -/)
   (latexEnv := "lemma")]
 theorem lemma_5_10a {k : ℕ} (hk : k ≥ 4) :
-    nth_prime' (k - 1) ≤ k * Real.log (nth_prime' (k - 1)) := by sorry
+    nth_prime' k ≤ k * Real.log (nth_prime' k) := by sorry
 
 @[blueprint "Dusart_lemma_5_10b"
   (title := "Dusart Lemma 5.10")


### PR DESCRIPTION
## Summary
- `lemma_5_10a` still used `nth_prime' (k - 1)` after #1622, but `nth_prime' k` already denotes Dusart's $p_k$ (see `Defs.lean` and the corrected `lemma_5_10b` in #1624).
- The statement therefore bounded $p_{k-1}$ while the RHS used paper index $k$.

## Root cause
Double subtraction: `nth_prime' n = nth_prime (n-1)` already converts to 1-indexed primes.

## Why this fix is correct
For $k=4$ the lemma should read $p_4 = 7 \le 4\log 7$, not $p_3 = 5$. Same convention as `lemma_5_10b` on main.

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IEANTN.Dusart`

Fixes #1129 (part a).

Made with [Cursor](https://cursor.com)