### PR TITLE
fix: rename FKS lemmas to 5.2 and 5.3

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/FioriKadiriSwidinsky/FioriKadiriSwidinsky.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FioriKadiriSwidinsky/FioriKadiriSwidinsky.lean
@@ -646,7 +646,7 @@ theorem theorem_1_1b {log_x0 σ2 c N K ε1 ε2 ε3 ε4 ε_total : ℝ}
     E_\psi(x) \leq 2(\log x)^{3/2} \exp\left(-0.8476836\sqrt{\log x}\right).
     \]
   -/)]
-theorem lemma_5_3 {x : ℝ} (h : log x ∈ Set.Ioc 0 2100) :
+theorem lemma_5_2 {x : ℝ} (h : log x ∈ Set.Ioc 0 2100) :
     Eψ x ≤ 2 * (log x) ^ (3 / 2) * exp (-0.8476836 * sqrt (log x)) := by sorry
 
 @[blueprint
@@ -658,7 +658,7 @@ theorem lemma_5_3 {x : ℝ} (h : log x ∈ Set.Ioc 0 2100) :
     E_\psi(x) \leq 9.22022(\log x)^{3/2} \exp\left(-0.8476836\sqrt{\log x}\right).
     \]
   -/)]
-theorem lemma_5_4 {x : ℝ} (h : log x ∈ Set.Ioc 2100 200000) :
+theorem lemma_5_3 {x : ℝ} (h : log x ∈ Set.Ioc 2100 200000) :
     Eψ x ≤ 9.22022 * (log x) ^ (3 / 2) * exp (-0.8476836 * sqrt (log x)) := by sorry
 
 noncomputable def A (x₀ : ℝ) : ℝ :=


### PR DESCRIPTION
## Summary
- Rename `lemma_5_3`/`lemma_5_4` to `lemma_5_2`/`lemma_5_3` to match FKS and the blueprint ids.

## Test plan
- [ ] Check arXiv:2204.02588 Lemmas 5.2–5.3

Made with [Cursor](https://cursor.com)