### PR TITLE
fix(ZetaSummary): rename PT2021 -> PT2021_RH to avoid bibkey collision

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/ZetaSummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/ZetaSummary.lean
@@ -82,7 +82,7 @@ theorem GW_theorem : riemannZeta.RH_up_to 2445999556030 := sorry
   "pt_theorem_1"
   (title := "PT Theorem 1")
   (statement := /--
-    By \cite{PT2021}, the Riemann hypothesis is verified up to
+    By \cite{PT2021_RH}, the Riemann hypothesis is verified up to
     $H_0 = 3 \times 10^{12}$.
   -/)
   (latexEnv := "theorem")]

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -949,7 +949,7 @@ MRREVIEWER = {O.\ Ramar\'e},
               \url{http://numbers.computation.free.fr/Constants/Miscellaneous/zetazeros1e13-1e24.pdf}},
 }
 
-@article {PT2021,
+@article {PT2021_RH,
     AUTHOR = {Platt, Dave and Trudgian, Tim},
      TITLE = {The {R}iemann hypothesis is true up to $3 \cdot 10^{12}$},
    JOURNAL = {Bull. Lond. Math. Soc.},


### PR DESCRIPTION
## Summary

- Commit 7659d2d introduced a duplicate `PT2021` bibtex key (the pre-existing entry at line 385 covers a different Platt-Trudgian 2021 paper, `mcom/3583`).
- Bibtex refused the new entry, cascading into 691 unresolved `\cite`/`\ref` and CI failure ([run 29625196005](https://github.com/AlexKontorovich/PrimeNumberTheoremAnd/actions/runs/29625196005/job/88028091130)).
- Rename the new entry to `PT2021_RH` (following the `Buthe`/`Buthe2` disambiguation pattern) and update the one `\cite` in `PT_theorem_1`.

## Test plan

- [x] `python`-based dedup check: 62 entries in `references.bib`, no duplicate keys.
- [ ] CI blueprint step passes (waiting on this PR run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)