### PR TITLE
fix: Eπ blueprint denominator is x/log x

### DIFF
--- a/PrimeNumberTheoremAnd/Defs.lean
+++ b/PrimeNumberTheoremAnd/Defs.lean
@@ -122,7 +122,7 @@ def Eψ.numericalBound (x₀ : ℝ) (ε : ℝ → ℝ) : Prop :=
   (title := "Equation (1) of FKS2")
   (statement := /--
   $E_\pi(x) = |\pi(x) - \mathrm{Li}(x)| /
-  \mathrm{Li}(x)$. -/)]
+  (x / \log x)$. -/)]
 noncomputable def Eπ (x : ℝ) : ℝ :=
   |pi x - Li x| / (x / log x)
 


### PR DESCRIPTION
## Summary
- Blueprint for `Eπ` said `/Li(x)`; FKS2 and the Lean def use `/(x/\log x)`.

## Test plan
- [ ] Compare to arXiv:2206.12557 (1) / FKS2 Eq. (1)

Made with [Cursor](https://cursor.com)