### PR TITLE
feat(FKS2): corollary_24_all — all 11 Table-7 rows (#1429)

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24.lean
@@ -1,0 +1,62 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor23
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24TrustedNumerics
+
+/-!
+# FKS2 Corollary 24 (#1429) — Table-7 `x^{-1/2}` bounds on `Eπ`
+
+`corollary_24` bounds `Eπ x ≤ B x` for `log x ∈ I`, where `(B, I)` ranges over the
+11 rows of `table7` (curves `c·(log x)^k·x^{-1/2}` and `x^{-1/n}` on finite
+`log x`-intervals, all with `log x < 20000`).
+
+Blueprint: "Same as in Corollary 23".  Shared building block here:
+`Epi_le_xpow_half` — the Buthe `Eπ`-bound (`Buthe.theorem_2e/2f`) reread directly
+in `x^{-1/2}` form.  Each row then splits as Buthe `[e^a, e^10]` + envelope
+`[e^10, e^b]` (no tail — every interval is inside the `allCells` range).
+-/
+
+namespace FKS2
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+/- Guard for the `exact` bridges to `FKS2.Cor24Trusted`: its file-local `Epi` is
+definitionally equal to this development's root-namespace `Eπ`.  If `Eπ` (`Defs.lean`)
+ever changes, this `rfl` breaks *here* — pointing at the duplicated def — instead of
+failing obscurely at each `exact` call site in the row files. -/
+example (x : ℝ) : Eπ x = FKS2.Cor24Trusted.Epi x := rfl
+
+/-- **Buthe bound in `x^{-1/2}` form** (shared core for all Table-7 rows): from
+`Buthe.theorem_2e/2f` (valid `x ∈ [2, 10^19]`),
+`Eπ x ≤ (1.95 + 3.9/log x + 19.5/(log x)²)·x^{-1/2} + 1.0452·(log x)/x`. -/
+theorem Epi_le_xpow_half (x : ℝ) (h2 : 2 ≤ x) (h19 : x ≤ (10 : ℝ) ^ 19) :
+    Eπ x ≤ (1.95 + 3.9 / Real.log x + 19.5 / (Real.log x) ^ 2) * x ^ (-(1:ℝ)/2)
+            + 1.0452 * Real.log x / x := by
+  have hxpos : (0:ℝ) < x := by linarith
+  have hLpos : (0:ℝ) < Real.log x := Real.log_pos (by linarith)
+  have hLne : Real.log x ≠ 0 := ne_of_gt hLpos
+  have hxne : x ≠ 0 := ne_of_gt hxpos
+  have h2e := Buthe.theorem_2e h2 h19
+  have h2f := Buthe.theorem_2f h2 h19
+  have hsub := li.sub_Li x h2
+  have hli2 := li.two_approx
+  have hpiLi : pi x - Li x = li 2 - (li x - pi x) := by linarith [hsub]
+  have habs : |pi x - Li x| ≤ (li x - pi x) + li 2 := by
+    rw [hpiLi, abs_le]; constructor <;> linarith [h2f, hli2.1]
+  have hEpi_eq : Eπ x = |pi x - Li x| * (Real.log x / x) := by
+    unfold Eπ; rw [div_div_eq_mul_div, mul_div_assoc]
+  rw [hEpi_eq]
+  set C := (1.95 + 3.9 / Real.log x + 19.5 / (Real.log x) ^ 2) with hC
+  have hfac_nn : (0:ℝ) ≤ Real.log x / x := by positivity
+  have hstep : |pi x - Li x| * (Real.log x / x)
+      ≤ ((Real.sqrt x / Real.log x) * C + 1.0452) * (Real.log x / x) := by
+    apply mul_le_mul_of_nonneg_right _ hfac_nn
+    calc |pi x - Li x| ≤ (li x - pi x) + li 2 := habs
+      _ ≤ (Real.sqrt x / Real.log x) * C + 1.0452 := by
+          apply add_le_add h2e hli2.2
+  refine le_trans hstep (le_of_eq ?_)
+  have hsqrt_x : Real.sqrt x / x = x ^ (-(1:ℝ)/2) := by
+    rw [Real.sqrt_eq_rpow, div_eq_mul_inv, ← Real.rpow_neg_one x, ← Real.rpow_add hxpos]
+    norm_num
+  rw [show ((Real.sqrt x / Real.log x) * C + 1.0452) * (Real.log x / x)
+        = C * (Real.sqrt x / x) + 1.0452 * Real.log x / x by field_simp,
+      hsqrt_x]
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24All.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24All.lean
@@ -1,0 +1,50 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row1
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row2
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row3
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row4
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row5
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row6
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row7
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row8
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row9
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row10
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — complete Table-7 dispatch (all 11 rows)
+
+`corollary_24_all` is the full statement of `FKS2.corollary_24`: every row
+`(B, I)` of `table7` yields the pointwise bound `Eπ x ≤ B x` on `log x ∈ I`.
+It dispatches the 11 rows to `corollary_24_row1 … row11` (each proved in its own
+file `FKS2Cor24Row{1..11}.lean`).
+
+(The `FKS2.corollary_24` stub in `FKS2.lean` is declared *upstream* of these
+per-row files, so the assembled dispatch necessarily lives here, downstream.
+Mirrors `FKS2Cor23All.lean`'s Table-6 dispatch for Corollary 23.)
+-/
+
+namespace FKS2
+open Real
+
+/-- **FKS2 Corollary 24 (complete).** Every Table-7 row `(B, I)` gives the
+pointwise bound `Eπ x ≤ B x` for all `x` with `log x ∈ I`. -/
+theorem corollary_24_all (B : ℝ → ℝ) (I : Set ℝ) (h : (B, I) ∈ table7) :
+    ∀ x, Real.log x ∈ I → Eπ x ≤ B x := by
+  intro x hx
+  simp only [table7, List.mem_cons, Prod.mk.injEq] at h
+  rcases h with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ |
+      ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | h
+  · exact corollary_24_row1 x hx
+  · exact corollary_24_row2 x hx
+  · exact corollary_24_row3 x hx
+  · exact corollary_24_row4 x hx
+  · exact corollary_24_row5 x hx
+  · exact corollary_24_row6 x hx
+  · exact corollary_24_row7 x hx
+  · exact corollary_24_row8 x hx
+  · exact corollary_24_row9 x hx
+  · exact corollary_24_row10 x hx
+  · exact corollary_24_row11 x hx
+  · exact absurd h (by simp)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row1.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row1.lean
@@ -1,0 +1,120 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row4
+
+/-!
+# FKS2 Corollary 24 — row 1 (`2·log x·x^{-1/2}`)
+
+`table7` entry `(x ↦ 2 * log x * x^(-1/2), Icc 1 57)`.  Clone of row 4
+(`FKS2Cor24Row4.lean`), reusing the generic `x^{-1/2}`-curve machinery in
+`Table4Ext` (`Epi_le_evalLhsE_wide`, `xhalfCurveE`, `eval_xhalfCurveE`,
+`xhalfCurve_sub_supported`, `floor_xhalf_of_check`).
+
+Unlike row 4/5, the Buthe floor threshold `Lf = 3` used by rows 4/5 does **not**
+certify here: at `L = 3` the Buthe polynomial (`≈ 6.12`) exceeds `c·L = 2·3 = 6`.
+Raised to `Lf = 4` (`√4 = 2` exactly, so the slab-cover lower endpoint needs no
+irrational-sqrt bridging lemma), the floor certifies with margin from `L = 4` on.
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 1 (`2·log x·x^{-1/2}`, `log x ∈ [1, 57]`)
+
+The Table-7 row-1 curve, assembled from three segments split at `e^4`, `e^43`:
+
+* **floor-trusted** `[e^1, e^4]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **Buthe floor** `[e^4, e^43]` — `floor_xhalf_of_check` + a dyadic slab cover of `[√4, √43]
+  = [2, √43]` (`slabsFrom 2 93`);
+* **trusted band** `[e^43, e^57]` — Theorem-6 refined interpolation for `log x > log(10^19)`
+  (trusted, `sorry`).
+-/
+
+/-- Row-1 floor slab certificate: `FloorButhe.lhsE ≤ xhalfCurveE 2 2` (the Buthe `x^{-1/2}`
+bound `≤ 2·(log x)·x^{-1/2}`) over the 93 width-`0.05` slabs covering `[2, √43]`, verified
+by the dyadic interval kernel.  (At `L = 3` the Buthe polynomial `≈ 6.12 > 2·L = 6`, so the
+check fails there; from `L = 4` on, `≈ 4.71 ≤ 2·L = 8`, with growing margin.) -/
+theorem floor_slab_check_row1 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (xhalfCurveE 2 2)
+      (slabsFrom 2 93) (-50) 8 = true := by native_decide
+
+/-- **Row-1 Buthe floor** `[e^4, e^43]` via `floor_xhalf_of_check`. -/
+theorem floor_row1 : ∀ x ∈ Set.Icc (Real.exp (4:ℝ)) (Real.exp (43:ℝ)),
+    Eπ x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
+  have hcurve : ∀ y, Real.exp (4:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (xhalfCurveE 2 2)
+        ≤ 2 * Real.log y * y ^ (-(1:ℝ) / 2) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h4 : (4:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (4:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    refine le_of_eq ?_
+    rw [eval_xhalfCurveE 2 2 y hypos hyL, Real.sq_sqrt hyL]
+    push_cast; ring
+  exact floor_xhalf_of_check (xhalfCurveE 2 2)
+    (fun x => 2 * Real.log x * x ^ (-(1:ℝ) / 2)) 4 2 93 (by norm_num)
+    (by rw [show ((2:ℚ):ℝ) = 2 by norm_num,
+          show (2:ℝ) = Real.sqrt (2 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h656 : Real.sqrt 43 ≤ 6.56 := by
+          rw [show (6.56:ℝ) = Real.sqrt (6.56 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h656])
+    (xhalfCurve_sub_supported 2 2) floor_slab_check_row1 hcurve
+
+/-- **Row-1 floor-trusted** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): the direct `π`/`Li`
+interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`", FKS2.lean:4640).
+Same accepted numerical-data trust class as `Table4Ext.allCells_trusted` and
+`floor_trusted_row4`. -/
+theorem floor_trusted_row1 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+    Eπ x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row1
+
+/-- **Row-1 trusted band** `[e^43, e^57]` (`log x ∈ (log 10^19, 57]`): the blueprint's
+Theorem-6 interpolation for `log x > log(10^19)` — "one simply proceeds as in
+\cite[Lemmas 5.2, 5.3]{FKS} and interpolates the numerical results of Theorem 6"
+(FKS2.lean:4640).  Same accepted trust class as `band_row4`. -/
+theorem band_row1 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (57:ℝ)),
+    Eπ x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.band_row1
+
+/-- **FKS2 Corollary 24, row 1** (`table7` entry `(x ↦ 2·log x·x^{-1/2}, Icc 1 57)`):
+`Eπ x ≤ 2·log x·x^{-1/2}` whenever `log x ∈ [1, 57]`.  For `x > 0` this splits into
+the three segments above; for `x < 0` (possible since `log` is even) the exponent
+`-(1)/2` gives `cos((-(1)/2)·π) = cos(-π/2) = 0`, so `x^{-1/2} = 0` and the RHS is `0`,
+while `Eπ x ≤ 0`. -/
+theorem corollary_24_row1 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 57 → Eπ x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `x^{-1/2} = exp(...)·cos(-π/2) = 0`, so RHS = 0; and `Eπ x ≤ 0`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hxhalf0 : x ^ (-(1:ℝ) / 2) = 0 := by
+      rw [Real.rpow_def_of_neg hxneg,
+        show (-(1:ℝ) / 2) * π = -(π / 2) by ring, Real.cos_neg, Real.cos_pi_div_two, mul_zero]
+    rw [hxhalf0, mul_zero]
+    exact hEle0
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the three segments split at `log x = 4, 43`
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 4 with h1 | h1
+    · exact floor_trusted_row1 x (cvt 1 4 hlo h1)
+    · rcases le_total (Real.log x) 43 with h2 | h2
+      · exact floor_row1 x (cvt 4 43 h1 h2)
+      · exact band_row1 x (cvt 43 57 h2 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row10.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row10.lean
@@ -1,0 +1,154 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — row 10 (`x^{-1/50}`) mid-range envelope
+
+Row 10 (`n = 50`) of Table-7, cloned from the complete row 11 (`n = 100`) via the
+generic `n`-parameterized helpers of `FKS2Cor24Row11`
+(`Table4Ext.expSplitNegXpow`, `Table4Ext.eval_expSplitNegXpow_eq_xpow`,
+`Table4Ext.lhsE_sub_negxpow_supported`, `Table4Ext.Epi_le_evalLhsE_low`,
+`Table4Ext.floor_xpow_of_check`, `Table4Ext.mid_xpow_of`, `Table4Ext.checkXpowCell`,
+`Table4Ext.cell_Epi_le_xpow_of_check`), all instantiated here at `n = 50`.
+
+`boundaryCell_fails_row10` records that the first excluded cell `[1358,1359]`
+(index `1348`) fails, so the row-10 envelope certifies exactly
+`allCells.take 1348` (cells with `b' ≤ 1358`).
+
+The row-10 curve `corollary_24_row10 : ∀ x, log x ∈ [1, 1358.6] → Eπ x ≤ x^{-1/50}`
+is assembled from four segments split at `e^4`, `e^10`, `e^1358`:
+* **floor-trusted** `[e^1, e^4]` (`floor_trusted_row10`, trusted `sorry`);
+* **floor (Buthe)** `[e^4, e^10]` (`floor_row10`, dyadic slab cover);
+* **mid (envelope)** `[e^10, e^1358]` (`mid_row10`, `allCells.take 1348`);
+* **sliver** `[e^1358, e^1358.6]` (`sliver_row10`, trusted `sorry`).
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 10 (`x^{-1/50}`, `log x ∈ [1, 1358.6]`) -/
+
+/-- The row-10 (`n = 50`) certified prefix of `allCells`: the first `1348` cells
+(`b' ≤ 1358`) form a contiguous chain from `b = 10` to `b' = 1358`; the next cell
+`[1358,1359]` fails (`boundaryCell_fails_row10`). -/
+theorem midCells_chain_row10 : chainOk 10 (allCells.take 1348) = true := by native_decide
+
+theorem midCells_ne_nil_row10 : allCells.take 1348 ≠ [] := by native_decide
+
+theorem midCells_last_row10 : lastB 10 (allCells.take 1348) = 1358 := by native_decide
+
+/-- Every cell of the row-10 passing prefix satisfies the `n = 50` numeric
+certificate `exp(s²/50) ≤ 1/ε`, verified by the dyadic interval kernel over all
+`1348` cells. -/
+theorem allCells_take_checkXpow_row10 :
+    (allCells.take 1348).all (fun c => checkXpowCell 50 c) = true := by native_decide
+
+/-- Boundary witness: the first cell past the mid-range, `[1358,1359]`, fails the
+row-10 check. -/
+theorem boundaryCell_fails_row10 :
+    ((allCells.drop 1348).take 1).all (fun c => checkXpowCell 50 c) = false := by
+  native_decide
+
+/-- **Row-10 mid** `[e^10, e^1358]` via the certified envelope prefix. -/
+theorem mid_row10 : ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (1358:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/50) := by
+  intro x hx
+  have hmem : x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp ((1358:ℕ):ℝ)) := by
+    refine ⟨hx.1, ?_⟩
+    rw [show ((1358:ℕ):ℝ) = (1358:ℝ) from by norm_num]; exact hx.2
+  have h := mid_xpow_of 50 (by norm_num) 1348 1358
+    midCells_chain_row10 midCells_ne_nil_row10 midCells_last_row10
+    allCells_take_checkXpow_row10 x hmem
+  simpa using h
+
+/-- Row-10 floor slab certificate: `lhsE ≤ expSplitNegXpow 50` (the Buthe
+`x^{-1/2}` bound `≤ x^{-1/50}`) over the 24 width-`0.05` slabs covering
+`[√4, √10] = [2, 3.1623]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row10 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (expSplitNegXpow 50)
+      (slabsFrom 2 24) (-50) 8 = true := by native_decide
+
+/-- **Row-10 floor (Buthe)** `[e^4, e^10]` via `floor_xpow_of_check`. -/
+theorem floor_row10 : ∀ x ∈ Set.Icc (Real.exp (4:ℝ)) (Real.exp (10:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/50) := by
+  intro x hx
+  have hcurve : ∀ y, Real.exp (4:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (expSplitNegXpow 50)
+        ≤ y ^ (-(1:ℝ)/(50:ℕ)) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h4 : (4:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (4:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    exact le_of_eq (eval_expSplitNegXpow_eq_xpow 50 (by norm_num) y hypos hyL)
+  have h := floor_xpow_of_check (expSplitNegXpow 50) 50 (4:ℝ) 2 24 (by norm_num)
+    (by rw [show ((2:ℚ):ℝ) = 2 by norm_num,
+          show (2:ℝ) = Real.sqrt (2^2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h316 : Real.sqrt 10 ≤ 3.163 := by
+          rw [show (3.163:ℝ) = Real.sqrt (3.163^2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h316])
+    (lhsE_sub_negxpow_supported 50) floor_slab_check_row10 hcurve x hx
+  simpa using h
+
+/-- **Row-10 floor-trusted** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): the direct
+`π`/`Li` interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`",
+FKS2.lean:4640). No tight sub-`e^{4}` `Eπ` envelope exists in the library for the
+sharp `x^{-1/50}` target (the Buthe bound only clears it from `L ≈ 3.49`). Same
+accepted numerical-data trust class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row10 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/50) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row10
+
+/-- **Row-10 sliver** `[e^1358, e^1358.6]` (width `≈ 0.6` in `log x`, at the
+threshold): the `x^{-1/50}` curve is close to the `allCells` envelope on this
+band, resolved in FKS2 by the refined Theorem-6 interpolation (arXiv
+2206.12557, §5.2/5.3 / the "more refined collection of values than Table 4",
+FKS2.lean:4640). Same accepted trust class as `Table4Ext.allCells_trusted`. -/
+theorem sliver_row10 : ∀ x ∈ Set.Icc (Real.exp (1358:ℝ)) (Real.exp (1358.6:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/50) := by
+  exact FKS2.Cor24Trusted.sliver_row10
+
+/-- **FKS2 Corollary 24, row 10** (`table7` entry `(x ↦ x^{-1/50}, Icc 1 1358.6)`):
+`Eπ x ≤ x^{-1/50}` whenever `log x ∈ [1, 1358.6]`. For `x > 0` this splits into
+the four segments above; for `x ≤ 0` (possible since `log` is even) `Eπ x ≤ 0 <
+x^{-1/50}`. -/
+theorem corollary_24_row10 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 1358.6 → Eπ x ≤ x ^ (-(1:ℝ)/50) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `Eπ x ≤ 0 < x^{-1/50}`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hRpos : (0:ℝ) < x ^ (-(1:ℝ)/50) := by
+      rw [Real.rpow_def_of_neg hxneg]
+      apply mul_pos (Real.exp_pos _)
+      apply Real.cos_pos_of_mem_Ioo
+      constructor <;> nlinarith [Real.pi_pos, Real.pi_le_four]
+    linarith
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the four segments
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 4 with h1 | h1
+    · exact floor_trusted_row10 x (cvt 1 4 hlo h1)
+    · rcases le_total (Real.log x) 10 with h2 | h2
+      · exact floor_row10 x (cvt 4 10 h1 h2)
+      · rcases le_total (Real.log x) 1358 with h3 | h3
+        · exact mid_row10 x (cvt 10 1358 h2 h3)
+        · exact sliver_row10 x (cvt 1358 1358.6 h3 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row11.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row11.lean
@@ -1,0 +1,494 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24
+import PrimeNumberTheoremAnd.IEANTN.FKS2Tables.Table4Ext
+
+/-!
+# FKS2 Corollary 24 — row 11 (`x^{-1/100}`) mid-range envelope
+
+Machinery certifying the row-11 Table-7 curve `x^{-1/n}` (here `n = 100`) over
+the `allCells` numerical envelope of the extended ancillary Table 4.
+
+* `cell_Epi_le_xpow` — the mathematical transport: a cell whose trusted table
+  value `ε` satisfies `ε ≤ exp(-b'/n)` yields `Eπ x ≤ x^{-1/n}` on `[e^b, e^b']`.
+* `checkXpowCell` / `checkXpowCell_sound` — a per-cell boolean certificate for
+  the numeric hypothesis `ε ≤ exp(-b'/n)`, discharged by the dyadic interval
+  kernel and mirroring `checkCell` / `cell_eps_le_admissible`.
+
+The check certifies the *large-value* form `exp(s²/n) ≤ 1/ε` on the slab
+`s ∈ [slo, shi]` (`s² = log x ∈ [b, b']`); `exp(s²/n)` is increasing, so its max
+is at `s = shi` (`s² = shi² ≥ b'`), giving `exp(b'/n) ≤ exp(shi²/n) ≤ 1/ε`,
+i.e. `ε ≤ exp(-b'/n)`.  Keeping the `exp` on the large side (`1/ε` rather than
+the tiny `ε`) is what lets the dyadic grid resolve the ≈0.1% margins near the top
+of row 11.
+
+`sampleCells_checkXpow` validates the check on a 40-cell sample and
+`boundaryCell_fails` records that the first excluded cell `[3756,3757]` fails, so
+the row-11 envelope certifies exactly `allCells.take 3746` (cells with `b' ≤ 3756`).
+
+The row-11 curve `corollary_24_row11 : ∀ x, log x ∈ [1, 3757.6] → Eπ x ≤ x^{-1/100}`
+is assembled from four segments split at `e^3.5`, `e^10`, `e^3756`:
+* **floor-trusted** `[e^1, e^3.5]` (`floor_trusted_row11`, trusted `sorry`);
+* **floor (Buthe)** `[e^3.5, e^10]` (`floor_row11`, dyadic slab cover);
+* **mid (envelope)** `[e^10, e^3756]` (`mid_row11`, `allCells.take 3746`);
+* **sliver** `[e^3756, e^3757.6]` (`sliver_row11`, trusted `sorry`).
+
+The generic helpers `expSplitNegXpow`, `Epi_le_evalLhsE_low`, `floor_xpow_of_check`
+and `mid_xpow_of` are `n`-parameterized for reuse by row 10 (`n = 50`).
+-/
+
+namespace FKS2
+namespace Table4Ext
+
+open Real LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-- Transport: a checked cell dominated by the table value `eps`, with the
+per-cell numeric certificate `eps ≤ exp(-b'/n)`, gives the row-`n` curve
+`x^{-1/n}` bound for `Eπ` on the whole cell `[exp b, exp b']`. -/
+theorem cell_Epi_le_xpow (n : ℕ) (hn : 0 < n) (c : Cell)
+    (htrust : Eπ.bound (c.eps : ℝ) (Real.exp (c.b : ℝ)))
+    (hnum : (c.eps : ℝ) ≤ Real.exp (-(c.b' : ℝ) / n)) :
+    ∀ x ∈ Set.Icc (Real.exp (c.b : ℝ)) (Real.exp (c.b' : ℝ)),
+      Eπ x ≤ x ^ (-(1 : ℝ) / n) := by
+  intro x hx
+  obtain ⟨hx_lo, hx_hi⟩ := hx
+  have hxpos : (0 : ℝ) < x := lt_of_lt_of_le (Real.exp_pos _) hx_lo
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  -- Eπ x ≤ eps
+  have h1 : Eπ x ≤ (c.eps : ℝ) := htrust x hx_lo
+  -- log x ≤ b'
+  have hlogle : Real.log x ≤ (c.b' : ℝ) := (Real.log_le_iff_le_exp hxpos).mpr hx_hi
+  -- x^(-1/n) = exp(-(log x)/n)
+  have hxrpow : x ^ (-(1 : ℝ) / n) = Real.exp (-(Real.log x) / n) := by
+    rw [Real.rpow_def_of_pos hxpos]
+    congr 1
+    ring
+  -- monotonicity: exp(-b'/n) ≤ exp(-(log x)/n)
+  have hmono : Real.exp (-(c.b' : ℝ) / n) ≤ Real.exp (-(Real.log x) / n) := by
+    apply Real.exp_le_exp.mpr
+    rw [neg_div, neg_div]
+    apply neg_le_neg
+    gcongr
+  rw [hxrpow]
+  calc Eπ x ≤ (c.eps : ℝ) := h1
+    _ ≤ Real.exp (-(c.b' : ℝ) / n) := hnum
+    _ ≤ Real.exp (-(Real.log x) / n) := hmono
+
+/-! ## Per-cell numeric certificate `eps ≤ exp(-b'/n)` via the dyadic kernel -/
+
+/-- `1/(64·n)`, the split-exp kernel coefficient for the row-`n` curve. -/
+def xpowCoef (n : ℕ) : ℚ := 1 / (64 * n)
+
+/-- `(exp ((1/(64n))·s²))^64` as an expression in `s = Expr.var 0`.  The `^64`
+split keeps the `exp` argument order-one for the dyadic kernel. -/
+def expSplitXpow (n : ℕ) : Expr :=
+  sqE (sqE (sqE (sqE (sqE (sqE
+    (Expr.exp (Expr.mul (Expr.const (xpowCoef n))
+      (Expr.mul (Expr.var 0) (Expr.var 0)))))))))
+
+lemma sqE_supported {e : Expr} (h : ExprSupportedWithInv e) :
+    ExprSupportedWithInv (sqE e) := ExprSupportedWithInv.mul h h
+
+lemma expSplitXpow_supported (n : ℕ) (q : ℚ) :
+    ExprSupportedWithInv (Expr.sub (expSplitXpow n) (Expr.const q)) := by
+  refine ExprSupportedWithInv.add ?_ (ExprSupportedWithInv.neg (ExprSupportedWithInv.const _))
+  unfold expSplitXpow
+  iterate 6 apply sqE_supported
+  exact ExprSupportedWithInv.exp (ExprSupportedWithInv.mul (ExprSupportedWithInv.const _)
+    (ExprSupportedWithInv.mul (ExprSupportedWithInv.var _) (ExprSupportedWithInv.var _)))
+
+lemma eval_expSplitXpow (n : ℕ) (s : ℝ) :
+    Expr.eval (fun _ => s) (expSplitXpow n)
+      = exp ((xpowCoef n : ℝ) * (s * s)) ^ (64 : ℕ) := by
+  simp only [expSplitXpow, eval_sqE, Expr.eval_exp, Expr.eval_mul,
+    Expr.eval_const, Expr.eval_var, ← pow_mul]
+
+/-- Boolean verification that the row-`n` curve `x^{-1/n}` dominates the table
+value `eps` on one cell: side conditions plus the dyadic slab check of
+`exp(s²/n) ≤ 1/eps` on `[slo, shi]`. -/
+def checkXpowCell (n : ℕ) (c : Cell) : Bool :=
+  if h : c.slo ≤ c.shi then
+    decide (0 < c.eps) && decide (0 ≤ c.slo) &&
+    decide (c.slo * c.slo ≤ (c.b : ℚ)) &&
+    decide ((c.b' : ℚ) ≤ c.shi * c.shi) &&
+    checkExprLeOnIntervalDyadic (expSplitXpow n) (Expr.const (1 / c.eps))
+      ⟨c.slo, c.shi, h⟩ (-50) 8
+  else false
+
+set_option maxHeartbeats 1000000 in
+-- One long transport declaration; each step is cheap but the default budget is
+-- exceeded cumulatively (mirrors `cell_eps_le_admissible`).
+/-- Soundness: a checked cell obeys `eps ≤ exp(-b'/n)`. -/
+theorem checkXpowCell_sound (n : ℕ) (hn : 0 < n) (c : Cell)
+    (hc : checkXpowCell n c = true) :
+    (c.eps : ℝ) ≤ Real.exp (-(c.b' : ℝ) / n) := by
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  unfold checkXpowCell at hc
+  split at hc
+  case isFalse => simp at hc
+  case isTrue hle =>
+    simp only [Bool.and_eq_true, decide_eq_true_eq] at hc
+    obtain ⟨⟨⟨⟨heps, _hslo0⟩, _hslo⟩, hshi⟩, hcheck⟩ := hc
+    -- semantic slab inequality: exp(s²/n) ≤ 1/eps on [slo, shi]
+    have hslab := verify_expr_le_on_interval_dyadic (expSplitXpow n)
+      (Expr.const (1 / c.eps)) ⟨c.slo, c.shi, hle⟩ (-50) 8
+      (expSplitXpow_supported _ _) (by norm_num) hcheck
+    -- instantiate at s = shi (the right endpoint, where exp(s²/n) is largest)
+    have hshi_mem : (c.shi : ℝ) ∈ Set.Icc ((c.slo : ℝ)) ((c.shi : ℝ)) :=
+      ⟨by exact_mod_cast hle, le_refl _⟩
+    have hineq := hslab (c.shi : ℝ) hshi_mem
+    rw [eval_expSplitXpow, Expr.eval_const] at hineq
+    -- (exp ((1/64n)·shi²))^64 = exp(shi²/n)
+    have hn' : (n : ℝ) ≠ 0 := ne_of_gt hnpos
+    have harg : ((64 : ℕ) : ℝ) * ((xpowCoef n : ℝ) * ((c.shi : ℝ) * (c.shi : ℝ)))
+        = ((c.shi : ℝ) * (c.shi : ℝ)) / n := by
+      simp only [xpowCoef]; push_cast; field_simp
+    have hexp64 :
+        exp ((xpowCoef n : ℝ) * ((c.shi : ℝ) * (c.shi : ℝ))) ^ (64 : ℕ)
+          = exp (((c.shi : ℝ) * (c.shi : ℝ)) / n) := by
+      rw [← Real.exp_nat_mul, harg]
+    rw [hexp64] at hineq
+    -- 1/eps on the RHS as a real reciprocal
+    have hrhs : ((1 / c.eps : ℚ) : ℝ) = 1 / (c.eps : ℝ) := by push_cast; ring
+    rw [hrhs] at hineq
+    -- positivity facts and the b' ≤ shi² side condition
+    have hepsR : (0 : ℝ) < (c.eps : ℝ) := by exact_mod_cast heps
+    have hbshi : (c.b' : ℝ) ≤ (c.shi : ℝ) * (c.shi : ℝ) := by exact_mod_cast hshi
+    have hexppos : (0 : ℝ) < exp ((c.b' : ℝ) / n) := Real.exp_pos _
+    -- exp(b'/n) ≤ exp(shi²/n) ≤ 1/eps
+    have hmono2 : exp ((c.b' : ℝ) / n) ≤ exp (((c.shi : ℝ) * (c.shi : ℝ)) / n) := by
+      apply Real.exp_le_exp.mpr
+      gcongr
+    have hchain : exp ((c.b' : ℝ) / n) ≤ 1 / (c.eps : ℝ) := le_trans hmono2 hineq
+    -- eps ≤ exp(-b'/n)
+    rw [neg_div, Real.exp_neg, ← one_div, le_div_iff₀ hexppos]
+    have hmul : exp ((c.b' : ℝ) / n) * (c.eps : ℝ) ≤ 1 :=
+      (le_div_iff₀ hepsR).mp hchain
+    linarith [hmul]
+
+/-- A checked cell together with its trusted row bound gives the row-`n` curve
+`x^{-1/n}` bound for `Eπ` on the cell. -/
+theorem cell_Epi_le_xpow_of_check (n : ℕ) (hn : 0 < n) (c : Cell)
+    (hc : checkXpowCell n c = true)
+    (hrow : Eπ.bound (c.eps : ℝ) (exp (c.b : ℝ))) :
+    ∀ x ∈ Set.Icc (exp (c.b : ℝ)) (exp (c.b' : ℝ)),
+      Eπ x ≤ x ^ (-(1 : ℝ) / n) :=
+  cell_Epi_le_xpow n hn c hrow (checkXpowCell_sound n hn c hc)
+
+/-! ## POC validation on a sample sublist (`n = 100`) -/
+
+/-- POC sample for row 11 (`n = 100`): 20 easy low-`L` cells (`b = 10..29`) plus
+20 tight cells (`b = 3736..3755`) running up to the last passing cell
+`[3755, 3756]`. -/
+def sampleCells : List Cell := allCells.take 20 ++ (allCells.drop 3726).take 20
+
+/-- Every sampled cell passes the row-11 numeric check. -/
+theorem sampleCells_checkXpow :
+    sampleCells.all (fun c => checkXpowCell 100 c) = true := by native_decide
+
+/-- Boundary witness: the first cell past the mid-range, `[3756, 3757]`, fails
+the check (its table value exceeds `exp(-3757/100)` by ≈0.24%). -/
+theorem boundaryCell_fails :
+    ((allCells.drop 3746).take 1).all (fun c => checkXpowCell 100 c) = false := by
+  native_decide
+
+/-! ## Generic `x^{-1/n}` floor and mid assemblers (reusable for row 10, `n = 50`)
+
+These promote the row-independent plumbing: a negative-exponent split target
+expression, the Buthe `Eπ`-bound reread on the low range `[2, e^10]`, and the
+floor / mid assemblers, all parameterized by `n`.  Row 11 instantiates `n = 100`;
+row 10 will instantiate `n = 50` with its own `native_decide`s. -/
+
+/-- Negative-exponent split expression `(exp (-(1/(64n))·s²))^64 = exp(-s²/n)`,
+i.e. the `x^{-1/n}` floor-curve target (the sign-flipped companion of the
+large-value `expSplitXpow`). -/
+def expSplitNegXpow (n : ℕ) : Expr :=
+  sqE (sqE (sqE (sqE (sqE (sqE
+    (Expr.exp (Expr.mul (Expr.const (-(xpowCoef n)))
+      (Expr.mul (Expr.var 0) (Expr.var 0)))))))))
+
+/-- `expSplitNegXpow n` evaluated at `s = √(log x)` is exactly `x^{-1/n}`
+(for `x > 0`, `log x ≥ 0`). -/
+lemma eval_expSplitNegXpow_eq_xpow (n : ℕ) (hn : 0 < n) (x : ℝ)
+    (hxpos : 0 < x) (hL : 0 ≤ Real.log x) :
+    Expr.eval (fun _ => Real.sqrt (Real.log x)) (expSplitNegXpow n) = x ^ (-(1:ℝ)/n) := by
+  have hnpos : (0:ℝ) < (n:ℝ) := by exact_mod_cast hn
+  have hnne : (n:ℝ) ≠ 0 := ne_of_gt hnpos
+  have hss : Real.sqrt (Real.log x) * Real.sqrt (Real.log x) = Real.log x :=
+    Real.mul_self_sqrt hL
+  simp only [expSplitNegXpow, eval_sqE, Expr.eval_exp, Expr.eval_mul, Expr.eval_const,
+    Expr.eval_var, ← pow_mul]
+  rw [← Real.exp_nat_mul, hss, Real.rpow_def_of_pos hxpos]
+  congr 1
+  simp only [xpowCoef]
+  push_cast
+  field_simp
+
+/-- Support of `lhsE - expSplitNegXpow n` for the dyadic slab kernel. -/
+lemma lhsE_sub_negxpow_supported (n : ℕ) :
+    ExprSupportedWithInv (Expr.sub FloorButhe.lhsE (expSplitNegXpow n)) := by
+  refine ExprSupportedWithInv.add ?_ (ExprSupportedWithInv.neg ?_)
+  · show ExprSupportedWithInv FloorButhe.lhsE
+    simp only [FloorButhe.lhsE, FloorButhe.pow8, FloorButhe.sqx, FloorButhe.s2,
+      FloorButhe.s4, FloorButhe.e2]
+    repeat constructor
+  · unfold expSplitNegXpow
+    iterate 6 apply sqE_supported
+    exact ExprSupportedWithInv.exp (ExprSupportedWithInv.mul (ExprSupportedWithInv.const _)
+      (ExprSupportedWithInv.mul (ExprSupportedWithInv.var _) (ExprSupportedWithInv.var _)))
+
+/-- Buthe `Eπ`-upper-bound as `eval_lhsE` on the LOW range `[2, e^10]` (vs the
+committed `FloorButhe.Epi_le_evalLhsE`'s `[e^5, e^10]`): identical reconciliation,
+only the hypothesis is `2 ≤ x`.  Curve-independent (`FloorButhe.lhsE` is the Buthe
+`x^{-1/2}` bound), so reusable by every `x^{-1/n}` row floor.  Bottoms out at Buthe
+`theorem_2e/2f` + `li.two_approx`. -/
+theorem Epi_le_evalLhsE_low (x : ℝ) (h2 : (2 : ℝ) ≤ x) (h10 : x ≤ Real.exp 10) :
+    Eπ x ≤ Expr.eval (fun _ => Real.sqrt (Real.log x)) FloorButhe.lhsE := by
+  have hxpos : (0:ℝ) < x := by linarith
+  have hLpos : (0:ℝ) < Real.log x := Real.log_pos (by linarith)
+  have hLnn : (0:ℝ) ≤ Real.log x := le_of_lt hLpos
+  have hx19 : x ≤ 10 ^ 19 := by
+    have h2' : Real.exp 10 < (3:ℝ) ^ 10 := by
+      calc Real.exp 10 = Real.exp 1 ^ 10 := by rw [← Real.exp_nat_mul]; norm_num
+        _ < 3 ^ 10 := by
+            have h1 := Real.exp_one_lt_d9
+            have hlt : Real.exp 1 < 3 := by linarith
+            gcongr
+    have h3 : (3:ℝ) ^ 10 ≤ 10 ^ 19 := by norm_num
+    linarith [h10]
+  have h2e := Buthe.theorem_2e h2 hx19
+  have h2f := Buthe.theorem_2f h2 hx19
+  have hsub := li.sub_Li x h2
+  have hli2 := li.two_approx
+  have hli2_le : li 2 ≤ 1.0452 := hli2.2
+  have hpiLi : pi x - Li x = li 2 - (li x - pi x) := by linarith [hsub]
+  have habs : |pi x - Li x| ≤ (li x - pi x) + li 2 := by
+    rw [hpiLi, abs_le]
+    constructor <;> linarith [h2f, hli2.1]
+  have hEpi_eq : Eπ x = |pi x - Li x| * (Real.log x / x) := by
+    unfold Eπ
+    rw [div_div_eq_mul_div, mul_div_assoc]
+  rw [hEpi_eq]
+  set B := Real.sqrt x / Real.log x * (1.95 + 3.9 / Real.log x + 19.5 / (Real.log x) ^ 2) with hB_def
+  have hfactor_nn : (0:ℝ) ≤ Real.log x / x := by positivity
+  have hstep1 : |pi x - Li x| * (Real.log x / x) ≤ (B + 1.0452) * (Real.log x / x) := by
+    apply mul_le_mul_of_nonneg_right _ hfactor_nn
+    calc |pi x - Li x| ≤ (li x - pi x) + li 2 := habs
+      _ ≤ B + 1.0452 := by
+          apply add_le_add
+          · rw [hB_def]; exact h2e
+          · exact hli2_le
+  refine le_trans hstep1 (le_of_eq ?_)
+  have hxne : x ≠ 0 := ne_of_gt hxpos
+  have hLne : Real.log x ≠ 0 := ne_of_gt hLpos
+  have hxinv : x⁻¹ = Real.exp (-(Real.log x)) := by
+    rw [Real.exp_neg, Real.exp_log hxpos]
+  have hsqrtx : Real.sqrt x = Real.exp (Real.log x / 2) := by
+    rw [← Real.exp_log (Real.sqrt_pos.mpr hxpos), Real.log_sqrt (le_of_lt hxpos)]
+  set s := Real.sqrt (Real.log x) with hs_def
+  have hss : s * s = Real.log x := by rw [hs_def]; exact Real.mul_self_sqrt hLnn
+  rw [FloorButhe.eval_lhsE, hss]
+  set L := Real.log x with hL_def
+  have hLx : L / x = L * Real.exp (-L) := by
+    rw [div_eq_mul_inv, hxinv]
+  have hsqrtxE2 : Real.sqrt x * Real.exp (-L) = Real.exp (-L / 2) := by
+    rw [hsqrtx, ← Real.exp_add]; congr 1; ring
+  rw [hB_def, hLx]
+  rw [show (Real.sqrt x / L * (1.95 + 3.9 / L + 19.5 / L ^ 2) + 1.0452) * (L * Real.exp (-L))
+      = (Real.sqrt x * Real.exp (-L)) * (1.95 + 3.9 / L + 19.5 / L ^ 2)
+        + 1.0452 * (L * Real.exp (-L)) by
+        field_simp]
+  rw [hsqrtxE2]
+  ring
+
+/-- Generic `x^{-1/n}` floor assembler on `[e^Lf, e^10]` (`1 ≤ Lf`): the Buthe
+`Eπ`-bound (`Epi_le_evalLhsE_low`, valid from `x ≥ 2`) below a dyadic slab curve
+`rE` that dominates `x^{-1/n}` (`hcurve`).  Slabs `slabsFrom slabLo nslabs` must
+cover `[√Lf, √10]`.  The `Eπ`-bound and slab-cover are curve-independent; only the
+per-row `rE`, its slab check, and `hcurve` vary. -/
+theorem floor_xpow_of_check (rE : Expr) (n : ℕ) (Lf : ℝ) (slabLo : ℚ) (nslabs : ℕ)
+    (hLf1 : (1 : ℝ) ≤ Lf)
+    (hslo : (slabLo : ℝ) ≤ Real.sqrt Lf)
+    (hshi : Real.sqrt 10 < (slabLo : ℝ) + (nslabs : ℝ) * 0.05)
+    (hsupp : ExprSupportedWithInv (Expr.sub FloorButhe.lhsE rE))
+    (hchk : checkExprLeOnSlabsDyadic FloorButhe.lhsE rE (slabsFrom slabLo nslabs) (-50) 8 = true)
+    (hcurve : ∀ x, Real.exp Lf ≤ x →
+        Expr.eval (fun _ => Real.sqrt (Real.log x)) rE ≤ x ^ (-(1 : ℝ) / n)) :
+    ∀ x ∈ Set.Icc (Real.exp Lf) (Real.exp 10), Eπ x ≤ x ^ (-(1:ℝ)/n) := by
+  intro x hx
+  obtain ⟨hlo, h10⟩ := hx
+  have hexpLfpos : (0:ℝ) < Real.exp Lf := Real.exp_pos _
+  have hxpos : (0:ℝ) < x := lt_of_lt_of_le hexpLfpos hlo
+  have h2 : (2:ℝ) ≤ x := by
+    have he1 : (2:ℝ) ≤ Real.exp 1 := by have := Real.add_one_le_exp (1:ℝ); linarith
+    have he1Lf : Real.exp 1 ≤ Real.exp Lf := Real.exp_le_exp.mpr hLf1
+    linarith [le_trans he1Lf hlo]
+  have hLgeLf : Lf ≤ Real.log x := by
+    rw [← Real.log_exp Lf]; exact Real.log_le_log hexpLfpos hlo
+  have hLle10 : Real.log x ≤ 10 := by
+    rw [← Real.log_exp 10]; exact Real.log_le_log hxpos h10
+  have hcov_lo : (slabLo:ℝ) ≤ Real.sqrt (Real.log x) := le_trans hslo (Real.sqrt_le_sqrt hLgeLf)
+  have hcov_hi : Real.sqrt (Real.log x) < (slabLo:ℝ) + (nslabs:ℝ) * 0.05 :=
+    lt_of_le_of_lt (Real.sqrt_le_sqrt hLle10) hshi
+  obtain ⟨I, hI, hmem⟩ := coverFrom slabLo nslabs _ hcov_lo hcov_hi
+  calc Eπ x ≤ Expr.eval (fun _ => Real.sqrt (Real.log x)) FloorButhe.lhsE :=
+        Epi_le_evalLhsE_low x h2 h10
+    _ ≤ Expr.eval (fun _ => Real.sqrt (Real.log x)) rE :=
+        verify_expr_le_on_slabs_dyadic FloorButhe.lhsE rE (slabsFrom slabLo nslabs) (-50) 8
+          hsupp (by norm_num) hchk I hI _ hmem
+    _ ≤ x ^ (-(1:ℝ)/n) := hcurve x hlo
+
+/-- Generic `x^{-1/n}` mid assembler: over the `allCells` prefix `take k` (chained
+from `10` to `m`, every cell passing the row-`n` `checkXpowCell`), `Eπ ≤ x^{-1/n}`
+on `[e^10, e^m]`.  Uses `cover_of_chainOk` + `cell_Epi_le_xpow_of_check` +
+`allCells_trusted`.  Row 11: `k = 3746, m = 3756`. -/
+theorem mid_xpow_of (n : ℕ) (hn : 0 < n) (k m : ℕ)
+    (hchain : chainOk 10 (allCells.take k) = true)
+    (hne : allCells.take k ≠ [])
+    (hlast : lastB 10 (allCells.take k) = m)
+    (hall : (allCells.take k).all (fun c => checkXpowCell n c) = true) :
+    ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (m:ℝ)), Eπ x ≤ x ^ (-(1:ℝ)/n) := by
+  intro x hx
+  have hx_lo : Real.exp ((10:ℕ):ℝ) ≤ x := by simpa using hx.1
+  have hx_hi : x ≤ Real.exp ((lastB 10 (allCells.take k) : ℕ):ℝ) := by
+    rw [hlast]; exact hx.2
+  obtain ⟨c, hcmem, hcx⟩ :=
+    cover_of_chainOk (allCells.take k) 10 hne hchain hx_lo hx_hi
+  have hck : checkXpowCell n c = true := List.all_eq_true.mp hall c hcmem
+  exact cell_Epi_le_xpow_of_check n hn c hck
+    (allCells_trusted c (List.mem_of_mem_take hcmem)) x hcx
+
+end Table4Ext
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 11 (`x^{-1/100}`, `log x ∈ [1, 3757.6]`)
+
+The Table-7 row-11 curve, assembled from four segments split at `e^3.5`, `e^10`,
+`e^3756`:
+
+* **floor-trusted** `[e^1, e^3.5]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **floor (Buthe)** `[e^3.5, e^10]` — `floor_xpow_of_check` + dyadic slab cover;
+* **mid (envelope)** `[e^10, e^3756]` — `mid_xpow_of` over the certified `allCells`
+  prefix `take 3746`;
+* **sliver** `[e^3756, e^3757.6]` — Theorem-6 refined interpolation near the
+  threshold (trusted, `sorry`).
+-/
+
+/-- The row-11 (`n = 100`) certified prefix of `allCells`: the first `3746` cells
+(`b' ≤ 3756`) form a contiguous chain from `b = 10` to `b' = 3756`; the next cell
+`[3756, 3757]` fails (`boundaryCell_fails`). -/
+theorem midCells_chain : chainOk 10 (allCells.take 3746) = true := by native_decide
+
+theorem midCells_ne_nil : allCells.take 3746 ≠ [] := by native_decide
+
+theorem midCells_last : lastB 10 (allCells.take 3746) = 3756 := by native_decide
+
+/-- Every cell of the row-11 passing prefix satisfies the `n = 100` numeric
+certificate `exp(s²/100) ≤ 1/ε`, verified by the dyadic interval kernel over all
+`3746` cells. -/
+theorem allCells_take_checkXpow :
+    (allCells.take 3746).all (fun c => checkXpowCell 100 c) = true := by native_decide
+
+/-- **Row-11 mid** `[e^10, e^3756]` via the certified envelope prefix. -/
+theorem mid_row11 : ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (3756:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/100) := by
+  intro x hx
+  have hmem : x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp ((3756:ℕ):ℝ)) := by
+    refine ⟨hx.1, ?_⟩
+    rw [show ((3756:ℕ):ℝ) = (3756:ℝ) from by norm_num]; exact hx.2
+  have h := mid_xpow_of 100 (by norm_num) 3746 3756
+    midCells_chain midCells_ne_nil midCells_last allCells_take_checkXpow x hmem
+  simpa using h
+
+/-- Row-11 floor slab certificate: `lhsE ≤ expSplitNegXpow 100` (the Buthe
+`x^{-1/2}` bound `≤ x^{-1/100}`) over the 26 width-`0.05` slabs covering
+`[√3.5, √10]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (expSplitNegXpow 100)
+      (slabsFrom (187/100) 26) (-50) 8 = true := by native_decide
+
+/-- **Row-11 floor (Buthe)** `[e^3.5, e^10]` via `floor_xpow_of_check`. -/
+theorem floor_row11 : ∀ x ∈ Set.Icc (Real.exp (3.5:ℝ)) (Real.exp (10:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/100) := by
+  intro x hx
+  have hcurve : ∀ y, Real.exp (3.5:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (expSplitNegXpow 100)
+        ≤ y ^ (-(1:ℝ)/(100:ℕ)) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h35 : (3.5:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (3.5:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    exact le_of_eq (eval_expSplitNegXpow_eq_xpow 100 (by norm_num) y hypos hyL)
+  have h := floor_xpow_of_check (expSplitNegXpow 100) 100 (3.5:ℝ) (187/100) 26 (by norm_num)
+    (by rw [show ((187/100:ℚ):ℝ) = 1.87 by norm_num,
+          show (1.87:ℝ) = Real.sqrt (1.87^2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h316 : Real.sqrt 10 ≤ 3.163 := by
+          rw [show (3.163:ℝ) = Real.sqrt (3.163^2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h316])
+    (lhsE_sub_negxpow_supported 100) floor_slab_check hcurve x hx
+  simpa using h
+
+/-- **Row-11 floor-trusted** `[e^1, e^3.5]` (`x ∈ [2.72, 33.1]`): the direct
+`π`/`Li` interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`",
+FKS2.lean:4640).  No tight sub-`e^{3.5}` `Eπ` envelope exists in the library for
+the sharp `x^{-1/100}` target (the Buthe bound only clears it from `L ≈ 3.44`).
+Same accepted numerical-data trust class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row11 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (3.5:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/100) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row11
+
+/-- **Row-11 sliver** `[e^3756, e^3757.6]` (width `≈ 1.6` in `log x`, at the
+threshold): the `x^{-1/100}` curve is `≤ 0.6%` above the `allCells` envelope on
+this band, resolved in FKS2 by the refined Theorem-6 interpolation (arXiv
+2206.12557, §5.2/5.3 / the "more refined collection of values than Table 4",
+FKS2.lean:4640).  Same accepted trust class as `Table4Ext.allCells_trusted`. -/
+theorem sliver_row11 : ∀ x ∈ Set.Icc (Real.exp (3756:ℝ)) (Real.exp (3757.6:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/100) := by
+  exact FKS2.Cor24Trusted.sliver_row11
+
+/-- **FKS2 Corollary 24, row 11** (`table7` entry `(x ↦ x^{-1/100}, Icc 1 3757.6)`):
+`Eπ x ≤ x^{-1/100}` whenever `log x ∈ [1, 3757.6]`.  For `x > 0` this splits into
+the four segments above; for `x ≤ 0` (possible since `log` is even) `Eπ x ≤ 0 <
+x^{-1/100}`. -/
+theorem corollary_24_row11 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 3757.6 → Eπ x ≤ x ^ (-(1:ℝ)/100) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `Eπ x ≤ 0 < x^{-1/100}`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hRpos : (0:ℝ) < x ^ (-(1:ℝ)/100) := by
+      rw [Real.rpow_def_of_neg hxneg]
+      apply mul_pos (Real.exp_pos _)
+      apply Real.cos_pos_of_mem_Ioo
+      constructor <;> nlinarith [Real.pi_pos, Real.pi_le_four]
+    linarith
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the four segments
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 3.5 with h1 | h1
+    · exact floor_trusted_row11 x (cvt 1 3.5 hlo h1)
+    · rcases le_total (Real.log x) 10 with h2 | h2
+      · exact floor_row11 x (cvt 3.5 10 h1 h2)
+      · rcases le_total (Real.log x) 3756 with h3 | h3
+        · exact mid_row11 x (cvt 10 3756 h2 h3)
+        · exact sliver_row11 x (cvt 3756 3757.6 h3 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row2.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row2.lean
@@ -1,0 +1,128 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row4
+
+/-!
+# FKS2 Corollary 24 — row 2 (`(log x)^{3/2}·x^{-1/2}`)
+
+`table7` entry `(x ↦ (log x)^(3/2) * x^(-1/2), Icc 1 65.65)`.  Clone of row 4
+(`FKS2Cor24Row4.lean`), reusing the generic `x^{-1/2}`-curve machinery in
+`Table4Ext` (`Epi_le_evalLhsE_wide`, `xhalfCurveE`, `eval_xhalfCurveE`,
+`xhalfCurve_sub_supported`, `floor_xhalf_of_check`).
+
+The exponent `3/2` here is stated as `Real.rpow` (`(3/2 : ℝ)`), matching the
+mathematical Table-7 entry: `(log x)^{3/2}` (a fractional power, not the `Nat`
+power that a bare `(log x)^(3/2)` literal would silently elaborate to via
+`Nat` division `3/2 = 1`).  The bridge from the curve machinery's `(√(log x))^3`
+(a `Monoid.npow`) to `(log x)^(3/2 : ℝ)` (an `Real.rpow`) goes through
+`Real.sqrt_eq_rpow`, `Real.rpow_natCast` and `Real.rpow_mul`.
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 2 (`(log x)^{3/2}·x^{-1/2}`, `log x ∈ [1, 65.65]`)
+
+The Table-7 row-2 curve, assembled from three segments split at `e^8`, `e^43`:
+
+* **floor-trusted** `[e^1, e^8]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **Buthe floor** `[e^8, e^43]` — `floor_xhalf_of_check` + a dyadic slab cover of
+  `[√8, √43] ≈ [2.83, 6.56]` (`slabsFrom (282/100) 76`);
+* **trusted band** `[e^43, e^65.65]` — Theorem-6 refined interpolation for
+  `log x > log(10^19)` (trusted, `sorry`).
+-/
+
+/-- Row-2 floor slab certificate: `FloorButhe.lhsE ≤ xhalfCurveE 1 3` (the Buthe `x^{-1/2}`
+bound `≤ (log x)^{3/2}·x^{-1/2}`) over the 76 width-`0.05` slabs covering `[√8, √43]`,
+verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row2 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (xhalfCurveE 1 3)
+      (slabsFrom (282/100) 76) (-50) 8 = true := by native_decide
+
+/-- **Row-2 Buthe floor** `[e^8, e^43]` via `floor_xhalf_of_check`. -/
+theorem floor_row2 : ∀ x ∈ Set.Icc (Real.exp (8:ℝ)) (Real.exp (43:ℝ)),
+    Eπ x ≤ (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2) := by
+  have hcurve : ∀ y, Real.exp (8:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (xhalfCurveE 1 3)
+        ≤ (Real.log y) ^ (3/2 : ℝ) * y ^ (-(1:ℝ) / 2) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h8 : (8:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (8:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    refine le_of_eq ?_
+    have hsq : (Real.sqrt (Real.log y)) ^ 3 = (Real.log y) ^ (3/2 : ℝ) := by
+      rw [Real.sqrt_eq_rpow, ← Real.rpow_natCast ((Real.log y) ^ (1/2 : ℝ)) 3,
+        ← Real.rpow_mul hyL]
+      congr 1
+      norm_num
+    rw [eval_xhalfCurveE 1 3 y hypos hyL, hsq]
+    push_cast; ring
+  exact floor_xhalf_of_check (xhalfCurveE 1 3)
+    (fun x => (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2)) 8 (282/100) 76 (by norm_num)
+    (by rw [show ((282/100:ℚ):ℝ) = 2.82 by norm_num,
+          show (2.82:ℝ) = Real.sqrt (2.82 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h656 : Real.sqrt 43 ≤ 6.56 := by
+          rw [show (6.56:ℝ) = Real.sqrt (6.56 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h656])
+    (xhalfCurve_sub_supported 1 3) floor_slab_check_row2 hcurve
+
+/-- **Row-2 floor-trusted** `[e^1, e^8]` (`x ∈ [2.72, 2981]`): the direct `π`/`Li`
+interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`", FKS2.lean:4640).
+Wider than row 4's `[e^1,e^3]` since the Buthe floor for the `(log x)^{3/2}` curve only
+certifies from `L = 8` on.  Same accepted numerical-data trust class as
+`Table4Ext.allCells_trusted` and `floor_trusted_row4`. -/
+theorem floor_trusted_row2 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (8:ℝ)),
+    Eπ x ≤ (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row2
+
+/-- **Row-2 trusted band** `[e^43, e^65.65]` (`log x ∈ (log 10^19, 65.65]`): the blueprint's
+Theorem-6 interpolation for `log x > log(10^19)` — "one simply proceeds as in
+\cite[Lemmas 5.2, 5.3]{FKS} and interpolates the numerical results of Theorem 6"
+(FKS2.lean:4640).  Same accepted trust class as `band_row4`. -/
+theorem band_row2 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (65.65:ℝ)),
+    Eπ x ≤ (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.band_row2
+
+/-- **FKS2 Corollary 24, row 2** (`table7` entry `(x ↦ (log x)^{3/2}·x^{-1/2}, Icc 1 65.65)`):
+`Eπ x ≤ (log x)^{3/2}·x^{-1/2}` whenever `log x ∈ [1, 65.65]`.  For `x > 0` this splits into
+the three segments above; for `x < 0` (possible since `log` is even) the exponent
+`-(1)/2` gives `cos((-(1)/2)·π) = cos(-π/2) = 0`, so `x^{-1/2} = 0` and the RHS is `0`,
+while `Eπ x ≤ 0`. -/
+theorem corollary_24_row2 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 65.65 →
+      Eπ x ≤ (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `x^{-1/2} = exp(...)·cos(-π/2) = 0`, so RHS = 0; and `Eπ x ≤ 0`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hxhalf0 : x ^ (-(1:ℝ) / 2) = 0 := by
+      rw [Real.rpow_def_of_neg hxneg,
+        show (-(1:ℝ) / 2) * π = -(π / 2) by ring, Real.cos_neg, Real.cos_pi_div_two, mul_zero]
+    rw [hxhalf0, mul_zero]
+    exact hEle0
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the three segments split at `log x = 8, 43`
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 8 with h1 | h1
+    · exact floor_trusted_row2 x (cvt 1 8 hlo h1)
+    · rcases le_total (Real.log x) 43 with h2 | h2
+      · exact floor_row2 x (cvt 8 43 h1 h2)
+      · exact band_row2 x (cvt 43 65.65 h2 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row3.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row3.lean
@@ -1,0 +1,143 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row4
+
+/-!
+# FKS2 Corollary 24 — row 3 (`(1/(8π))·(log x)²·x^{-1/2}`)
+
+`table7` entry `(x ↦ (1/(8*π)) * (log x)^2 * x^(-1/2), Icc 8 60.8)`.  Clone of row 4
+(`FKS2Cor24Row4.lean`), reusing the generic `x^{-1/2}`-curve machinery in
+`Table4Ext` (`Epi_le_evalLhsE_wide`, `xhalfCurveE`, `eval_xhalfCurveE`,
+`xhalfCurve_sub_supported`, `floor_xhalf_of_check`).
+
+Two features distinguish this row from rows 1/2/4/5:
+
+* the target coefficient `1/(8π)` is irrational, so the dyadic slab machinery (which needs
+  a `ℚ` curve coefficient) instead certifies the *rational under-approximation*
+  `c = 79/2000` (`0.0395 < 1/(8π) = 0.039789…`), and `hcurve` closes the gap with a
+  one-line rational bound `π < 3.15` (`Real.pi_lt_d2`);
+* the target interval starts at `log x = 8` (not `1`), so the floor-trusted segment is
+  `[e^8, e^9]` and the whole dispatch shifts up.
+
+`Lf = 9` is chosen (rather than `8`, as the naive "same as row 4" guess) because
+`√9 = 3` is exactly rational: the slab-cover lower endpoint needs no irrational-sqrt
+squeeze, and — empirically — starting the dyadic cover exactly at `s = 3` avoids the
+interval-width blowup that made a `299/100`-anchored cover spuriously fail just
+below `s = 3` (the mathematical margin there is real, ~13%, but a `0.05`-wide slab
+straddling `L = 9` is too coarse for the certified check to resolve it). -/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 3 (`(1/(8π))·(log x)²·x^{-1/2}`, `log x ∈ [8, 60.8]`)
+
+The Table-7 row-3 curve, assembled from three segments split at `e^9`, `e^43`:
+
+* **floor-trusted** `[e^8, e^9]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **Buthe floor** `[e^9, e^43]` — `floor_xhalf_of_check` against the rational
+  under-approximation `xhalfCurveE (79/2000) 4`, then `hcurve` bridges
+  `(79/2000)·(log x)²·x^{-1/2} ≤ (1/(8π))·(log x)²·x^{-1/2}` via `π < 3.15`;
+* **trusted band** `[e^43, e^60.8]` — Theorem-6 refined interpolation for
+  `log x > log(10^19)` (trusted, `sorry`).
+-/
+
+/-- Row-3 floor slab certificate: `FloorButhe.lhsE ≤ xhalfCurveE (79/2000) 4` (the Buthe
+`x^{-1/2}` bound `≤ (79/2000)·(log x)²·x^{-1/2}`, a rational under-approximation of the
+target `(1/(8π))·(log x)²·x^{-1/2}`) over the 74 width-`0.05` slabs covering `[√9, √43]
+= [3, √43]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row3 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (xhalfCurveE (79/2000) 4)
+      (slabsFrom 3 74) (-50) 8 = true := by native_decide
+
+/-- **Row-3 Buthe floor** `[e^9, e^43]` via `floor_xhalf_of_check`. -/
+theorem floor_row3 : ∀ x ∈ Set.Icc (Real.exp (9:ℝ)) (Real.exp (43:ℝ)),
+    Eπ x ≤ (1 / (8 * π)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  have hcurve : ∀ y, Real.exp (9:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (xhalfCurveE (79/2000) 4)
+        ≤ (1 / (8 * π)) * (Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h9 : (9:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (9:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    have hsq : (Real.sqrt (Real.log y)) ^ 4 = (Real.log y) ^ 2 := by
+      rw [show (4:ℕ) = 2 * 2 from rfl, pow_mul, Real.sq_sqrt hyL]
+    rw [eval_xhalfCurveE (79/2000) 4 y hypos hyL, hsq]
+    push_cast
+    have hc_le : (79/2000:ℝ) ≤ 1 / (8 * π) := by
+      rw [le_div_iff₀ (by positivity : (0:ℝ) < 8 * π)]
+      nlinarith [Real.pi_lt_d2]
+    have hnn : (0:ℝ) ≤ (Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2) := by positivity
+    calc (79/2000:ℝ) * (Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2)
+        = (79/2000:ℝ) * ((Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2)) := by ring
+      _ ≤ (1 / (8 * π)) * ((Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2)) :=
+          mul_le_mul_of_nonneg_right hc_le hnn
+      _ = (1 / (8 * π)) * (Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2) := by ring
+  exact floor_xhalf_of_check (xhalfCurveE (79/2000) 4)
+    (fun x => (1 / (8 * π)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2)) 9 3 74 (by norm_num)
+    (by rw [show ((3:ℚ):ℝ) = 3 by norm_num,
+          show (3:ℝ) = Real.sqrt (3 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h656 : Real.sqrt 43 ≤ 6.56 := by
+          rw [show (6.56:ℝ) = Real.sqrt (6.56 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h656])
+    (xhalfCurve_sub_supported (79/2000) 4) floor_slab_check_row3 hcurve
+
+/-- **Row-3 floor-trusted** `[e^8, e^9]` (`x ∈ [2981, 8103]`): the direct `π`/`Li`
+interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`", FKS2.lean:4640).
+Same accepted numerical-data trust class as `Table4Ext.allCells_trusted` and
+`floor_trusted_row4`. -/
+theorem floor_trusted_row3 : ∀ x ∈ Set.Icc (Real.exp (8:ℝ)) (Real.exp (9:ℝ)),
+    Eπ x ≤ (1 / (8 * π)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row3
+
+/-- **Row-3 trusted band** `[e^43, e^60.8]` (`log x ∈ (log 10^19, 60.8]`): the blueprint's
+Theorem-6 interpolation for `log x > log(10^19)` — "one simply proceeds as in
+\cite[Lemmas 5.2, 5.3]{FKS} and interpolates the numerical results of Theorem 6"
+(FKS2.lean:4640).  Same accepted trust class as `band_row4`. -/
+theorem band_row3 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (60.8:ℝ)),
+    Eπ x ≤ (1 / (8 * π)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.band_row3
+
+/-- **FKS2 Corollary 24, row 3**
+(`table7` entry `(x ↦ (1/(8π))·(log x)²·x^{-1/2}, Icc 8 60.8)`):
+`Eπ x ≤ (1/(8π))·(log x)²·x^{-1/2}` whenever `log x ∈ [8, 60.8]`.  For `x > 0` this
+splits into the three segments above; for `x < 0` (possible since `log` is even) the
+exponent `-(1)/2` gives `cos((-(1)/2)·π) = cos(-π/2) = 0`, so `x^{-1/2} = 0` and the RHS
+is `0`, while `Eπ x ≤ 0`. -/
+theorem corollary_24_row3 :
+    ∀ x, Real.log x ∈ Set.Icc (8:ℝ) 60.8 →
+      Eπ x ≤ (1 / (8 * π)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `x^{-1/2} = exp(...)·cos(-π/2) = 0`, so RHS = 0; and `Eπ x ≤ 0`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hxhalf0 : x ^ (-(1:ℝ) / 2) = 0 := by
+      rw [Real.rpow_def_of_neg hxneg,
+        show (-(1:ℝ) / 2) * π = -(π / 2) by ring, Real.cos_neg, Real.cos_pi_div_two, mul_zero]
+    rw [hxhalf0, mul_zero]
+    exact hEle0
+  · -- x = 0: `log 0 = 0` contradicts `8 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the three segments split at `log x = 9, 43`
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 9 with h1 | h1
+    · exact floor_trusted_row3 x (cvt 8 9 hlo h1)
+    · rcases le_total (Real.log x) 43 with h2 | h2
+      · exact floor_row3 x (cvt 9 43 h1 h2)
+      · exact band_row3 x (cvt 43 60.8 h2 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row4.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row4.lean
@@ -1,0 +1,286 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — row 4 (`(log x)²·x^{-1/2}`) and the `x^{-1/2}`-curve floor machinery
+
+Rows 1–5 of `table7` are the *sharp* `c·(log x)^K·x^{-1/2}` curves.  Unlike the
+`x^{-1/n}` rows (6–11), the `allCells` numerical envelope does **not** fit under
+these curves (the envelope's `ε ≈ exp(-√L)`-scale is `≫ x^{-1/2} = exp(-L/2)`), so
+there is **no envelope mid segment**.  Each `x^{-1/2}` row instead splits into three
+segments:
+
+1. **floor-trusted** `[e^1, e^{Lf}]` — small-`x` direct `π`/`Li` check (trusted `sorry`,
+   FKS §5.2/5.3);
+2. **Buthe floor** `[e^{Lf}, e^43]` — PROVABLE.  The committed Buthe `x^{-1/2}` bound
+   `FloorButhe.lhsE` (valid `x ∈ [2, 10^19]`, i.e. `log x ≤ 43.7`) is `≤ c·(log x)^K·x^{-1/2}`
+   because `c·L^K` eventually dominates the Buthe polynomial `1.95 + 3.9/L + 19.5/L²`;
+   certified by a dyadic slab cover of `[√Lf, √43]`;
+3. **trusted band** `[e^43, e^b]` (`b ≤ 80`) — the blueprint's "interpolate the numerical
+   results of Theorem 6" step for `log x > log(10^19)` (trusted `sorry`, the big authorized
+   region for `x^{-1/2}` rows; same accepted trust class as `Table4Ext.allCells_trusted`
+   and the Cor 23 row-8 band).
+
+## Generic (`c`/`K`-parameterized) machinery, reusable for rows 1/2/3/5
+
+* `Epi_le_evalLhsE_wide` — the Buthe `Eπ`-bound reread as `eval FloorButhe.lhsE (√(log x))`
+  on the FULL `[2, e^43]` range (vs `Epi_le_evalLhsE_low`'s `[2, e^10]`);
+* `xhalfCurveE c twoK` — the target expression `c·s^{2K}·exp(-s²/2)` (`= c·s^{2K}·x^{-1/2}`
+  at `s = √(log x)`), with `eval_xhalfCurveE` and support lemma `xhalfCurve_sub_supported`;
+* `floor_xhalf_of_check` — the generic Buthe-floor assembler on `[e^{Lf}, e^43]`.
+
+Row 4 (`c = 1`, `K = 2`, `2K = 4`) is the template.
+-/
+
+namespace FKS2
+namespace Table4Ext
+
+open Real LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## Generic `x^{-1/2}`-curve floor machinery -/
+
+/-- Buthe `Eπ`-upper-bound as `eval FloorButhe.lhsE` on the WIDE range `[2, e^43]`
+(vs `Epi_le_evalLhsE_low`'s `[2, e^10]`): identical reconciliation, but taking the
+`x ≤ 10^19` hypothesis directly (`e^43 ≈ 4.7e18 < 10^19`), which extends the Buthe
+reread to the full `x^{-1/2}`-floor range.  Curve-independent, so reusable by every
+`x^{-1/2}` row (rows 1–5).  Bottoms out at Buthe `theorem_2e/2f` + `li.two_approx`. -/
+theorem Epi_le_evalLhsE_wide (x : ℝ) (h2 : (2 : ℝ) ≤ x) (h19 : x ≤ (10 : ℝ) ^ 19) :
+    Eπ x ≤ Expr.eval (fun _ => Real.sqrt (Real.log x)) FloorButhe.lhsE := by
+  have hxpos : (0:ℝ) < x := by linarith
+  have hLpos : (0:ℝ) < Real.log x := Real.log_pos (by linarith)
+  have hLnn : (0:ℝ) ≤ Real.log x := le_of_lt hLpos
+  have h2e := Buthe.theorem_2e h2 h19
+  have h2f := Buthe.theorem_2f h2 h19
+  have hsub := li.sub_Li x h2
+  have hli2 := li.two_approx
+  have hli2_le : li 2 ≤ 1.0452 := hli2.2
+  have hpiLi : pi x - Li x = li 2 - (li x - pi x) := by linarith [hsub]
+  have habs : |pi x - Li x| ≤ (li x - pi x) + li 2 := by
+    rw [hpiLi, abs_le]
+    constructor <;> linarith [h2f, hli2.1]
+  have hEpi_eq : Eπ x = |pi x - Li x| * (Real.log x / x) := by
+    unfold Eπ
+    rw [div_div_eq_mul_div, mul_div_assoc]
+  rw [hEpi_eq]
+  set B := Real.sqrt x / Real.log x * (1.95 + 3.9 / Real.log x + 19.5 / (Real.log x) ^ 2) with hB_def
+  have hfactor_nn : (0:ℝ) ≤ Real.log x / x := by positivity
+  have hstep1 : |pi x - Li x| * (Real.log x / x) ≤ (B + 1.0452) * (Real.log x / x) := by
+    apply mul_le_mul_of_nonneg_right _ hfactor_nn
+    calc |pi x - Li x| ≤ (li x - pi x) + li 2 := habs
+      _ ≤ B + 1.0452 := by
+          apply add_le_add
+          · rw [hB_def]; exact h2e
+          · exact hli2_le
+  refine le_trans hstep1 (le_of_eq ?_)
+  have hxne : x ≠ 0 := ne_of_gt hxpos
+  have hLne : Real.log x ≠ 0 := ne_of_gt hLpos
+  have hxinv : x⁻¹ = Real.exp (-(Real.log x)) := by
+    rw [Real.exp_neg, Real.exp_log hxpos]
+  have hsqrtx : Real.sqrt x = Real.exp (Real.log x / 2) := by
+    rw [← Real.exp_log (Real.sqrt_pos.mpr hxpos), Real.log_sqrt (le_of_lt hxpos)]
+  set s := Real.sqrt (Real.log x) with hs_def
+  have hss : s * s = Real.log x := by rw [hs_def]; exact Real.mul_self_sqrt hLnn
+  rw [FloorButhe.eval_lhsE, hss]
+  set L := Real.log x with hL_def
+  have hLx : L / x = L * Real.exp (-L) := by
+    rw [div_eq_mul_inv, hxinv]
+  have hsqrtxE2 : Real.sqrt x * Real.exp (-L) = Real.exp (-L / 2) := by
+    rw [hsqrtx, ← Real.exp_add]; congr 1; ring
+  rw [hB_def, hLx]
+  rw [show (Real.sqrt x / L * (1.95 + 3.9 / L + 19.5 / L ^ 2) + 1.0452) * (L * Real.exp (-L))
+      = (Real.sqrt x * Real.exp (-L)) * (1.95 + 3.9 / L + 19.5 / L ^ 2)
+        + 1.0452 * (L * Real.exp (-L)) by
+        field_simp]
+  rw [hsqrtxE2]
+  ring
+
+/-- The `x^{-1/2}` row-curve target expression `c·s^{2K}·exp(-s²/2)` in `s = Expr.var 0`
+(`= c·(√(log x))^{2K}·x^{-1/2}` at `s = √(log x)`).  Instantiated per row:
+row 1 `xhalfCurveE 2 2`, row 2 `xhalfCurveE 1 3`, row 3 `xhalfCurveE (rational ≤ 1/(8π)) 4`,
+row 4 `xhalfCurveE 1 4`, row 5 `xhalfCurveE 1 6`. -/
+def xhalfCurveE (c : ℚ) (twoK : ℕ) : Expr :=
+  Expr.mul (Expr.const c) (Expr.mul (Expr.pow (Expr.var 0) twoK) (expSplitNegXpow 2))
+
+/-- `xhalfCurveE c twoK` at `s = √(log x)` equals `c·(√(log x))^{2K}·x^{-1/2}` (for
+`x > 0`, `log x ≥ 0`).  The row-level bridge `(√(log x))^{2K} = (log x)^K` is done at
+the call site (`Real.sq_sqrt`). -/
+lemma eval_xhalfCurveE (c : ℚ) (twoK : ℕ) (x : ℝ) (hxpos : 0 < x) (hL : 0 ≤ Real.log x) :
+    Expr.eval (fun _ => Real.sqrt (Real.log x)) (xhalfCurveE c twoK)
+      = (c : ℝ) * (Real.sqrt (Real.log x)) ^ twoK * x ^ (-(1:ℝ) / 2) := by
+  have hcast : ((2:ℕ) : ℝ) = (2:ℝ) := by norm_num
+  have h2 := eval_expSplitNegXpow_eq_xpow 2 (by norm_num) x hxpos hL
+  rw [hcast] at h2
+  simp only [xhalfCurveE, Expr.eval_mul, Expr.eval_const, Expr.eval_pow, Expr.eval_var, h2]
+  ring
+
+/-- Support of `lhsE - xhalfCurveE c twoK` for the dyadic slab kernel. -/
+lemma xhalfCurve_sub_supported (c : ℚ) (twoK : ℕ) :
+    ExprSupportedWithInv (Expr.sub FloorButhe.lhsE (xhalfCurveE c twoK)) := by
+  refine ExprSupportedWithInv.add ?_ (ExprSupportedWithInv.neg ?_)
+  · show ExprSupportedWithInv FloorButhe.lhsE
+    simp only [FloorButhe.lhsE, FloorButhe.pow8, FloorButhe.sqx, FloorButhe.s2,
+      FloorButhe.s4, FloorButhe.e2]
+    repeat constructor
+  · unfold xhalfCurveE
+    refine ExprSupportedWithInv.mul (ExprSupportedWithInv.const _) ?_
+    refine ExprSupportedWithInv.mul (pow_supported (ExprSupportedWithInv.var 0) twoK) ?_
+    unfold expSplitNegXpow
+    iterate 6 apply sqE_supported
+    exact ExprSupportedWithInv.exp (ExprSupportedWithInv.mul (ExprSupportedWithInv.const _)
+      (ExprSupportedWithInv.mul (ExprSupportedWithInv.var _) (ExprSupportedWithInv.var _)))
+
+/-- Generic `x^{-1/2}` **Buthe-floor** assembler on `[e^{Lf}, e^43]` (`1 ≤ Lf`): the Buthe
+`Eπ`-bound (`Epi_le_evalLhsE_wide`, valid from `x ≥ 2` up to `e^43 < 10^19`) below a
+dyadic slab curve `rE` that dominates the row curve (`hcurve`).  Slabs
+`slabsFrom slabLo nslabs` must cover `[√Lf, √43]`.  The `Eπ`-bound and slab-cover are
+curve-independent; only the per-row `rE`, its slab check, and `hcurve` vary. -/
+theorem floor_xhalf_of_check (rE : Expr) (curve : ℝ → ℝ) (Lf : ℝ) (slabLo : ℚ) (nslabs : ℕ)
+    (hLf1 : (1 : ℝ) ≤ Lf)
+    (hslo : (slabLo : ℝ) ≤ Real.sqrt Lf)
+    (hshi : Real.sqrt 43 < (slabLo : ℝ) + (nslabs : ℝ) * 0.05)
+    (hsupp : ExprSupportedWithInv (Expr.sub FloorButhe.lhsE rE))
+    (hchk : checkExprLeOnSlabsDyadic FloorButhe.lhsE rE (slabsFrom slabLo nslabs) (-50) 8 = true)
+    (hcurve : ∀ x, Real.exp Lf ≤ x →
+        Expr.eval (fun _ => Real.sqrt (Real.log x)) rE ≤ curve x) :
+    ∀ x ∈ Set.Icc (Real.exp Lf) (Real.exp 43), Eπ x ≤ curve x := by
+  intro x hx
+  obtain ⟨hlo, h43⟩ := hx
+  have hexpLfpos : (0:ℝ) < Real.exp Lf := Real.exp_pos _
+  have hxpos : (0:ℝ) < x := lt_of_lt_of_le hexpLfpos hlo
+  have h2 : (2:ℝ) ≤ x := by
+    have he1 : (2:ℝ) ≤ Real.exp 1 := by have := Real.add_one_le_exp (1:ℝ); linarith
+    have he1Lf : Real.exp 1 ≤ Real.exp Lf := Real.exp_le_exp.mpr hLf1
+    linarith [le_trans he1Lf hlo]
+  have he43 : Real.exp 43 ≤ (10:ℝ) ^ 19 := by
+    have h1 : Real.exp 1 < 2.72 := by have := Real.exp_one_lt_d9; linarith
+    have h1le : Real.exp 1 ≤ 2.72 := h1.le
+    have h1nn : (0:ℝ) ≤ Real.exp 1 := (Real.exp_pos 1).le
+    calc Real.exp 43 = Real.exp 1 ^ (43:ℕ) := by rw [← Real.exp_nat_mul]; norm_num
+      _ ≤ (2.72:ℝ) ^ (43:ℕ) := by gcongr
+      _ ≤ (10:ℝ) ^ 19 := by norm_num
+  have h19 : x ≤ (10:ℝ) ^ 19 := le_trans h43 he43
+  have hLgeLf : Lf ≤ Real.log x := by
+    rw [← Real.log_exp Lf]; exact Real.log_le_log hexpLfpos hlo
+  have hLle43 : Real.log x ≤ 43 := by
+    rw [← Real.log_exp 43]; exact Real.log_le_log hxpos h43
+  have hcov_lo : (slabLo : ℝ) ≤ Real.sqrt (Real.log x) := le_trans hslo (Real.sqrt_le_sqrt hLgeLf)
+  have hcov_hi : Real.sqrt (Real.log x) < (slabLo : ℝ) + (nslabs : ℝ) * 0.05 :=
+    lt_of_le_of_lt (Real.sqrt_le_sqrt hLle43) hshi
+  obtain ⟨I, hI, hmem⟩ := coverFrom slabLo nslabs _ hcov_lo hcov_hi
+  calc Eπ x ≤ Expr.eval (fun _ => Real.sqrt (Real.log x)) FloorButhe.lhsE :=
+        Epi_le_evalLhsE_wide x h2 h19
+    _ ≤ Expr.eval (fun _ => Real.sqrt (Real.log x)) rE :=
+        verify_expr_le_on_slabs_dyadic FloorButhe.lhsE rE (slabsFrom slabLo nslabs) (-50) 8
+          hsupp (by norm_num) hchk I hI _ hmem
+    _ ≤ curve x := hcurve x hlo
+
+end Table4Ext
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 4 (`(log x)²·x^{-1/2}`, `log x ∈ [1, 70.6]`)
+
+The Table-7 row-4 curve, assembled from three segments split at `e^3`, `e^43`:
+
+* **floor-trusted** `[e^1, e^3]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **Buthe floor** `[e^3, e^43]` — `floor_xhalf_of_check` + a dyadic slab cover of `[√3, √43]`;
+* **trusted band** `[e^43, e^70.6]` — Theorem-6 refined interpolation for `log x > log(10^19)`
+  (trusted, `sorry`).
+-/
+
+/-- Row-4 floor slab certificate: `FloorButhe.lhsE ≤ xhalfCurveE 1 4` (the Buthe `x^{-1/2}`
+bound `≤ (log x)²·x^{-1/2}`) over the 97 width-`0.05` slabs covering `[√3, √43]`, verified
+by the dyadic interval kernel.  (At `L = 3` the Buthe polynomial `≈ 5.4 ≤ L² = 9`; below
+`L = 3` it fails, tuned via `#eval`.) -/
+theorem floor_slab_check_row4 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (xhalfCurveE 1 4)
+      (slabsFrom (173/100) 97) (-50) 8 = true := by native_decide
+
+/-- **Row-4 Buthe floor** `[e^3, e^43]` via `floor_xhalf_of_check`. -/
+theorem floor_row4 : ∀ x ∈ Set.Icc (Real.exp (3:ℝ)) (Real.exp (43:ℝ)),
+    Eπ x ≤ (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  have hcurve : ∀ y, Real.exp (3:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (xhalfCurveE 1 4)
+        ≤ (Real.log y) ^ 2 * y ^ (-(1:ℝ) / 2) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h3 : (3:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (3:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    refine le_of_eq ?_
+    have hsq : (Real.sqrt (Real.log y)) ^ 4 = (Real.log y) ^ 2 := by
+      rw [show (4:ℕ) = 2 * 2 from rfl, pow_mul, Real.sq_sqrt hyL]
+    rw [eval_xhalfCurveE 1 4 y hypos hyL, hsq]
+    push_cast; ring
+  exact floor_xhalf_of_check (xhalfCurveE 1 4)
+    (fun x => (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2)) 3 (173/100) 97 (by norm_num)
+    (by rw [show ((173/100:ℚ):ℝ) = 1.73 by norm_num,
+          show (1.73:ℝ) = Real.sqrt (1.73 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h656 : Real.sqrt 43 ≤ 6.56 := by
+          rw [show (6.56:ℝ) = Real.sqrt (6.56 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h656])
+    (xhalfCurve_sub_supported 1 4) floor_slab_check_row4 hcurve
+
+/-- **Row-4 floor-trusted** `[e^1, e^3]` (`x ∈ [2.72, 20.1]`): the direct `π`/`Li`
+interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`", FKS2.lean:4640).
+No tight sub-`e^3` `Eπ` envelope exists in the library for the sharp `(log x)²·x^{-1/2}`
+target (the Buthe bound only clears it from `L = 3`).  Same accepted numerical-data trust
+class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row4 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (3:ℝ)),
+    Eπ x ≤ (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row4
+
+/-- **Row-4 trusted band** `[e^43, e^70.6]` (`log x ∈ (log 10^19, 70.6]`): the blueprint's
+Theorem-6 interpolation for `log x > log(10^19)` — "one simply proceeds as in
+\cite[Lemmas 5.2, 5.3]{FKS} and interpolates the numerical results of Theorem 6"
+(FKS2.lean:4640).  The `allCells` envelope is too loose for the sharp `x^{-1/2}` target
+here (envelope `ε ≈ exp(-√L) ≫ x^{-1/2} = exp(-L/2)`), so this is the big authorized
+trusted region for `x^{-1/2}` rows.  Same accepted trust class as `Table4Ext.allCells_trusted`
+and the Cor 23 row-8 band. -/
+theorem band_row4 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (70.6:ℝ)),
+    Eπ x ≤ (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.band_row4
+
+/-- **FKS2 Corollary 24, row 4** (`table7` entry `(x ↦ (log x)²·x^{-1/2}, Icc 1 70.6)`):
+`Eπ x ≤ (log x)²·x^{-1/2}` whenever `log x ∈ [1, 70.6]`.  For `x > 0` this splits into
+the three segments above; for `x < 0` (possible since `log` is even) the exponent
+`-(1)/2` gives `cos((-(1)/2)·π) = cos(-π/2) = 0`, so `x^{-1/2} = 0` and the RHS is `0`,
+while `Eπ x ≤ 0`. -/
+theorem corollary_24_row4 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 70.6 → Eπ x ≤ (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `x^{-1/2} = exp(...)·cos(-π/2) = 0`, so RHS = 0; and `Eπ x ≤ 0`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hxhalf0 : x ^ (-(1:ℝ) / 2) = 0 := by
+      rw [Real.rpow_def_of_neg hxneg,
+        show (-(1:ℝ) / 2) * π = -(π / 2) by ring, Real.cos_neg, Real.cos_pi_div_two, mul_zero]
+    rw [hxhalf0, mul_zero]
+    exact hEle0
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the three segments split at `log x = 3, 43`
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 3 with h1 | h1
+    · exact floor_trusted_row4 x (cvt 1 3 hlo h1)
+    · rcases le_total (Real.log x) 43 with h2 | h2
+      · exact floor_row4 x (cvt 3 43 h1 h2)
+      · exact band_row4 x (cvt 43 70.6 h2 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row5.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row5.lean
@@ -1,0 +1,121 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row4
+
+/-!
+# FKS2 Corollary 24 — row 5 (`(log x)³·x^{-1/2}`)
+
+`table7` entry `(x ↦ (log x)^3 * x^(-1/2), Icc 1 80)`.  Clone of row 4
+(`FKS2Cor24Row4.lean`), reusing the generic `x^{-1/2}`-curve machinery in
+`Table4Ext` (`Epi_le_evalLhsE_wide`, `xhalfCurveE`, `eval_xhalfCurveE`,
+`xhalfCurve_sub_supported`, `floor_xhalf_of_check`).  Same three-segment split
+at `e^3`, `e^43` as row 4; only the top of the trusted band moves to `e^80`
+and the bridge exponent moves from `(√L)^4 = L^2` to `(√L)^6 = L^3`.
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 5 (`(log x)³·x^{-1/2}`, `log x ∈ [1, 80]`)
+
+The Table-7 row-5 curve, assembled from three segments split at `e^3`, `e^43`:
+
+* **floor-trusted** `[e^1, e^3]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **Buthe floor** `[e^3, e^43]` — `floor_xhalf_of_check` + a dyadic slab cover of `[√3, √43]`
+  (identical cover to row 4: `slabsFrom (173/100) 97`);
+* **trusted band** `[e^43, e^80]` — Theorem-6 refined interpolation for `log x > log(10^19)`
+  (trusted, `sorry`).
+-/
+
+/-- Row-5 floor slab certificate: `FloorButhe.lhsE ≤ xhalfCurveE 1 6` (the Buthe `x^{-1/2}`
+bound `≤ (log x)³·x^{-1/2}`) over the 97 width-`0.05` slabs covering `[√3, √43]`, verified
+by the dyadic interval kernel.  (`c·L³` dominates the Buthe polynomial even more easily than
+row 4's `L²` from `L = 3` on, so the same cover works verbatim.) -/
+theorem floor_slab_check_row5 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (xhalfCurveE 1 6)
+      (slabsFrom (173/100) 97) (-50) 8 = true := by native_decide
+
+/-- **Row-5 Buthe floor** `[e^3, e^43]` via `floor_xhalf_of_check`.  (Named `floor_xhalf_row5`,
+not `floor_row5`, since `FKS2.floor_row5` is already taken by Corollary 23's row 5 in the
+imported `FKS2Cor23.lean` base file — unrelated corollary, same row index.) -/
+theorem floor_xhalf_row5 : ∀ x ∈ Set.Icc (Real.exp (3:ℝ)) (Real.exp (43:ℝ)),
+    Eπ x ≤ (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2) := by
+  have hcurve : ∀ y, Real.exp (3:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (xhalfCurveE 1 6)
+        ≤ (Real.log y) ^ 3 * y ^ (-(1:ℝ) / 2) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h3 : (3:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (3:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    refine le_of_eq ?_
+    have hsq : (Real.sqrt (Real.log y)) ^ 6 = (Real.log y) ^ 3 := by
+      rw [show (6:ℕ) = 2 * 3 from rfl, pow_mul, Real.sq_sqrt hyL]
+    rw [eval_xhalfCurveE 1 6 y hypos hyL, hsq]
+    push_cast; ring
+  exact floor_xhalf_of_check (xhalfCurveE 1 6)
+    (fun x => (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2)) 3 (173/100) 97 (by norm_num)
+    (by rw [show ((173/100:ℚ):ℝ) = 1.73 by norm_num,
+          show (1.73:ℝ) = Real.sqrt (1.73 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h656 : Real.sqrt 43 ≤ 6.56 := by
+          rw [show (6.56:ℝ) = Real.sqrt (6.56 ^ 2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h656])
+    (xhalfCurve_sub_supported 1 6) floor_slab_check_row5 hcurve
+
+/-- **Row-5 floor-trusted** `[e^1, e^3]` (`x ∈ [2.72, 20.1]`): the direct `π`/`Li`
+interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`", FKS2.lean:4640).
+Same accepted numerical-data trust class as `Table4Ext.allCells_trusted` and
+`floor_trusted_row4`. -/
+theorem floor_trusted_row5 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (3:ℝ)),
+    Eπ x ≤ (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row5
+
+/-- **Row-5 trusted band** `[e^43, e^80]` (`log x ∈ (log 10^19, 80]`): the blueprint's
+Theorem-6 interpolation for `log x > log(10^19)` — "one simply proceeds as in
+\cite[Lemmas 5.2, 5.3]{FKS} and interpolates the numerical results of Theorem 6"
+(FKS2.lean:4640).  Same accepted trust class as `band_row4`. -/
+theorem band_row5 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (80:ℝ)),
+    Eπ x ≤ (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2) := by
+  exact FKS2.Cor24Trusted.band_row5
+
+/-- **FKS2 Corollary 24, row 5** (`table7` entry `(x ↦ (log x)³·x^{-1/2}, Icc 1 80)`):
+`Eπ x ≤ (log x)³·x^{-1/2}` whenever `log x ∈ [1, 80]`.  For `x > 0` this splits into
+the three segments above; for `x < 0` (possible since `log` is even) the exponent
+`-(1)/2` gives `cos((-(1)/2)·π) = cos(-π/2) = 0`, so `x^{-1/2} = 0` and the RHS is `0`,
+while `Eπ x ≤ 0`. -/
+theorem corollary_24_row5 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 80 → Eπ x ≤ (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `x^{-1/2} = exp(...)·cos(-π/2) = 0`, so RHS = 0; and `Eπ x ≤ 0`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hxhalf0 : x ^ (-(1:ℝ) / 2) = 0 := by
+      rw [Real.rpow_def_of_neg hxneg,
+        show (-(1:ℝ) / 2) * π = -(π / 2) by ring, Real.cos_neg, Real.cos_pi_div_two, mul_zero]
+    rw [hxhalf0, mul_zero]
+    exact hEle0
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the three segments split at `log x = 3, 43`
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 3 with h1 | h1
+    · exact floor_trusted_row5 x (cvt 1 3 hlo h1)
+    · rcases le_total (Real.log x) 43 with h2 | h2
+      · exact floor_xhalf_row5 x (cvt 3 43 h1 h2)
+      · exact band_row5 x (cvt 43 80 h2 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row6.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row6.lean
@@ -1,0 +1,154 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — row 6 (`x^{-1/3}`) mid-range envelope
+
+Row 6 (`n = 3`) of Table-7, cloned from the complete row 11 (`n = 100`) via the
+generic `n`-parameterized helpers of `FKS2Cor24Row11`
+(`Table4Ext.expSplitNegXpow`, `Table4Ext.eval_expSplitNegXpow_eq_xpow`,
+`Table4Ext.lhsE_sub_negxpow_supported`, `Table4Ext.Epi_le_evalLhsE_low`,
+`Table4Ext.floor_xpow_of_check`, `Table4Ext.mid_xpow_of`, `Table4Ext.checkXpowCell`,
+`Table4Ext.cell_Epi_le_xpow_of_check`), all instantiated here at `n = 3`.
+
+`boundaryCell_fails_row6` records that the first excluded cell `[80,81]`
+(index `70`) fails, so the row-6 envelope certifies exactly
+`allCells.take 70` (cells with `b' ≤ 80`).
+
+The row-6 curve `corollary_24_row6 : ∀ x, log x ∈ [1, 80.55] → Eπ x ≤ x^{-1/3}`
+is assembled from four segments split at `e^8`, `e^10`, `e^80`:
+* **floor-trusted** `[e^1, e^8]` (`floor_trusted_row6`, trusted `sorry`);
+* **floor (Buthe)** `[e^8, e^10]` (`floor_row6`, dyadic slab cover);
+* **mid (envelope)** `[e^10, e^80]` (`mid_row6`, `allCells.take 70`);
+* **sliver** `[e^80, e^80.55]` (`sliver_row6`, trusted `sorry`).
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 6 (`x^{-1/3}`, `log x ∈ [1, 80.55]`) -/
+
+/-- The row-6 (`n = 3`) certified prefix of `allCells`: the first `70` cells
+(`b' ≤ 80`) form a contiguous chain from `b = 10` to `b' = 80`; the next cell
+`[80,81]` fails (`boundaryCell_fails_row6`). -/
+theorem midCells_chain_row6 : chainOk 10 (allCells.take 70) = true := by native_decide
+
+theorem midCells_ne_nil_row6 : allCells.take 70 ≠ [] := by native_decide
+
+theorem midCells_last_row6 : lastB 10 (allCells.take 70) = 80 := by native_decide
+
+/-- Every cell of the row-6 passing prefix satisfies the `n = 3` numeric
+certificate `exp(s²/3) ≤ 1/ε`, verified by the dyadic interval kernel over all
+`70` cells. -/
+theorem allCells_take_checkXpow_row6 :
+    (allCells.take 70).all (fun c => checkXpowCell 3 c) = true := by native_decide
+
+/-- Boundary witness: the first cell past the mid-range, `[80,81]`, fails the
+row-6 check. -/
+theorem boundaryCell_fails_row6 :
+    ((allCells.drop 70).take 1).all (fun c => checkXpowCell 3 c) = false := by
+  native_decide
+
+/-- **Row-6 mid** `[e^10, e^80]` via the certified envelope prefix. -/
+theorem mid_row6 : ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (80:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/3) := by
+  intro x hx
+  have hmem : x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp ((80:ℕ):ℝ)) := by
+    refine ⟨hx.1, ?_⟩
+    rw [show ((80:ℕ):ℝ) = (80:ℝ) from by norm_num]; exact hx.2
+  have h := mid_xpow_of 3 (by norm_num) 70 80
+    midCells_chain_row6 midCells_ne_nil_row6 midCells_last_row6
+    allCells_take_checkXpow_row6 x hmem
+  simpa using h
+
+/-- Row-6 floor slab certificate: `lhsE ≤ expSplitNegXpow 3` (the Buthe
+`x^{-1/2}` bound `≤ x^{-1/3}`) over the 8 width-`0.05` slabs covering
+`[√8, √10] = [2.8284, 3.1623]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row6 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (expSplitNegXpow 3)
+      (slabsFrom (282/100) 8) (-50) 8 = true := by native_decide
+
+/-- **Row-6 floor (Buthe)** `[e^8, e^10]` via `floor_xpow_of_check`. -/
+theorem floor_row6 : ∀ x ∈ Set.Icc (Real.exp (8:ℝ)) (Real.exp (10:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/3) := by
+  intro x hx
+  have hcurve : ∀ y, Real.exp (8:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (expSplitNegXpow 3)
+        ≤ y ^ (-(1:ℝ)/(3:ℕ)) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h8 : (8:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (8:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    exact le_of_eq (eval_expSplitNegXpow_eq_xpow 3 (by norm_num) y hypos hyL)
+  have h := floor_xpow_of_check (expSplitNegXpow 3) 3 (8:ℝ) (282/100) 8 (by norm_num)
+    (by rw [show ((282/100:ℚ):ℝ) = 2.82 by norm_num,
+          show (2.82:ℝ) = Real.sqrt (2.82^2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h316 : Real.sqrt 10 ≤ 3.163 := by
+          rw [show (3.163:ℝ) = Real.sqrt (3.163^2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h316])
+    (lhsE_sub_negxpow_supported 3) floor_slab_check_row6 hcurve x hx
+  simpa using h
+
+/-- **Row-6 floor-trusted** `[e^1, e^8]` (`x ∈ [2.72, 2981]`): the direct
+`π`/`Li` interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`",
+FKS2.lean:4640). No tight sub-`e^{8}` `Eπ` envelope exists in the library for the
+sharp `x^{-1/3}` target (the Buthe bound only clears it from `L ≈ 7.99`). Same
+accepted numerical-data trust class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row6 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (8:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/3) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row6
+
+/-- **Row-6 sliver** `[e^80, e^80.55]` (width `≈ 0.55` in `log x`, at the
+threshold): the `x^{-1/3}` curve is close to the `allCells` envelope on this
+band, resolved in FKS2 by the refined Theorem-6 interpolation (arXiv
+2206.12557, §5.2/5.3 / the "more refined collection of values than Table 4",
+FKS2.lean:4640). Same accepted trust class as `Table4Ext.allCells_trusted`. -/
+theorem sliver_row6 : ∀ x ∈ Set.Icc (Real.exp (80:ℝ)) (Real.exp (80.55:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/3) := by
+  exact FKS2.Cor24Trusted.sliver_row6
+
+/-- **FKS2 Corollary 24, row 6** (`table7` entry `(x ↦ x^{-1/3}, Icc 1 80.55)`):
+`Eπ x ≤ x^{-1/3}` whenever `log x ∈ [1, 80.55]`. For `x > 0` this splits into
+the four segments above; for `x ≤ 0` (possible since `log` is even) `Eπ x ≤ 0 <
+x^{-1/3}`. -/
+theorem corollary_24_row6 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 80.55 → Eπ x ≤ x ^ (-(1:ℝ)/3) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `Eπ x ≤ 0 < x^{-1/3}`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hRpos : (0:ℝ) < x ^ (-(1:ℝ)/3) := by
+      rw [Real.rpow_def_of_neg hxneg]
+      apply mul_pos (Real.exp_pos _)
+      apply Real.cos_pos_of_mem_Ioo
+      constructor <;> nlinarith [Real.pi_pos, Real.pi_le_four]
+    linarith
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the four segments
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 8 with h1 | h1
+    · exact floor_trusted_row6 x (cvt 1 8 hlo h1)
+    · rcases le_total (Real.log x) 10 with h2 | h2
+      · exact floor_row6 x (cvt 8 10 h1 h2)
+      · rcases le_total (Real.log x) 80 with h3 | h3
+        · exact mid_row6 x (cvt 10 80 h2 h3)
+        · exact sliver_row6 x (cvt 80 80.55 h3 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row7.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row7.lean
@@ -1,0 +1,154 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — row 7 (`x^{-1/4}`) mid-range envelope
+
+Row 7 (`n = 4`) of Table-7, cloned from the complete row 11 (`n = 100`) via the
+generic `n`-parameterized helpers of `FKS2Cor24Row11`
+(`Table4Ext.expSplitNegXpow`, `Table4Ext.eval_expSplitNegXpow_eq_xpow`,
+`Table4Ext.lhsE_sub_negxpow_supported`, `Table4Ext.Epi_le_evalLhsE_low`,
+`Table4Ext.floor_xpow_of_check`, `Table4Ext.mid_xpow_of`, `Table4Ext.checkXpowCell`,
+`Table4Ext.cell_Epi_le_xpow_of_check`), all instantiated here at `n = 4`.
+
+`boundaryCell_fails_row7` records that the first excluded cell `[107,108]`
+(index `97`) fails, so the row-7 envelope certifies exactly
+`allCells.take 97` (cells with `b' ≤ 107`).
+
+The row-7 curve `corollary_24_row7 : ∀ x, log x ∈ [1, 107.6] → Eπ x ≤ x^{-1/4}`
+is assembled from four segments split at `e^6`, `e^10`, `e^107`:
+* **floor-trusted** `[e^1, e^6]` (`floor_trusted_row7`, trusted `sorry`);
+* **floor (Buthe)** `[e^6, e^10]` (`floor_row7`, dyadic slab cover);
+* **mid (envelope)** `[e^10, e^107]` (`mid_row7`, `allCells.take 97`);
+* **sliver** `[e^107, e^107.6]` (`sliver_row7`, trusted `sorry`).
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 7 (`x^{-1/4}`, `log x ∈ [1, 107.6]`) -/
+
+/-- The row-7 (`n = 4`) certified prefix of `allCells`: the first `97` cells
+(`b' ≤ 107`) form a contiguous chain from `b = 10` to `b' = 107`; the next cell
+`[107,108]` fails (`boundaryCell_fails_row7`). -/
+theorem midCells_chain_row7 : chainOk 10 (allCells.take 97) = true := by native_decide
+
+theorem midCells_ne_nil_row7 : allCells.take 97 ≠ [] := by native_decide
+
+theorem midCells_last_row7 : lastB 10 (allCells.take 97) = 107 := by native_decide
+
+/-- Every cell of the row-7 passing prefix satisfies the `n = 4` numeric
+certificate `exp(s²/4) ≤ 1/ε`, verified by the dyadic interval kernel over all
+`97` cells. -/
+theorem allCells_take_checkXpow_row7 :
+    (allCells.take 97).all (fun c => checkXpowCell 4 c) = true := by native_decide
+
+/-- Boundary witness: the first cell past the mid-range, `[107,108]`, fails the
+row-7 check. -/
+theorem boundaryCell_fails_row7 :
+    ((allCells.drop 97).take 1).all (fun c => checkXpowCell 4 c) = false := by
+  native_decide
+
+/-- **Row-7 mid** `[e^10, e^107]` via the certified envelope prefix. -/
+theorem mid_row7 : ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (107:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/4) := by
+  intro x hx
+  have hmem : x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp ((107:ℕ):ℝ)) := by
+    refine ⟨hx.1, ?_⟩
+    rw [show ((107:ℕ):ℝ) = (107:ℝ) from by norm_num]; exact hx.2
+  have h := mid_xpow_of 4 (by norm_num) 97 107
+    midCells_chain_row7 midCells_ne_nil_row7 midCells_last_row7
+    allCells_take_checkXpow_row7 x hmem
+  simpa using h
+
+/-- Row-7 floor slab certificate: `lhsE ≤ expSplitNegXpow 4` (the Buthe
+`x^{-1/2}` bound `≤ x^{-1/4}`) over the 15 width-`0.05` slabs covering
+`[√6, √10] = [2.449, 3.1623]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row7 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (expSplitNegXpow 4)
+      (slabsFrom (244/100) 15) (-50) 8 = true := by native_decide
+
+/-- **Row-7 floor (Buthe)** `[e^6, e^10]` via `floor_xpow_of_check`. -/
+theorem floor_row7 : ∀ x ∈ Set.Icc (Real.exp (6:ℝ)) (Real.exp (10:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/4) := by
+  intro x hx
+  have hcurve : ∀ y, Real.exp (6:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (expSplitNegXpow 4)
+        ≤ y ^ (-(1:ℝ)/(4:ℕ)) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h6 : (6:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (6:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    exact le_of_eq (eval_expSplitNegXpow_eq_xpow 4 (by norm_num) y hypos hyL)
+  have h := floor_xpow_of_check (expSplitNegXpow 4) 4 (6:ℝ) (244/100) 15 (by norm_num)
+    (by rw [show ((244/100:ℚ):ℝ) = 2.44 by norm_num,
+          show (2.44:ℝ) = Real.sqrt (2.44^2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h316 : Real.sqrt 10 ≤ 3.163 := by
+          rw [show (3.163:ℝ) = Real.sqrt (3.163^2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h316])
+    (lhsE_sub_negxpow_supported 4) floor_slab_check_row7 hcurve x hx
+  simpa using h
+
+/-- **Row-7 floor-trusted** `[e^1, e^6]` (`x ∈ [2.72, 403.4]`): the direct
+`π`/`Li` interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`",
+FKS2.lean:4640). No tight sub-`e^{6}` `Eπ` envelope exists in the library for the
+sharp `x^{-1/4}` target (the Buthe bound only clears it from `L ≈ 5.99`). Same
+accepted numerical-data trust class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row7 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (6:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/4) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row7
+
+/-- **Row-7 sliver** `[e^107, e^107.6]` (width `≈ 0.6` in `log x`, at the
+threshold): the `x^{-1/4}` curve is close to the `allCells` envelope on this
+band, resolved in FKS2 by the refined Theorem-6 interpolation (arXiv
+2206.12557, §5.2/5.3 / the "more refined collection of values than Table 4",
+FKS2.lean:4640). Same accepted trust class as `Table4Ext.allCells_trusted`. -/
+theorem sliver_row7 : ∀ x ∈ Set.Icc (Real.exp (107:ℝ)) (Real.exp (107.6:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/4) := by
+  exact FKS2.Cor24Trusted.sliver_row7
+
+/-- **FKS2 Corollary 24, row 7** (`table7` entry `(x ↦ x^{-1/4}, Icc 1 107.6)`):
+`Eπ x ≤ x^{-1/4}` whenever `log x ∈ [1, 107.6]`. For `x > 0` this splits into
+the four segments above; for `x ≤ 0` (possible since `log` is even) `Eπ x ≤ 0 <
+x^{-1/4}`. -/
+theorem corollary_24_row7 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 107.6 → Eπ x ≤ x ^ (-(1:ℝ)/4) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `Eπ x ≤ 0 < x^{-1/4}`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hRpos : (0:ℝ) < x ^ (-(1:ℝ)/4) := by
+      rw [Real.rpow_def_of_neg hxneg]
+      apply mul_pos (Real.exp_pos _)
+      apply Real.cos_pos_of_mem_Ioo
+      constructor <;> nlinarith [Real.pi_pos, Real.pi_le_four]
+    linarith
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the four segments
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 6 with h1 | h1
+    · exact floor_trusted_row7 x (cvt 1 6 hlo h1)
+    · rcases le_total (Real.log x) 10 with h2 | h2
+      · exact floor_row7 x (cvt 6 10 h1 h2)
+      · rcases le_total (Real.log x) 107 with h3 | h3
+        · exact mid_row7 x (cvt 10 107 h2 h3)
+        · exact sliver_row7 x (cvt 107 107.6 h3 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row8.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row8.lean
@@ -1,0 +1,154 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — row 8 (`x^{-1/5}`) mid-range envelope
+
+Row 8 (`n = 5`) of Table-7, cloned from the complete row 11 (`n = 100`) via the
+generic `n`-parameterized helpers of `FKS2Cor24Row11`
+(`Table4Ext.expSplitNegXpow`, `Table4Ext.eval_expSplitNegXpow_eq_xpow`,
+`Table4Ext.lhsE_sub_negxpow_supported`, `Table4Ext.Epi_le_evalLhsE_low`,
+`Table4Ext.floor_xpow_of_check`, `Table4Ext.mid_xpow_of`, `Table4Ext.checkXpowCell`,
+`Table4Ext.cell_Epi_le_xpow_of_check`), all instantiated here at `n = 5`.
+
+`boundaryCell_fails_row8` records that the first excluded cell `[134,135]`
+(index `124`) fails, so the row-8 envelope certifies exactly
+`allCells.take 124` (cells with `b' ≤ 134`).
+
+The row-8 curve `corollary_24_row8 : ∀ x, log x ∈ [1, 134.8] → Eπ x ≤ x^{-1/5}`
+is assembled from four segments split at `e^5`, `e^10`, `e^134`:
+* **floor-trusted** `[e^1, e^5]` (`floor_trusted_row8`, trusted `sorry`);
+* **floor (Buthe)** `[e^5, e^10]` (`floor_row8`, dyadic slab cover);
+* **mid (envelope)** `[e^10, e^134]` (`mid_row8`, `allCells.take 124`);
+* **sliver** `[e^134, e^134.8]` (`sliver_row8`, trusted `sorry`).
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 8 (`x^{-1/5}`, `log x ∈ [1, 134.8]`) -/
+
+/-- The row-8 (`n = 5`) certified prefix of `allCells`: the first `124` cells
+(`b' ≤ 134`) form a contiguous chain from `b = 10` to `b' = 134`; the next cell
+`[134,135]` fails (`boundaryCell_fails_row8`). -/
+theorem midCells_chain_row8 : chainOk 10 (allCells.take 124) = true := by native_decide
+
+theorem midCells_ne_nil_row8 : allCells.take 124 ≠ [] := by native_decide
+
+theorem midCells_last_row8 : lastB 10 (allCells.take 124) = 134 := by native_decide
+
+/-- Every cell of the row-8 passing prefix satisfies the `n = 5` numeric
+certificate `exp(s²/5) ≤ 1/ε`, verified by the dyadic interval kernel over all
+`124` cells. -/
+theorem allCells_take_checkXpow_row8 :
+    (allCells.take 124).all (fun c => checkXpowCell 5 c) = true := by native_decide
+
+/-- Boundary witness: the first cell past the mid-range, `[134,135]`, fails the
+row-8 check. -/
+theorem boundaryCell_fails_row8 :
+    ((allCells.drop 124).take 1).all (fun c => checkXpowCell 5 c) = false := by
+  native_decide
+
+/-- **Row-8 mid** `[e^10, e^134]` via the certified envelope prefix. -/
+theorem mid_row8 : ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (134:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/5) := by
+  intro x hx
+  have hmem : x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp ((134:ℕ):ℝ)) := by
+    refine ⟨hx.1, ?_⟩
+    rw [show ((134:ℕ):ℝ) = (134:ℝ) from by norm_num]; exact hx.2
+  have h := mid_xpow_of 5 (by norm_num) 124 134
+    midCells_chain_row8 midCells_ne_nil_row8 midCells_last_row8
+    allCells_take_checkXpow_row8 x hmem
+  simpa using h
+
+/-- Row-8 floor slab certificate: `lhsE ≤ expSplitNegXpow 5` (the Buthe
+`x^{-1/2}` bound `≤ x^{-1/5}`) over the 20 width-`0.05` slabs covering
+`[√5, √10] = [2.236, 3.1623]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row8 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (expSplitNegXpow 5)
+      (slabsFrom (223/100) 20) (-50) 8 = true := by native_decide
+
+/-- **Row-8 floor (Buthe)** `[e^5, e^10]` via `floor_xpow_of_check`. -/
+theorem floor_row8 : ∀ x ∈ Set.Icc (Real.exp (5:ℝ)) (Real.exp (10:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/5) := by
+  intro x hx
+  have hcurve : ∀ y, Real.exp (5:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (expSplitNegXpow 5)
+        ≤ y ^ (-(1:ℝ)/(5:ℕ)) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h5 : (5:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (5:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    exact le_of_eq (eval_expSplitNegXpow_eq_xpow 5 (by norm_num) y hypos hyL)
+  have h := floor_xpow_of_check (expSplitNegXpow 5) 5 (5:ℝ) (223/100) 20 (by norm_num)
+    (by rw [show ((223/100:ℚ):ℝ) = 2.23 by norm_num,
+          show (2.23:ℝ) = Real.sqrt (2.23^2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h316 : Real.sqrt 10 ≤ 3.163 := by
+          rw [show (3.163:ℝ) = Real.sqrt (3.163^2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h316])
+    (lhsE_sub_negxpow_supported 5) floor_slab_check_row8 hcurve x hx
+  simpa using h
+
+/-- **Row-8 floor-trusted** `[e^1, e^5]` (`x ∈ [2.72, 148.4]`): the direct
+`π`/`Li` interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`",
+FKS2.lean:4640). No tight sub-`e^{5}` `Eπ` envelope exists in the library for the
+sharp `x^{-1/5}` target (the Buthe bound only clears it from `L ≈ 4.9`). Same
+accepted numerical-data trust class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row8 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (5:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/5) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row8
+
+/-- **Row-8 sliver** `[e^134, e^134.8]` (width `≈ 0.8` in `log x`, at the
+threshold): the `x^{-1/5}` curve is close to the `allCells` envelope on this
+band, resolved in FKS2 by the refined Theorem-6 interpolation (arXiv
+2206.12557, §5.2/5.3 / the "more refined collection of values than Table 4",
+FKS2.lean:4640). Same accepted trust class as `Table4Ext.allCells_trusted`. -/
+theorem sliver_row8 : ∀ x ∈ Set.Icc (Real.exp (134:ℝ)) (Real.exp (134.8:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/5) := by
+  exact FKS2.Cor24Trusted.sliver_row8
+
+/-- **FKS2 Corollary 24, row 8** (`table7` entry `(x ↦ x^{-1/5}, Icc 1 134.8)`):
+`Eπ x ≤ x^{-1/5}` whenever `log x ∈ [1, 134.8]`. For `x > 0` this splits into
+the four segments above; for `x ≤ 0` (possible since `log` is even) `Eπ x ≤ 0 <
+x^{-1/5}`. -/
+theorem corollary_24_row8 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 134.8 → Eπ x ≤ x ^ (-(1:ℝ)/5) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `Eπ x ≤ 0 < x^{-1/5}`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hRpos : (0:ℝ) < x ^ (-(1:ℝ)/5) := by
+      rw [Real.rpow_def_of_neg hxneg]
+      apply mul_pos (Real.exp_pos _)
+      apply Real.cos_pos_of_mem_Ioo
+      constructor <;> nlinarith [Real.pi_pos, Real.pi_le_four]
+    linarith
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the four segments
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 5 with h1 | h1
+    · exact floor_trusted_row8 x (cvt 1 5 hlo h1)
+    · rcases le_total (Real.log x) 10 with h2 | h2
+      · exact floor_row8 x (cvt 5 10 h1 h2)
+      · rcases le_total (Real.log x) 134 with h3 | h3
+        · exact mid_row8 x (cvt 10 134 h2 h3)
+        · exact sliver_row8 x (cvt 134 134.8 h3 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row9.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row9.lean
@@ -1,0 +1,154 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row11
+
+/-!
+# FKS2 Corollary 24 — row 9 (`x^{-1/10}`) mid-range envelope
+
+Row 9 (`n = 10`) of Table-7, cloned from the complete row 11 (`n = 100`) via the
+generic `n`-parameterized helpers of `FKS2Cor24Row11`
+(`Table4Ext.expSplitNegXpow`, `Table4Ext.eval_expSplitNegXpow_eq_xpow`,
+`Table4Ext.lhsE_sub_negxpow_supported`, `Table4Ext.Epi_le_evalLhsE_low`,
+`Table4Ext.floor_xpow_of_check`, `Table4Ext.mid_xpow_of`, `Table4Ext.checkXpowCell`,
+`Table4Ext.cell_Epi_le_xpow_of_check`), all instantiated here at `n = 10`.
+
+`boundaryCell_fails_row9` records that the first excluded cell `[270,271]`
+(index `260`) fails, so the row-9 envelope certifies exactly
+`allCells.take 260` (cells with `b' ≤ 270`).
+
+The row-9 curve `corollary_24_row9 : ∀ x, log x ∈ [1, 270.8] → Eπ x ≤ x^{-1/10}`
+is assembled from four segments split at `e^4`, `e^10`, `e^270`:
+* **floor-trusted** `[e^1, e^4]` (`floor_trusted_row9`, trusted `sorry`);
+* **floor (Buthe)** `[e^4, e^10]` (`floor_row9`, dyadic slab cover);
+* **mid (envelope)** `[e^10, e^270]` (`mid_row9`, `allCells.take 260`);
+* **sliver** `[e^270, e^270.8]` (`sliver_row9`, trusted `sorry`).
+-/
+
+namespace FKS2
+
+open Real Table4Ext LeanCert.Core LeanCert.ANT.Asymp
+
+set_option linter.style.nativeDecide false
+
+/-! ## FKS2 Corollary 24, row 9 (`x^{-1/10}`, `log x ∈ [1, 270.8]`) -/
+
+/-- The row-9 (`n = 10`) certified prefix of `allCells`: the first `260` cells
+(`b' ≤ 270`) form a contiguous chain from `b = 10` to `b' = 270`; the next cell
+`[270,271]` fails (`boundaryCell_fails_row9`). -/
+theorem midCells_chain_row9 : chainOk 10 (allCells.take 260) = true := by native_decide
+
+theorem midCells_ne_nil_row9 : allCells.take 260 ≠ [] := by native_decide
+
+theorem midCells_last_row9 : lastB 10 (allCells.take 260) = 270 := by native_decide
+
+/-- Every cell of the row-9 passing prefix satisfies the `n = 10` numeric
+certificate `exp(s²/10) ≤ 1/ε`, verified by the dyadic interval kernel over all
+`260` cells. -/
+theorem allCells_take_checkXpow_row9 :
+    (allCells.take 260).all (fun c => checkXpowCell 10 c) = true := by native_decide
+
+/-- Boundary witness: the first cell past the mid-range, `[270,271]`, fails the
+row-9 check. -/
+theorem boundaryCell_fails_row9 :
+    ((allCells.drop 260).take 1).all (fun c => checkXpowCell 10 c) = false := by
+  native_decide
+
+/-- **Row-9 mid** `[e^10, e^270]` via the certified envelope prefix. -/
+theorem mid_row9 : ∀ x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp (270:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/10) := by
+  intro x hx
+  have hmem : x ∈ Set.Icc (Real.exp (10:ℝ)) (Real.exp ((270:ℕ):ℝ)) := by
+    refine ⟨hx.1, ?_⟩
+    rw [show ((270:ℕ):ℝ) = (270:ℝ) from by norm_num]; exact hx.2
+  have h := mid_xpow_of 10 (by norm_num) 260 270
+    midCells_chain_row9 midCells_ne_nil_row9 midCells_last_row9
+    allCells_take_checkXpow_row9 x hmem
+  simpa using h
+
+/-- Row-9 floor slab certificate: `lhsE ≤ expSplitNegXpow 10` (the Buthe
+`x^{-1/2}` bound `≤ x^{-1/10}`) over the 24 width-`0.05` slabs covering
+`[√4, √10] = [2, 3.1623]`, verified by the dyadic interval kernel. -/
+theorem floor_slab_check_row9 :
+    checkExprLeOnSlabsDyadic FloorButhe.lhsE (expSplitNegXpow 10)
+      (slabsFrom 2 24) (-50) 8 = true := by native_decide
+
+/-- **Row-9 floor (Buthe)** `[e^4, e^10]` via `floor_xpow_of_check`. -/
+theorem floor_row9 : ∀ x ∈ Set.Icc (Real.exp (4:ℝ)) (Real.exp (10:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/10) := by
+  intro x hx
+  have hcurve : ∀ y, Real.exp (4:ℝ) ≤ y →
+      Expr.eval (fun _ => Real.sqrt (Real.log y)) (expSplitNegXpow 10)
+        ≤ y ^ (-(1:ℝ)/(10:ℕ)) := by
+    intro y hy
+    have hypos : (0:ℝ) < y := lt_of_lt_of_le (Real.exp_pos _) hy
+    have hyL : (0:ℝ) ≤ Real.log y := by
+      have h4 : (4:ℝ) ≤ Real.log y := by
+        rw [← Real.log_exp (4:ℝ)]; exact Real.log_le_log (Real.exp_pos _) hy
+      linarith
+    exact le_of_eq (eval_expSplitNegXpow_eq_xpow 10 (by norm_num) y hypos hyL)
+  have h := floor_xpow_of_check (expSplitNegXpow 10) 10 (4:ℝ) 2 24 (by norm_num)
+    (by rw [show ((2:ℚ):ℝ) = 2 by norm_num,
+          show (2:ℝ) = Real.sqrt (2^2) from (Real.sqrt_sq (by norm_num)).symm]
+        exact Real.sqrt_le_sqrt (by norm_num))
+    (by have h316 : Real.sqrt 10 ≤ 3.163 := by
+          rw [show (3.163:ℝ) = Real.sqrt (3.163^2) from (Real.sqrt_sq (by norm_num)).symm]
+          exact Real.sqrt_le_sqrt (by norm_num)
+        push_cast; linarith [h316])
+    (lhsE_sub_negxpow_supported 10) floor_slab_check_row9 hcurve x hx
+  simpa using h
+
+/-- **Row-9 floor-trusted** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): the direct
+`π`/`Li` interpolation for small `x` that the blueprint proof invokes
+(\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`",
+FKS2.lean:4640). No tight sub-`e^{4}` `Eπ` envelope exists in the library for the
+sharp `x^{-1/10}` target (the Buthe bound only clears it from `L ≈ 3.49`). Same
+accepted numerical-data trust class as `Table4Ext.allCells_trusted`. -/
+theorem floor_trusted_row9 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/10) := by
+  exact FKS2.Cor24Trusted.floor_trusted_row9
+
+/-- **Row-9 sliver** `[e^270, e^270.8]` (width `≈ 0.8` in `log x`, at the
+threshold): the `x^{-1/10}` curve is close to the `allCells` envelope on this
+band, resolved in FKS2 by the refined Theorem-6 interpolation (arXiv
+2206.12557, §5.2/5.3 / the "more refined collection of values than Table 4",
+FKS2.lean:4640). Same accepted trust class as `Table4Ext.allCells_trusted`. -/
+theorem sliver_row9 : ∀ x ∈ Set.Icc (Real.exp (270:ℝ)) (Real.exp (270.8:ℝ)),
+    Eπ x ≤ x ^ (-(1:ℝ)/10) := by
+  exact FKS2.Cor24Trusted.sliver_row9
+
+/-- **FKS2 Corollary 24, row 9** (`table7` entry `(x ↦ x^{-1/10}, Icc 1 270.8)`):
+`Eπ x ≤ x^{-1/10}` whenever `log x ∈ [1, 270.8]`. For `x > 0` this splits into
+the four segments above; for `x ≤ 0` (possible since `log` is even) `Eπ x ≤ 0 <
+x^{-1/10}`. -/
+theorem corollary_24_row9 :
+    ∀ x, Real.log x ∈ Set.Icc (1:ℝ) 270.8 → Eπ x ≤ x ^ (-(1:ℝ)/10) := by
+  intro x hlog
+  obtain ⟨hlo, hhi⟩ := hlog
+  rcases lt_trichotomy x 0 with hxneg | hx0 | hxpos
+  · -- x < 0: `Eπ x ≤ 0 < x^{-1/10}`
+    have hLpos : (0:ℝ) < Real.log x := by linarith
+    have hEle0 : Eπ x ≤ 0 := by
+      unfold Eπ
+      apply div_nonpos_of_nonneg_of_nonpos (abs_nonneg _)
+      exact le_of_lt (div_neg_of_neg_of_pos hxneg hLpos)
+    have hRpos : (0:ℝ) < x ^ (-(1:ℝ)/10) := by
+      rw [Real.rpow_def_of_neg hxneg]
+      apply mul_pos (Real.exp_pos _)
+      apply Real.cos_pos_of_mem_Ioo
+      constructor <;> nlinarith [Real.pi_pos, Real.pi_le_four]
+    linarith
+  · -- x = 0: `log 0 = 0` contradicts `1 ≤ log x`
+    exfalso; rw [hx0, Real.log_zero] at hlo; linarith
+  · -- x > 0: dispatch to the four segments
+    have cvt : ∀ a b : ℝ, a ≤ Real.log x → Real.log x ≤ b →
+        x ∈ Set.Icc (Real.exp a) (Real.exp b) := by
+      intro a b ha hb
+      exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
+             by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
+    rcases le_total (Real.log x) 4 with h1 | h1
+    · exact floor_trusted_row9 x (cvt 1 4 hlo h1)
+    · rcases le_total (Real.log x) 10 with h2 | h2
+      · exact floor_row9 x (cvt 4 10 h1 h2)
+      · rcases le_total (Real.log x) 270 with h3 | h3
+        · exact mid_row9 x (cvt 10 270 h2 h3)
+        · exact sliver_row9 x (cvt 270 270.8 h3 hhi)
+
+end FKS2

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24TrustedNumerics.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24TrustedNumerics.lean
@@ -1,0 +1,234 @@
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+
+/-!
+# Trusted numerical boundaries introduced by FKS2 Corollary 24
+
+This file collects, in one place and with **minimal imports**, the trusted numerical
+`sorry`s that the formalisation of FKS2 Corollary 24 (`corollary_24_all`) **introduces**:
+twenty-two bounds on compact windows `x ∈ [eᵃ, eᵇ]`, two per Table-7 row — a small-`x`
+*floor* and a large-`x` *sliver*/*band* at the threshold.  Each is a finite-range
+numerical datum taken from the published computations of
+
+> M. Cully-Hugill, D. R. Johnston, T. S. Trudgian, A. Yang (FKS2),
+> *Explicit bounds for `π(x)` and related functions* (arXiv:2206.12557).
+
+## Scope
+
+These twenty-two are the trust that Corollary 24 adds *on top of* the existing
+development.  `corollary_24_all` additionally relies on trusted numerical `sorry`s that
+already live elsewhere in the repository and are **not** reproduced here:
+
+* the Büthe bounds `Buthe.theorem_2e` / `theorem_2f` (used via `Epi_le_xpow_half`),
+  backing the proved Büthe `x^{-1/2}` floor segments;
+* `Table4Ext.allCells_trusted` — the ancillary Table-4 cell data, backing the numerical
+  mid-range envelope.
+
+So `#print axioms corollary_24_all` reports `sorryAx` on account of those as well as of
+the facts gathered here.
+
+## What the facts are
+
+The eleven *floor* windows are small-`x` (`x ≲ 10⁴`): there `π(x)` is an exact prime
+count and `Li(x) = ∫_2^x dt / log t` a certified quadrature, so the bound is a direct
+finite check with no analytic input — the "checks directly for particularly small `x`"
+step of FKS2 §5.2–§5.3.  The eleven *sliver*/*band* windows sit at the Table-7 threshold
+and are of a different, **tabular** character: they lie at astronomically large `x` (from
+`e^43 ≈ 5·10¹⁸` up to `e^3757.6`), far beyond any direct prime count, and rest on FKS2's
+interpolation of the numerical results of Theorem 6 (the "more refined collection of
+values than Table 4").  None is a zero-free region or an unproved asymptotic to be
+discharged inside this development; each is a finite, paper-verified numerical datum.
+
+## Auditing
+
+To keep imports minimal this file does not import the main development; the FKS2
+abbreviation `E_π` that appears below is written out here from Mathlib primitives only:
+
+* `Epi x` is `E_π(x) = |π(x) − Li(x)| / (x / log x)` with
+  `π(x) = Nat.primeCounting ⌊x⌋₊` and `Li(x) = ∫_2^x dt / log t`.
+
+The Table-7 bound curves (`c · (log x)^a · x^{-1/2}`, `x^{-1/k}`) are already elementary
+and appear verbatim.  `Epi` is *definitionally equal* to the root-namespace `Eπ` of the
+main development (`Defs.lean`); the equality is guarded by a `rfl` `example` in
+`FKS2Cor24.lean`, and the row files discharge their goals by `exact` against the lemmas
+below.
+-/
+
+open MeasureTheory
+
+namespace FKS2.Cor24Trusted
+
+/-- `E_π(x) = |π(x) − Li(x)| / (x / log x)`, written out with Mathlib primitives only
+(`π(x) = Nat.primeCounting ⌊x⌋₊`, `Li(x) = ∫_2^x dt / log t`).  Definitionally equal to
+the main development's root-namespace `Eπ` (`Defs.lean`). -/
+noncomputable def Epi (x : ℝ) : ℝ :=
+  |(Nat.primeCounting ⌊x⌋₊ : ℝ) - ∫ t in (2 : ℝ)..x, 1 / Real.log t| / (x / Real.log x)
+
+/-! ### Row 1 — curve `2·log x·x^{-1/2}` -/
+
+/-- **Row 1 floor** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ 2·log x·x^{-1/2}`.  Purely computational. -/
+theorem floor_trusted_row1 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+    Epi x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-- **Row 1 band** `[e^43, e^57]` (`x` from `≈5·10¹⁸`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's Theorem-6 interpolation, no direct prime count.
+`E_π(x) ≤ 2·log x·x^{-1/2}`. -/
+theorem band_row1 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (57:ℝ)),
+    Epi x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-! ### Row 2 — curve `(log x)^{3/2}·x^{-1/2}` -/
+
+/-- **Row 2 floor** `[e^1, e^8]` (`x ∈ [2.72, 2981]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ (log x)^{3/2}·x^{-1/2}`.  Purely computational. -/
+theorem floor_trusted_row2 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (8:ℝ)),
+    Epi x ≤ (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-- **Row 2 band** `[e^43, e^65.65]` (`x` from `≈5·10¹⁸`): trusted **tabular** boundary
+at the Table-7 threshold — FKS2's Theorem-6 interpolation, no direct prime count.
+`E_π(x) ≤ (log x)^{3/2}·x^{-1/2}`. -/
+theorem band_row2 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (65.65:ℝ)),
+    Epi x ≤ (Real.log x) ^ (3/2 : ℝ) * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-! ### Row 3 — curve `(1/(8π))·(log x)^2·x^{-1/2}` -/
+
+/-- **Row 3 floor** `[e^8, e^9]` (`x ∈ [2981, 8103]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ (1/(8π))·(log x)^2·x^{-1/2}`.  Purely computational. -/
+theorem floor_trusted_row3 : ∀ x ∈ Set.Icc (Real.exp (8:ℝ)) (Real.exp (9:ℝ)),
+    Epi x ≤ (1 / (8 * Real.pi)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-- **Row 3 band** `[e^43, e^60.8]` (`x` from `≈5·10¹⁸`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's Theorem-6 interpolation, no direct prime count.
+`E_π(x) ≤ (1/(8π))·(log x)^2·x^{-1/2}`. -/
+theorem band_row3 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (60.8:ℝ)),
+    Epi x ≤ (1 / (8 * Real.pi)) * (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-! ### Row 4 — curve `(log x)^2·x^{-1/2}` -/
+
+/-- **Row 4 floor** `[e^1, e^3]` (`x ∈ [2.72, 20.1]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ (log x)^2·x^{-1/2}`.  Purely computational. -/
+theorem floor_trusted_row4 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (3:ℝ)),
+    Epi x ≤ (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-- **Row 4 band** `[e^43, e^70.6]` (`x` from `≈5·10¹⁸`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's Theorem-6 interpolation, no direct prime count.
+`E_π(x) ≤ (log x)^2·x^{-1/2}`. -/
+theorem band_row4 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (70.6:ℝ)),
+    Epi x ≤ (Real.log x) ^ 2 * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-! ### Row 5 — curve `(log x)^3·x^{-1/2}` -/
+
+/-- **Row 5 floor** `[e^1, e^3]` (`x ∈ [2.72, 20.1]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ (log x)^3·x^{-1/2}`.  Purely computational. -/
+theorem floor_trusted_row5 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (3:ℝ)),
+    Epi x ≤ (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-- **Row 5 band** `[e^43, e^80]` (`x` from `≈5·10¹⁸`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's Theorem-6 interpolation, no direct prime count.
+`E_π(x) ≤ (log x)^3·x^{-1/2}`. -/
+theorem band_row5 : ∀ x ∈ Set.Icc (Real.exp (43:ℝ)) (Real.exp (80:ℝ)),
+    Epi x ≤ (Real.log x) ^ 3 * x ^ (-(1:ℝ) / 2) := by
+  sorry
+
+/-! ### Row 6 — curve `x^{-1/3}` -/
+
+/-- **Row 6 floor** `[e^1, e^8]` (`x ∈ [2.72, 2981]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ x^{-1/3}`.  Purely computational. -/
+theorem floor_trusted_row6 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (8:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/3) := by
+  sorry
+
+/-- **Row 6 sliver** `[e^80, e^80.55]` (`x ≈ 5·10³⁴`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's refined Theorem-6 interpolation, far beyond any direct
+prime count.  `E_π(x) ≤ x^{-1/3}`. -/
+theorem sliver_row6 : ∀ x ∈ Set.Icc (Real.exp (80:ℝ)) (Real.exp (80.55:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/3) := by
+  sorry
+
+/-! ### Row 7 — curve `x^{-1/4}` -/
+
+/-- **Row 7 floor** `[e^1, e^6]` (`x ∈ [2.72, 403]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ x^{-1/4}`.  Purely computational. -/
+theorem floor_trusted_row7 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (6:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/4) := by
+  sorry
+
+/-- **Row 7 sliver** `[e^107, e^107.6]` (`x ≈ 3·10⁴⁶`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's refined Theorem-6 interpolation, far beyond any direct
+prime count.  `E_π(x) ≤ x^{-1/4}`. -/
+theorem sliver_row7 : ∀ x ∈ Set.Icc (Real.exp (107:ℝ)) (Real.exp (107.6:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/4) := by
+  sorry
+
+/-! ### Row 8 — curve `x^{-1/5}` -/
+
+/-- **Row 8 floor** `[e^1, e^5]` (`x ∈ [2.72, 148]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ x^{-1/5}`.  Purely computational. -/
+theorem floor_trusted_row8 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (5:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/5) := by
+  sorry
+
+/-- **Row 8 sliver** `[e^134, e^134.8]` (`x ≈ 1.6·10⁵⁸`): trusted **tabular** boundary at
+the Table-7 threshold — FKS2's refined Theorem-6 interpolation, far beyond any direct
+prime count.  `E_π(x) ≤ x^{-1/5}`. -/
+theorem sliver_row8 : ∀ x ∈ Set.Icc (Real.exp (134:ℝ)) (Real.exp (134.8:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/5) := by
+  sorry
+
+/-! ### Row 9 — curve `x^{-1/10}` -/
+
+/-- **Row 9 floor** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ x^{-1/10}`.  Purely computational. -/
+theorem floor_trusted_row9 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/10) := by
+  sorry
+
+/-- **Row 9 sliver** `[e^270, e^270.8]` (`x` astronomically large): trusted **tabular**
+boundary at the Table-7 threshold — FKS2's refined Theorem-6 interpolation, far beyond
+any direct prime count.  `E_π(x) ≤ x^{-1/10}`. -/
+theorem sliver_row9 : ∀ x ∈ Set.Icc (Real.exp (270:ℝ)) (Real.exp (270.8:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/10) := by
+  sorry
+
+/-! ### Row 10 — curve `x^{-1/50}` -/
+
+/-- **Row 10 floor** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ x^{-1/50}`.  Purely computational. -/
+theorem floor_trusted_row10 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/50) := by
+  sorry
+
+/-- **Row 10 sliver** `[e^1358, e^1358.6]` (`x` astronomically large): trusted **tabular**
+boundary at the Table-7 threshold — FKS2's refined Theorem-6 interpolation, far beyond
+any direct prime count.  `E_π(x) ≤ x^{-1/50}`. -/
+theorem sliver_row10 : ∀ x ∈ Set.Icc (Real.exp (1358:ℝ)) (Real.exp (1358.6:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/50) := by
+  sorry
+
+/-! ### Row 11 — curve `x^{-1/100}` -/
+
+/-- **Row 11 floor** `[e^1, e^3.5]` (`x ∈ [2.72, 33.1]`): direct `π`/`Li` check for small
+`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ x^{-1/100}`.  Purely computational. -/
+theorem floor_trusted_row11 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (3.5:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/100) := by
+  sorry
+
+/-- **Row 11 sliver** `[e^3756, e^3757.6]` (`x` astronomically large): trusted **tabular**
+boundary at the Table-7 threshold — FKS2's refined Theorem-6 interpolation, far beyond
+any direct prime count.  `E_π(x) ≤ x^{-1/100}`. -/
+theorem sliver_row11 : ∀ x ∈ Set.Icc (Real.exp (3756:ℝ)) (Real.exp (3757.6:ℝ)),
+    Epi x ≤ x ^ (-(1:ℝ)/100) := by
+  sorry
+
+end FKS2.Cor24Trusted


### PR DESCRIPTION
Proves **FKS2 Corollary 24 (#1429)** — all 11 rows of Table 7.

`FKS2.corollary_24_all` (`FKS2Cor24All.lean`) proves, for every `(B, I) ∈ table7`,
the pointwise bound `Eπ x ≤ B x` for all `x` with `log x ∈ I`, dispatching to
`corollary_24_row1 … row11`. Shared `x^{-1/2}` core `Epi_le_xpow_half`
(`FKS2Cor24.lean`) rereads the Büthe `Eπ`-bound (`Buthe.theorem_2e/2f`) directly
in `x^{-1/2}` form; each row then splits as a Büthe floor `[e^split, e^10]` + a
Table-4 envelope mid `[e^10, e^b]` (every Table-7 interval sits inside the
`allCells` range, so there is no tail).

Blueprint: "Same as in Corollary 23". Mirrors the merged Corollary 23 (#1629)
structure one-to-one. Green on v4.32.0.

### Trust surface
`#print axioms corollary_24_all`: `{propext, Classical.choice, Quot.sound, sorryAx}`
plus 37 `native_decide` compiler-trust axioms (the interval-arithmetic cell/slab
checks — the `Lean.ofReduceBool` class) — no custom axioms, the same accepted class
as `corollary_23_all` (#1629). The `sorryAx` comes from:

* **22 trusted numerical windows** (2 per row), collected as named theorems with
  expanded statements + human docstrings in `FKS2Cor24TrustedNumerics.lean` (a
  dedicated, minimal-import file that does not import the main development — the
  structure accepted for #1629's `FKS2TrustedNumerics.lean`);
* the pre-existing trusted `sorry`s reused via the proved segments — `Buthe.theorem_2e/2f`
  (via `Epi_le_xpow_half`) and `Table4Ext.allCells_trusted` (the Table-4 envelope) —
  which are **not** reproduced in the trusted file.

Each row's two trusted windows are a small-`x` **floor** (below the Büthe range —
a direct `π`/`Li` finite check, FKS2 §5.2–§5.3) and a **band/sliver** at the Table-7
threshold (astronomically large `x`, resting on FKS2's Theorem-6 interpolation, no
direct prime count). Per row:

| Row | curve | proven `log x` | floor window | band/sliver window |
|----:|-------|----------------|--------------|--------------------|
| 1 | `2·log x·x^{-1/2}` | `[1,57]` | `[e^1,e^4]` | `[e^43,e^57]` |
| 2 | `(log x)^{3/2}·x^{-1/2}` | `[1,65.65]` | `[e^1,e^8]` | `[e^43,e^65.65]` |
| 3 | `(1/(8π))·(log x)^2·x^{-1/2}` | `[8,60.8]` | `[e^8,e^9]` | `[e^43,e^60.8]` |
| 4 | `(log x)^2·x^{-1/2}` | `[1,70.6]` | `[e^1,e^3]` | `[e^43,e^70.6]` |
| 5 | `(log x)^3·x^{-1/2}` | `[1,80]` | `[e^1,e^3]` | `[e^43,e^80]` |
| 6 | `x^{-1/3}` | `[1,80.55]` | `[e^1,e^8]` | `[e^80,e^80.55]` |
| 7 | `x^{-1/4}` | `[1,107.6]` | `[e^1,e^6]` | `[e^107,e^107.6]` |
| 8 | `x^{-1/5}` | `[1,134.8]` | `[e^1,e^5]` | `[e^134,e^134.8]` |
| 9 | `x^{-1/10}` | `[1,270.8]` | `[e^1,e^4]` | `[e^270,e^270.8]` |
| 10 | `x^{-1/50}` | `[1,1358.6]` | `[e^1,e^4]` | `[e^1358,e^1358.6]` |
| 11 | `x^{-1/100}` | `[1,3757.6]` | `[e^1,e^3.5]` | `[e^3756,e^3757.6]` |

### Dependencies (both already merged)
- **#1629** — Corollary 23; `FKS2Cor24.lean` imports `FKS2Cor23` and reuses its
  Büthe / Table-4 infrastructure.
- **#1672** — the Table-7 row-2 statement fix (`(log x)^((3:ℝ)/2)`, the ℕ-division
  bug I reported on #1429). This PR needs no change to `FKS2.lean`.

### Notes
- Full Corollary 24 deliverable (14 files: shared core, one file per row, the
  trusted-numerics collector). Happy to split if that reviews more easily.
- `FKS2.corollary_24` (the stub in `FKS2.lean`) sits upstream of these per-row
  files in the import DAG, so it is proven downstream as `corollary_24_all`, exactly
  as `corollary_23_all` does for #1629.
- Authored with AI assistance; the trusted-numerics file is written so each `sorry`
  is auditable in isolation against arXiv:2206.12557.
