### PR TITLE
fix: Dusart Prop 3.2 blueprint is relative |ψ-x|/x

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -68,7 +68,7 @@ def Table1 : List (ℝ × ℝ × ℕ × ℝ × ℝ × ℝ) := [
 @[blueprint "Dusart_prop_3_2"
   (title := "Dusart Proposition 3.2")
   (statement := /--
-  For $x \geq e^{b}$ we have $\psi(x) - x| \leq \varepsilon$, where $b, \varepsilon$ are given by \cite[Table 1]{Dusart2018}.-/)
+  For $x \geq e^{b}$ we have $|\psi(x) - x|/x \leq \varepsilon$, where $b, \varepsilon$ are given by \cite[Table 1]{Dusart2018}.-/)
   (latexEnv := "proposition")]
 theorem proposition_3_2 {b σ₀ : ℝ} {m : ℕ} {δ T₁ ε : ℝ} (h : (b, σ₀, m, δ, T₁, ε) ∈ Table1)
 {x : ℝ} (hx : x ≥ exp b) : Eψ x ≤ ε := by sorry


### PR DESCRIPTION
## Summary
- Blueprint had a broken `$\\psi(x) - x|$` and claimed an absolute bound; Lean proves `Eψ x ≤ ε`, i.e. `|ψ-x|/x ≤ ε`.

## Test plan
- [ ] Blueprint matches `proposition_3_2` / `Eψ`