### PR TITLE
Chore: fix warnings

### DIFF
--- a/PrimeNumberTheoremAnd/MellinCalculus.lean
+++ b/PrimeNumberTheoremAnd/MellinCalculus.lean
@@ -1290,7 +1290,7 @@ lemma MellinOfSmooth1a {ν : ℝ → ℝ} (diffν : ContDiff ℝ 1 ν)
     · apply Integrable.piecewise Smeas ?_ integrableOn_zero
       simp only [IntegrableOn, Measure.restrict_restrict_of_subset SsubI]
       apply MeasureTheory.Integrable.mono_measure ?_
-      · apply MeasureTheory.Measure.restrict_mono' (HasSubset.Subset.eventuallyLE SsubT) le_rfl
+      · apply MeasureTheory.Measure.restrict_mono' SsubT.eventuallyLE le_rfl
       have : volume.restrict (Tx ×ˢ Ty) = (volume.restrict Tx).prod (volume.restrict Ty) := by
         rw [Measure.prod_restrict, MeasureTheory.Measure.volume_eq_prod]
       conv => rw [this]; lhs; intro; rw [mul_comm]

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -4023,8 +4023,7 @@ theorem WeakPNT_AP {q : ℕ} {a : ℕ} (hq : q ≥ 1) (ha : a.Coprime q) (ha' : 
   have h_summable : ∀ s : ℝ, 1 < s → Summable (fun n ↦ (if n % q = a then Λ n else 0) / n ^ s) := by
     intro s hs
     refine .of_nonneg_of_le (fun n ↦ ?_) (fun n ↦ ?_) (summable_vonMangoldt_div_rpow hs)
-    · split_ifs <;> first | positivity | exact div_nonneg (not_not.mp fun h ↦ by
-        have := Nat.Prime.pos (by contrapose! h; aesop : n.Prime); aesop) (rpow_nonneg (Nat.cast_nonneg _) _)
+    · split_ifs <;> positivity
     · split_ifs <;> norm_num; exact div_nonneg vonMangoldt_nonneg (by positivity)
   obtain ⟨G, hG₁, hG₂⟩ := WeakPNT_AP_prelim hq ha ha'
   convert WienerIkeharaTheorem'' _ _ _ _ using 1

--- a/PrimeNumberTheoremAnd/ZetaConj.lean
+++ b/PrimeNumberTheoremAnd/ZetaConj.lean
@@ -28,82 +28,6 @@ theorem deriv_conj_conj' (f : ℂ → ℂ) (p : ℂ) :
   simp
 
 @[blueprint
-  (title := "conj-riemannZeta-conj-aux1")
-  (statement := /--
-    Conjugation symmetry of the Riemann zeta function in the half-plane of convergence. Let
-    $s \in \mathbb{C}$ with $\Re(s) > 1$. Then $\overline{\zeta(\overline{s})} = \zeta(s)$.
-  -/)
-  (proof := /--
-    We expand the definition of the Riemann zeta function as a series and find that the two sides
-    are equal term by term.
-  -/)]
-lemma conj_riemannZeta_conj_aux1 (s : ℂ) (hs : 1 < s.re) :
-    conj (riemannZeta (conj s)) = riemannZeta s := by
-  rw [zeta_eq_tsum_one_div_nat_add_one_cpow hs]
-  rw [zeta_eq_tsum_one_div_nat_add_one_cpow (by simpa)]
-  rw [Complex.conj_tsum]
-  congr
-  ext n
-  have h1 : n + 1 ≠ 0 := by linarith
-  have h2 : (n : ℂ) + 1 ≠ 0 := by exact_mod_cast h1
-  rw [Complex.cpow_def_of_ne_zero h2, Complex.cpow_def_of_ne_zero h2, RCLike.conj_div, map_one,
-    ← Complex.exp_conj, map_mul, Complex.conj_conj]
-  congr 2
-  rw [show (↑n + 1 : ℂ) = ↑((n + 1 : ℕ) : ℕ) from by push_cast; ring,
-    ← Complex.natCast_log, Complex.conj_ofReal]
-
-blueprint_comment /--
-% TODO: Submit this and the following corollaries to Mathlib.
--/
-@[blueprint
-  (title := "conj-riemannZeta-conj")
-  (statement := /--
-    Conjugation symmetry of the Riemann zeta function. Let $s \in \mathbb{C}$. Then
-    $$\overline{\zeta(\overline{s})} = \zeta(s).$$
-  -/)
-  (proof := /--
-    By the previous lemma, the two sides are equal on the half-plane
-    $\{s \in \mathbb{C} : \Re(s) > 1\}$. Then, by analytic continuation, they are equal on the
-    whole complex plane.
-  -/)]
-theorem conj_riemannZeta_conj (s : ℂ) : conj (riemannZeta (conj s)) = riemannZeta s := by
-  by_cases hs1 : s = 1
-  · subst hs1
-    rw [map_one, Complex.conj_eq_iff_real, riemannZeta_one]
-    use (Real.eulerMascheroniConstant - Real.log (4 * Real.pi)) / 2
-    rw [show (4 * ↑Real.pi : ℂ) = ↑(4 * Real.pi) from by push_cast; ring,
-      ← Complex.ofReal_log (by positivity : (0 : ℝ) ≤ 4 * Real.pi)]
-    push_cast
-    ring
-  · let U : Set ℂ := {1}ᶜ
-    let g := fun s ↦ conj (riemannZeta (conj s))
-    suffices Set.EqOn g riemannZeta U by
-      apply this
-      rwa [Set.mem_compl_singleton_iff]
-    apply AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq (𝕜 := ℂ) (z₀ := 2)
-    · simp [U]
-    · rw [Filter.eventuallyEq_iff_exists_mem]
-      set V := Complex.re ⁻¹' (Set.Ioi 1)
-      use V
-      constructor
-      · have Vopen : IsOpen V := Complex.continuous_re.isOpen_preimage _ isOpen_Ioi
-        exact Vopen.mem_nhds (by simp [V])
-      · intro s hs
-        exact conj_riemannZeta_conj_aux1 s hs
-    · refine DifferentiableOn.analyticOnNhd ?_ isOpen_compl_singleton
-      intro s₁ hs₁
-      have hs₁' : conj s₁ ≠ 1 :=
-        (map_ne_one_iff (starRingEnd ℂ) (RingHom.injective (starRingEnd ℂ))).mpr hs₁
-      convert! (HasDerivAt.conj_conj
-        (differentiableAt_riemannZeta hs₁').hasDerivAt).differentiableAt.differentiableWithinAt
-        (s := U)
-      rw [Complex.conj_conj]
-    · refine DifferentiableOn.analyticOnNhd ?_ isOpen_compl_singleton
-      intro s₁ hs₁
-      exact (differentiableAt_riemannZeta hs₁).differentiableWithinAt
-    · exact (isConnected_compl_singleton_of_one_lt_rank (by simp) 1).isPreconnected
-
-@[blueprint
   (title := "deriv-riemannZeta-conj")
   (statement := /--
     Conjugation symmetry of the derivative of the Riemann zeta function. Let $s \in \mathbb{C}$.
@@ -115,7 +39,7 @@ theorem conj_riemannZeta_conj (s : ℂ) : conj (riemannZeta (conj s)) = riemannZ
   -/)]
 theorem deriv_riemannZeta_conj (s : ℂ) :
     deriv riemannZeta (conj s) = conj (deriv riemannZeta s) := by
-  simp [← deriv_conj_conj', conj_riemannZeta_conj]
+  simp [← deriv_conj_conj']
 
 theorem logDerivZeta_conj (s : ℂ) :
     (deriv riemannZeta / riemannZeta) (conj s) = conj ((deriv riemannZeta / riemannZeta) s) := by


### PR DESCRIPTION
Fix some build and deprecation warnings.  Also removes some results from ZetaConj which are now unused due to upstreaming.