### PR TITLE
docs(PULL_REQUEST_STYLE): §4 helper scoping, §8 no-linter-warnings, new §12 for formalisation PRs

### DIFF
--- a/PULL_REQUEST_STYLE.md
+++ b/PULL_REQUEST_STYLE.md
@@ -261,7 +261,14 @@ Minimum checks:
    or `references.bib`**: run the xelatex check documented in the
    pnt-plus-ieantn skill / `CLAUDE.md` — the LaTeX errors surface only
    there, not in `lake build :blueprint`.
-4. **CI green on the PR** before commenting `awaiting-review`. If CI is
+4. **No new warnings other than `declaration uses 'sorry'`.** Linter
+   warnings (unused variables, deprecated names, `Try this:` autofix
+   suggestions, docstring nits, …) are cheap to silence; the fix is
+   almost always mechanical. Leaving them in a PR shifts a chore onto
+   the reviewer. If a warning is intentional (rare) and can't be
+   suppressed with a small local `set_option`, explain it in the PR
+   body — otherwise clear it.
+5. **CI green on the PR** before commenting `awaiting-review`. If CI is
    red, either it's your fault (fix it) or a genuine main-was-broken
    situation (say so on the PR).
 
@@ -315,13 +322,76 @@ Open a PR as **draft** if any of the following are true:
   infrastructure in `*_tables.lean` — reviewers may want to steer the
   shape before you build downstream on it.
 - You're refactoring a widely-used definition.
-- You're proposing a new file for a new paper (the "bootstrapping"
+- You're proposing a new file for a new paper (see also §12, and the "bootstrapping"
   workflow in the pnt-plus-ieantn skill).
 - You're bulk-editing many files with mechanical similar changes.
 
 Convert to "ready for review" only after CI is green.
 
-## 12. AI-assisted contributions
+## 12. Contributing formalizations of new material (not yet in the blueprint)
+
+Sometimes a contributor has independently formalised a result that
+isn't currently a `sorry` in the repo — a theorem from the IEANTN
+literature the blueprint hasn't reached yet, or an alternate route to
+something already partially covered. That's welcome, but the mechanism
+matters.
+
+**What to do**:
+
+- Open a pull request against `main` that adds the material as one or
+  more `.lean` files under `PrimeNumberTheoremAnd/IEANTN/`. If the
+  contribution is a single file, add it at the folder root; if it's
+  multiple files (a paper subproject), create a subfolder for them
+  (matching the existing `BKLNW/`, `CH2/`, `eSHP/`,
+  `FioriKadiriSwidinsky/`, `Ramanujan/`, `RosserSchoenfeld/`
+  convention).
+- Integrate the files with LeanArchitect the same way existing IEANTN
+  files do (see the "Bootstrapping a new paper file" recipe in the
+  `pnt-plus-ieantn` skill and the existing files as templates):
+  `import Architect`, `@[blueprint …]` metadata on the main results,
+  `blueprint_comment` for section prose, `\cite{…}` referring to
+  entries you've also added to `blueprint/src/references.bib`.
+- Tag the **main results** with `@[blueprint]` — that surfaces them in
+  the blueprint so the maintainers and other contributors can see the
+  scope of what you've formalised without having to open every Lean
+  file. Supporting sublemmas follow the §4 scoping rule
+  (`private` for local scaffolding; public + `@[blueprint]` for
+  reusable helpers).
+- The PR description should explain what the material is, cite the
+  source paper (with a bibkey added to `references.bib` if the paper
+  isn't already there), and mention any dependencies on unfinished
+  parts of the blueprint. Consider posting on the Zulip channel
+  (§2) before opening the PR — that gives maintainers a chance to
+  flag overlap with in-flight work.
+- Maintainers may later wire the new material into the wider IEANTN
+  build (updating `blueprint/src/blueprint.tex` chapter placement,
+  `PrimeNumberTheoremAnd.lean`'s umbrella imports, and downstream
+  consumers). You don't have to do this yourself — a clean PR with
+  the material in the right folder and the blueprints in the right
+  shape is enough.
+
+**What NOT to do**:
+
+- **Don't submit formalisations as zip files, tarballs, patches
+  attached to Zulip messages, or links to external repositories in
+  place of a PR.** The project's review, CI, blueprint-generation, and
+  history-tracking machinery all run on PR-shaped contributions;
+  attachments and off-repo drops sit outside all of that and have no
+  path to being adopted. If the work already lives in an external
+  repo, the productive move is to open a PR that ports it into
+  `PrimeNumberTheoremAnd/IEANTN/` under this repo's conventions —
+  even if that reformatting is most of the work.
+- Don't PR just the `.lean` file body without `@[blueprint]`
+  metadata on the headline results. Without that, the material lands
+  in the codebase but is invisible on the blueprint page, which
+  defeats a large part of the point.
+
+Supplementing a formalisation PR with LeanArchitect links (e.g. to
+the rendered blueprint page or the LeanArchitect-generated
+declaration index) is welcome and helps reviewers orient — but the
+material itself belongs in Lean files in the repo.
+
+## 13. AI-assisted contributions
 
 Contributions produced with the aid of an AI coding assistant (Cursor,
 Claude Code, Copilot, Codex, aider, …) are welcome and follow the same
@@ -353,7 +423,7 @@ rules as any other contribution — but they should also:
    them.** As a rough guideline, don't have more than 3 open AI-assisted
    PRs from you at a time.
 
-## 13. Portions bound for Mathlib
+## 14. Portions bound for Mathlib
 
 Code intended for upstream Mathlib follows Mathlib's own style manual
 (golfing standards, naming conventions, docstring rules, `_root_`
@@ -366,7 +436,7 @@ If you notice a small helper lemma in this repository that plausibly
 belongs upstream, flag it in the PR description; the maintainers can
 decide whether to route it via a separate Mathlib PR.
 
-## 14. What NOT to do
+## 15. What NOT to do
 
 - **Don't edit files under `.lake/` or `docbuild/`** — these are build
   artefacts.
@@ -413,6 +483,14 @@ politely close/reject PRs exhibiting them and request re-submission:
   closed by near-identical proofs (or two similar theorems each with
   their own bespoke helpers) — ask the author to extract the shared
   proposition instead.
+- **Linter warnings left in the diff.** Anything beyond
+  `declaration uses 'sorry'`. Ask the author to clear them (§8).
+- **Off-repo formalisation drop**. A contribution offered as a zip
+  file, tarball, patch attached to a Zulip message, or a pointer to
+  an external repository, in lieu of a PR that lands the material
+  inside `PrimeNumberTheoremAnd/IEANTN/` with proper LeanArchitect
+  integration and `@[blueprint]` metadata. Ask the contributor to
+  re-shape it as a PR against this repo (§12).
 
 ---
 

--- a/PULL_REQUEST_STYLE.md
+++ b/PULL_REQUEST_STYLE.md
@@ -330,11 +330,16 @@ Convert to "ready for review" only after CI is green.
 
 ## 12. Contributing formalizations of new material (not yet in the blueprint)
 
-Sometimes a contributor has independently formalised a result that
-isn't currently a `sorry` in the repo — a theorem from the IEANTN
-literature the blueprint hasn't reached yet, or an alternate route to
-something already partially covered. That's welcome, but the mechanism
-matters.
+**Pull requests contributing formalisations of results in explicit
+analytic number theory are welcome even when they don't correspond to
+an already-issued task**, provided they adhere to the style guidelines
+in this document. If you've formalised (or partially formalised) a
+result from the IEANTN literature that the blueprint hasn't reached
+yet, an alternate route to something already partially covered, or a
+helpful piece of infrastructure the project could reuse — please open
+a PR. You don't have to wait for a maintainer to file an issue first.
+
+The mechanism matters, though.
 
 **What to do**:
 


### PR DESCRIPTION
## Summary

Continues the work-in-progress evolution of `PULL_REQUEST_STYLE.md` (introduced in #1674) with three sets of additions folded in from Zulip feedback since the initial merge:

- **§4 (Reuse over reinvention)** — two new rules on scoping helper lemmas.
  - *Scope helpers by intended reach.* Sublemmas used only to prove one target result should be marked `private`; those with broader project applicability stay public and get an `@[blueprint]` tag so they surface on the blueprint page. Public unblueprinted helpers are the worst of both worlds.
  - *Actively de-duplicate across targets.* If two related tasks would each need a very similar computation, extract one shared proposition rather than proving each independently. Explicit note that this is a common AI-assistance failure mode — the tool sees the immediate goal but not the sibling goal it could share machinery with.

- **§8 (Verify locally before requesting review)** — new bullet added per Alastair Irving's Zulip feedback: no new warnings other than `declaration uses 'sorry'`. Linter warnings (unused vars, deprecations, `Try this:` autofix suggestions, docstring nits) are cheap to silence and shifting them onto the reviewer is not free.

- **§12 (new: Contributing formalisations of new material, not yet in the blueprint)** — added after Harald Helfgott's Zulip discussion around off-repo formalisation drops. Opens with an explicit "PRs of formalisations in explicit analytic number theory are welcome even without an issue, provided they adhere to the guidelines here". Explains the intended mechanism: PR against `main`, files under `PrimeNumberTheoremAnd/IEANTN/` (subfolder if multi-file), LeanArchitect integration, main results tagged `@[blueprint]`. Explicitly rejects zip files / tarballs / patches attached to Zulip messages / links to external repositories as substitutes for a PR. Sections 12-14 renumbered to 13-15 accordingly.

Matching entries added to the reviewer antipatterns cheat sheet: *"Public helper with no `@[blueprint]` tag"*, *"Parallel proofs of parallel computations"*, *"Linter warnings left in the diff"*, and *"Off-repo formalisation drop"*.

The guide's overall "work in progress" framing is unchanged — expect further evolution as more PRs surface new patterns.

## Test plan

- [x] Markdown renders cleanly (visual review of the diff and section numbering).
- [x] Section headings run 1-15 sequentially with no gaps.
- [x] Cross-references (§2 ↔ §12; §11 → §12) resolve to the intended sections after renumbering.
- [x] Cheat-sheet additions are consistent with the corresponding section rules.
- [ ] Maintainer sign-off on tone / scope / rules — the guide is explicitly work-in-progress; individual wording remains open to revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)