### PR TITLE
fix: cast liouville to ArithmeticFunction ℝ

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1426,7 +1426,7 @@ The Liouville function is completely multiplicative. -/
   (proof := /--
   The Liouville function $\lambda(n)$ is defined as $(-1)^{\Omega(n)}$, where $\Omega(n)$ counts the total number of prime factors of $n$ with multiplicity. To show that $\lambda$ is completely multiplicative, we need to verify that $\lambda(1) = 1$ and that $\lambda(ab) = \lambda(a)\lambda(b)$ for all natural numbers $a$ and $b$.
   -/)]
-lemma isCompletelyMultiplicative_liouville : IsCompletelyMultiplicative (liouville : ArithmeticFunction ℤ) := by
+lemma isCompletelyMultiplicative_liouville : IsCompletelyMultiplicative (liouville : ArithmeticFunction ℝ) := by
   sorry
 
 /--


### PR DESCRIPTION
## Summary
- `IsCompletelyMultiplicative` takes `ArithmeticFunction ℝ`.
- Use the `ℤ → ℝ` coercion, not `↗` (that yields `ℕ → ℂ`).

## Test plan
- [ ] `lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1`