### PR TITLE
fix: Dusart Prop 4.3 lower bounds match the paper

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -176,91 +176,16 @@ theorem theorem_4_2 {k : ℕ} {ηk xk : ℝ} (h : (k, ηk, xk) ∈ Table_4_2) {x
   (statement := /--
   For $x \geq 121$, we have
   \[
-  1 - \frac{4 \log 2}{\log x} \sqrt{x} < \psi(x) - \vartheta(x),
-  \quad \sqrt{\frac{\log^3 x}{x}} \, \vartheta(x^{1/2}).
+  0.9999\sqrt{x} < \psi(x) - \vartheta(x),
+  \quad
+  \sqrt{x}\Bigl(1 - \frac{4}{(\log x)^3}\Bigr) < \psi(x) - \vartheta(x).
   \]
   -/)
   (latexEnv := "proposition")]
 theorem proposition_4_3 {x : ℝ} (hx : x ≥ 121) :
-  ψ x - θ x ≥ 1 - (4 * Real.log 2) / (log x) * sqrt x ∧
-  ψ x - θ x ≥ sqrt (log x ^ 3 / x) * θ (x ^ (1 / 2 : ℝ)) := by
-  have hx_pos : 0 < x := by linarith
-  have hx_nonneg : 0 ≤ x := by linarith
-  have hlog_pos : 0 < log x := Real.log_pos (by linarith)
-  have hsqrt_pos : 0 < sqrt x := Real.sqrt_pos.mpr hx_pos
-  have hpsi_theta_nn : ψ x - θ x ≥ 0 := by linarith [theta_le_psi x]
-  -- Key: ψ x - θ x ≥ θ (x^(1/2))
-  have hpsi_sub : ψ x - θ x ≥ θ (x ^ ((1:ℝ) / 2)) := by
-    have hx2 : (2 : ℝ) ≤ x := by linarith
-    have h := psi_eq_theta_add_sum_theta hx2
-    linarith [Finset.single_le_sum (f := fun (n : ℕ) => θ (x ^ ((1:ℝ) / ↑n)))
-      (fun (i : ℕ) _ => theta_nonneg (x ^ ((1:ℝ) / ↑i)))
-      (show (2 : ℕ) ∈ Finset.Icc 2 ⌊log x / Real.log 2⌋₊ from by
-        simp only [Finset.mem_Icc, le_refl, true_and]
-        apply Nat.le_floor; rw [Nat.cast_ofNat]
-        have hlog2_pos : (0 : ℝ) < Real.log 2 := by positivity
-        rw [le_div_iff₀ hlog2_pos]
-        nlinarith [Real.log_le_log (by positivity : (0:ℝ) < 4) (show (4:ℝ) ≤ x by linarith),
-                   show Real.log (4:ℝ) = 2 * Real.log 2 from by
-                     rw [show (4:ℝ) = 2^2 from by norm_num, Real.log_pow]; ring])]
-  -- (log x)^3 ≤ x for x ≥ 121 (via interval bootstrapping)
-  have hlog_cube : (log x) ^ 3 ≤ x := by
-    -- Helper: in [a,b] with (log b)^3 ≤ a and a ≥ 1, deduce (log x)^3 ≤ x
-    have hlci : ∀ (a b : ℝ), 1 ≤ a → (Real.log b) ^ 3 ≤ a → a ≤ x → x ≤ b → (log x) ^ 3 ≤ x :=
-      fun a b ha hlog hxa hxb =>
-        calc (log x) ^ 3 ≤ (log b) ^ 3 :=
-              pow_le_pow_left₀ (Real.log_nonneg (by linarith)) (Real.log_le_log (by linarith) hxb) 3
-          _ ≤ a := hlog
-          _ ≤ x := hxa
-    -- Macro for the interval_auto step: prove (Real.log c)^3 ≤ d
-    have hpow3 : ∀ (c d : ℝ), Real.log c * (Real.log c * Real.log c) ≤ d →
-        (Real.log c) ^ 3 ≤ d := fun c d h => by nlinarith [show (Real.log c)^3 = Real.log c * (Real.log c * Real.log c) from by ring]
-    by_cases! h1 : x ≤ 130
-    · exact hlci 121 130 (by norm_num) (hpow3 130 121 (by linarith [LogTables.log_130_cube_lt])) hx h1
-    · by_cases! h2 : x ≤ 155
-      · exact hlci 130 155 (by norm_num) (hpow3 155 130 (by linarith [LogTables.log_155_cube_lt])) h1.le h2
-      · by_cases! h3 : x ≤ 200
-        · exact hlci 155 200 (by norm_num) (hpow3 200 155 (by linarith [LogTables.log_200_cube_lt])) h2.le h3
-        · by_cases! h4 : x ≤ 300
-          · exact hlci 200 300 (by norm_num) (hpow3 300 200 (by linarith [LogTables.log_300_cube_lt])) h3.le h4
-          · by_cases! h5 : x ≤ 550
-            · exact hlci 300 550 (by norm_num) (hpow3 550 300 (by linarith [LogTables.log_550_cube_lt])) h4.le h5
-            · by_cases! h6 : x ≤ 1500
-              · exact hlci 550 1500 (by norm_num) (hpow3 1500 550 (by linarith [LogTables.log_1500_cube_lt])) h5.le h6
-              · by_cases! h7 : x ≤ 10000
-                · exact hlci 1500 10000 (by norm_num) (hpow3 10000 1500 (by linarith [LogTables.log_10000_cube_lt])) h6.le h7
-                · by_cases! h8 : x ≤ (10:ℝ)^8
-                  · exact hlci 10000 ((10:ℝ)^8) (by norm_num) (hpow3 ((10:ℝ)^8) 10000 (by linarith [LogTables.log_1e8_cube_lt])) h7.le h8
-                  · by_cases! h9 : x ≤ 3 * (10:ℝ)^10
-                    · exact hlci ((10:ℝ)^8) (3 * (10:ℝ)^10) (by norm_num) (hpow3 (3 * (10:ℝ)^10) ((10:ℝ)^8) (by linarith [LogTables.log_3e10_cube_lt])) h8.le h9
-                    · -- Tail: x ≥ 3*10^10, so log x ≥ 24, use exp(t) ≥ t^4/24 ≥ t^3
-                      have hlog_nn : 0 ≤ log x := hlog_pos.le
-                      have hlog_ge : 24 ≤ log x := le_of_lt (lt_of_lt_of_le
-                        (show (24:ℝ) < Real.log (3 * (10:ℝ)^10) by interval_auto)
-                        (Real.log_le_log (by positivity) h9.le))
-                      calc (log x) ^ 3 ≤ (log x) ^ 4 / 24 := by nlinarith [pow_nonneg hlog_nn 3]
-                        _ ≤ Real.exp (log x) := by
-                            have h := Real.sum_le_exp_of_nonneg hlog_nn 5
-                            simp [Finset.sum_range_succ, Nat.factorial] at h
-                            nlinarith [pow_nonneg hlog_nn 2, pow_nonneg hlog_nn 3]
-                        _ = x := Real.exp_log hx_pos
-  constructor
-  · -- First bound: ψ x - θ x ≥ 1 - (4 * log 2) / (log x) * sqrt x
-    -- The RHS is ≤ 0 since 4 log 2 * √x / log x ≥ 1, and ψ - θ ≥ 0.
-    suffices h : 1 - (4 * Real.log 2) / (log x) * sqrt x ≤ 0 by linarith
-    rw [sub_nonpos, div_mul_eq_mul_div, le_div_iff₀ hlog_pos]
-    -- Need: log x ≤ 4 * log 2 * √x
-    have hlog_le : log x ≤ 2 * sqrt x := by
-      have h := Real.log_le_rpow_div hx_nonneg (show (0:ℝ) < 1/2 by norm_num)
-      rw [← sqrt_eq_rpow] at h; linarith
-    have h2 : (2 : ℝ) ≤ 4 * Real.log 2 := by linarith [LogTables.log_2_gt_d9]
-    nlinarith [mul_le_mul_of_nonneg_right h2 hsqrt_pos.le]
-  · -- Second bound: ψ x - θ x ≥ sqrt (log³x / x) * θ (x^(1/2))
-    -- Since √(log³x/x) ≤ 1 and θ(x^(1/2)) ≥ 0, and ψ-θ ≥ θ(x^(1/2)).
-    have htheta_nn : 0 ≤ θ (x ^ ((1:ℝ) / 2)) := theta_nonneg _
-    have hsqrt_le : sqrt (log x ^ 3 / x) ≤ 1 :=
-      Real.sqrt_le_one.mpr (div_le_one_of_le₀ hlog_cube hx_pos.le)
-    nlinarith [mul_le_mul_of_nonneg_right hsqrt_le htheta_nn]
+  ψ x - θ x > 0.9999 * sqrt x ∧
+  ψ x - θ x > sqrt x * (1 - 4 / (log x) ^ 3) := by
+  sorry
 
 @[blueprint "Dusart_prop_4_4"
   (title := "Dusart Proposition 4.4")


### PR DESCRIPTION
## Summary
- Restate Prop 4.3 as $0.9999\sqrt{x} < \psi-\vartheta$ and $\sqrt{x}(1-4/(\log x)^3) < \psi-\vartheta$ (Dusart).
- Drop the previous proof of the incorrect/trivial form.

## Test plan
- [ ] Blueprint and Lean match arXiv:1002.0442 / Ramanujan J. Prop 4.3