### PR TITLE
fix: Eπ blueprint uses x/log x, matching Lean

### DIFF
--- a/PrimeNumberTheoremAnd/Defs.lean
+++ b/PrimeNumberTheoremAnd/Defs.lean
@@ -122,7 +122,7 @@ def Eψ.numericalBound (x₀ : ℝ) (ε : ℝ → ℝ) : Prop :=
   (title := "Equation (1) of FKS2")
   (statement := /--
   $E_\pi(x) = |\pi(x) - \mathrm{Li}(x)| /
-  \mathrm{Li}(x)$. -/)]
+  (x / \log x)$. -/)]
 noncomputable def Eπ (x : ℝ) : ℝ :=
   |pi x - Li x| / (x / log x)
 


### PR DESCRIPTION
## Summary
- Blueprint for `Eπ` said `/Li(x)`; Lean (and FKS2 usage) is `/(x/log x)`.

## Test plan
- [ ] Blueprint matches `Defs.Eπ`