### PR TITLE
fix: Liouville Euler product factors

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1438,7 +1438,7 @@ The Dirichlet series of the Liouville function is `ζ(2s)/ζ(s)`. -/
   (proof := /--
   The Liouville function $\lambda(n)$ is multiplicative, and its value at prime powers is given by $\lambda(p^k) = (-1)^k$. The Dirichlet series of $\lambda$ can be expressed as an Euler product over primes:
 \[
-L(\lambda, s) = \prod_{p} \left(1 + \lambda(p)p^{-s} + \lambda(p^2)p^{-2s} + \ldots\right) = \prod_{p} \left(1 - p^{-s}\right)^{-1} \left(1 - p^{-2s}\right) = \frac{\zeta(2s)}{\zeta(s)}.
+L(\lambda, s) = \prod_{p} \left(1 + \lambda(p)p^{-s} + \lambda(p^2)p^{-2s} + \ldots\right) = \prod_{p} \left(1 - p^{-s}\right) \left(1 - p^{-2s}\right)^{-1} = \frac{\zeta(2s)}{\zeta(s)}.
 \]
   -/)]
 lemma LSeries_liouville_eq {s : ℂ} (hs : 1 < s.re) :


### PR DESCRIPTION
## Summary
- Blueprint proof had $(1-p^{-s})^{-1}(1-p^{-2s})$; needs $(1-p^{-s})(1-p^{-2s})^{-1}$.

## Test plan
- [ ] Check against $\zeta(2s)/\zeta(s)=\prod(1+p^{-s})^{-1}$