### PR TITLE
fix: ε₄ geometric mesh uses K+1

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/FioriKadiriSwidinsky/FioriKadiriSwidinsky.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FioriKadiriSwidinsky/FioriKadiriSwidinsky.lean
@@ -478,18 +478,19 @@ theorem corollary_3_10 {σ₁ σ₂ T x : ℝ} (hσ₁ : σ₁ ∈ Set.Icc 0.9 1
   (title := "FKS Proposition 3.11")
   (statement := /--
     Let $5/8 < \sigma_2 \leq 1$, $t_0 = t_0(\sigma_2,x) = \max(H_{\sigma_2},
-    \exp( \sqrt{\log x}/R))$ and $T > 0$.  Let $K \geq 2$ and consider a strictly increasing
-    sequence $(t_k)_{k=0}^K$ such that $t_k = T$.  Then
-    $\Sigma_{\sigma_2}^1 ≤ 2 N(\sigma_2,T) x^{-1/R\log t_0}/t_0$ and
+    \exp( \sqrt{\log x}/R))$ and $T > t_0$.  Let $K \geq 2$ and consider a strictly increasing
+    sequence $(t_k)_{k=0}^K$ such that $t_K = T$.  Then
+    $\Sigma_{\sigma_2}^1 ≤ 2 N(\sigma_2,T) x^{-1/(R\log t_0)}/t_0$ and
     $\Sigma_{\sigma_2}^1 ≤ 2 ((\sum_{k=1}^{K-1} N(\sigma_2, t_k)
-    (x^{-1/R\log t_{k-1}} / t_{k-1} - x^{-1/(R \log t_k)}/t_k)) +
-    x^{-1/R \log t_{K-1}}/t_{K-1} N(\sigma_2,T))$.
+    (x^{-1/(R\log t_{k-1})} / t_{k-1} - x^{-1/(R \log t_k)}/t_k)) +
+    x^{-1/(R \log t_{K-1})}/t_{K-1} N(\sigma_2,T))$.
   -/)]
 theorem proposition_3_11 (I : Inputs) {σ₂ T x : ℝ} (K : ℕ) (hK : 2 ≤ K)
     (hσ₂ : σ₂ ∈ Set.Ioc (5 / 8) 1)
     (t_seq : Fin (K + 2) → ℝ)
     (ht0 : t_seq 0 = max (Hσ I.H₀ I.R σ₂) (exp (sqrt (log x) / I.R)))
-    (htK : t_seq (Fin.last (K + 1)) = T) (ht_incr : StrictMono t_seq) :
+    (htK : t_seq (Fin.last (K + 1)) = T) (ht_incr : StrictMono t_seq)
+    (hT : T > t_seq 0) :
     riemannZeta.Sigma T x σ₂ 1 ≤
       2 * (riemannZeta.N' σ₂ T) * x ^ (-1 / (I.R * log (t_seq 0))) / (t_seq 0)
     ∧
@@ -501,7 +502,7 @@ theorem proposition_3_11 (I : Inputs) {σ₂ T x : ℝ} (K : ℕ) (hK : 2 ≤ K)
         (t_seq (Fin.last K).castSucc) * riemannZeta.N' σ₂ T := by sorry
 
 noncomputable def ε₄ (I : Inputs) (t₀ x σ₂ : ℝ) (K : ℕ) (T : ℝ) : ℝ :=
-    let t : Fin (K + 2) → ℝ := fun k ↦ t₀ * (T / t₀) ^ (k / K)
+    let t : Fin (K + 2) → ℝ := fun k ↦ t₀ * (T / t₀) ^ ((k : ℝ) / (K + 1))
     2 * ∑ k ∈ Finset.Ioo 0 (Fin.last (K + 1)),
       (x ^ (-1 / (I.R * log (t k))) / (t k)) *
         (I.ZDB.N σ₂ (t (k + 1)) - I.ZDB.N σ₂ (t k)) +


### PR DESCRIPTION
## Summary
- `ε₄` indexes `Fin (K+2)`, so the mesh exponent is `k/(K+1)` (else `t_{K+1} ≠ T`).
- Prop 3.11: require `T > t₀`; write `x^{-1/(R\log t)}`.

## Test plan
- [ ] Check arXiv:2204.02588 Cor 3.12 / Prop 3.11 against `ε₄` / `proposition_3_11`

Made with [Cursor](https://cursor.com)