### PR TITLE
fix: PT/JY/Trudgian secondary estimate statements

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -130,7 +130,7 @@ theorem corollary_1 (X σ A B C ε₀ : ℝ) (h : (X, σ, A, B, C, ε₀) ∈ Ta
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{Li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
+  |\pi(x) - \mathrm{li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
   \]
   for all $x \geq \exp(2000)$.
   -/)
@@ -241,7 +241,8 @@ theorem lemma_1 (x : ℝ) (hx : x ≥ exp 35) :
   -/)
   (latexEnv := "theorem")]
 theorem theorem_2 (x : ℝ) (hx : x ≥ 229) :
-    Eπ.numericalBound x (fun x ↦ 0.2795 * (log x)^(1/4) * exp (-sqrt (log x / 6.455))) := by
+    |pi x - li x| ≤ 0.2795 * x / (log x) ^ ((3 : ℝ) / 4) *
+      exp (-sqrt (log x / 6.455)) := by
   sorry
 
 
@@ -270,7 +271,7 @@ blueprint_comment /-- results from \cite{johnston-yang}-/
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{Li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
+  |\pi(x) - \mathrm{li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
   \]
   for all $x \geq 2$.
   -/)
@@ -330,12 +331,12 @@ theorem corollary_1_3 : Eπ.classicalBound 9.59 1.515 0.8274 1 2 := by
   One has
   \[
   |\pi(x) - \mathrm{Li}(x)| \leq 0.028 x (\log x)^{0.801}
-    \exp(-0.1853 \log^{3/5} x / (\log \log x)^{1/5}))
+    \exp(-0.1853 \log^{3/5} x / (\log \log x)^{1/5})
   \]
-  for all $x \geq 2$.
+  for all $x \geq 23$.
   -/)
   (latexEnv := "theorem")]
-theorem theorem_1_4 : Eπ.vinogradovBound 0.028 0.801 0.1853 23 := sorry
+theorem theorem_1_4 : Eπ.vinogradovBound 0.028 1.801 0.1853 23 := sorry
 
 blueprint_comment /-- TODO: input other results from JY -/
 

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -528,11 +528,11 @@ theorem psi_bound_1 (x : ℝ) (hx : x ≥ exp 5000) :
 @[blueprint
   "thm:jy-psi-2"
   (title := "Johnston-Yang $\\psi$ bound 2")
-  (statement := /-- For $x \geq 2$, we have $|\psi(x) - x| \leq x \cdot 9.39\, (\log x)^{1.51} \exp(-0.8274\sqrt{\log x})$. -/)
+  (statement := /-- For $x \geq 2$, we have $|\psi(x) - x| \leq x \cdot 9.39\, (\log x)^{1.515} \exp(-0.8274\sqrt{\log x})$. -/)
   (latexEnv := "theorem")]
 theorem psi_bound_2 (x : ℝ) (hx : x ≥ 2) :
-    |ψ x - x| ≤ x * 9.39 * (log x) ^ (1.51 : ℝ) * exp (-0.8274 * sqrt (log x)) := by
-  have h_exp : (log x) ^ (0.01 : ℝ) * exp (0.0202836 * sqrt (log x)) ≥ 1 := by
+    |ψ x - x| ≤ x * 9.39 * (log x) ^ (1.515 : ℝ) * exp (-0.8274 * sqrt (log x)) := by
+  have h_exp : (log x) ^ (0.015 : ℝ) * exp (0.0202836 * sqrt (log x)) ≥ 1 := by
     by_cases h₂ : log x ≤ 1 <;> by_cases h₃ : log x ≥ 1
     · norm_num [show log x = 1 by grind] at *
     · simp_all only [ge_iff_le, not_le, rpow_def_of_pos (log_pos <| show 1 < x by grind)]
@@ -580,10 +580,13 @@ blueprint_comment /-- Some results from \cite{PT2021}-/
 @[blueprint
   "thm:pt2021-psi"
   (title := "Platt-Trudgian 2021 $\\psi$ bound")
-  (statement := /-- For $x \geq e^{2000}$, we have $|\psi(x) - x| \leq x \cdot 235\, (\log x)^{0.52} \exp\!\left(-\sqrt{\frac{\log x}{5.573412}}\right)$. -/)
+  (statement := /-- For $x \geq e^{2000}$, we have
+  $|\psi(x) - x| \leq x \cdot 411.4\, (\log x / R)^{1.52}
+  \exp\!\left(-1.89\sqrt{\frac{\log x}{R}}\right)$ with $R = 5.573412$. -/)
   (latexEnv := "theorem")]
 theorem psi_bound (x : ℝ) (hx : x ≥ exp 2000) :
-    |ψ x - x| ≤ x * 235 * (log x) ^ (0.52 : ℝ) * exp (-sqrt (log x / 5.573412)) := by sorry
+    |ψ x - x| ≤ x * 411.4 * (log x / 5.573412) ^ (1.52 : ℝ) *
+      exp (-1.89 * sqrt (log x / 5.573412)) := by sorry
 
 end PT
 


### PR DESCRIPTION
## Summary
- Trudgian Thm 2: `|π-li|`
- JY Thm 1.4: `Eπ` exponent `1.801`; PT/JY π blueprints use `li`
- PT ψ Table 1 constants; JY ψ exponent `1.515`

Supersedes #1652 #1653 #1659 #1661 #1663.

## Test plan
- [ ] Compare PT / JY / Trudgian papers for the cited theorems

Made with [Cursor](https://cursor.com)