### PR TITLE
fix: PT/JY π bounds use li

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -130,7 +130,7 @@ theorem corollary_1 (X σ A B C ε₀ : ℝ) (h : (X, σ, A, B, C, ε₀) ∈ Ta
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{Li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
+  |\pi(x) - \mathrm{li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
   \]
   for all $x \geq \exp(2000)$.
   -/)
@@ -270,7 +270,7 @@ blueprint_comment /-- results from \cite{johnston-yang}-/
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{Li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
+  |\pi(x) - \mathrm{li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
   \]
   for all $x \geq 2$.
   -/)


### PR DESCRIPTION
## Summary
- PT Cor 2 and JY Cor 1.3 blueprints: $|\pi-\mathrm{li}|$ as in the papers.

## Test plan
- [ ] Check arXiv:1809.03134 Cor 2 and arXiv:2204.01980 Cor 1.3

Made with [Cursor](https://cursor.com)