### PR TITLE
feat(IK): prove isCompletelyMultiplicative_liouville

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1422,7 +1422,17 @@ The Liouville function is completely multiplicative. -/
   The Liouville function $\lambda(n)$ is defined as $(-1)^{\Omega(n)}$, where $\Omega(n)$ counts the total number of prime factors of $n$ with multiplicity. To show that $\lambda$ is completely multiplicative, we need to verify that $\lambda(1) = 1$ and that $\lambda(ab) = \lambda(a)\lambda(b)$ for all natural numbers $a$ and $b$.
   -/)]
 lemma isCompletelyMultiplicative_liouville : IsCompletelyMultiplicative (liouville : ArithmeticFunction ℝ) := by
-  sorry
+  refine ⟨?_, fun a b ↦ ?_⟩
+  · -- λ(1) = (-1)^{Ω(1)} = (-1)^0 = 1
+    simp [liouville, toArithmeticFunction, cardFactors_one]
+  · -- λ(ab) = (-1)^{Ω(ab)} = (-1)^{Ω(a)+Ω(b)} = λ(a)λ(b) for a,b ≠ 0 (and both sides vanish if either is 0)
+    simp only [intCoe_apply]
+    by_cases ha : a = 0
+    · simp [ha]
+    by_cases hb : b = 0
+    · simp [hb]
+    simp [liouville, toArithmeticFunction, ha, hb, mul_ne_zero ha hb, cardFactors_mul ha hb,
+      pow_add]
 
 /--
 The Dirichlet series of the Liouville function is `ζ(2s)/ζ(s)`. -/


### PR DESCRIPTION
## Motivation
Closes #1685. Close the `sorry` on `isCompletelyMultiplicative_liouville` in `IwaniecKowalskiCh1.lean`. This is a foundational multiplicativity fact used by the Liouville L-series identity (`LSeries_liouville_eq`) and related IK Ch.1 statements.

## Scope
- Prove `IsCompletelyMultiplicative (liouville : ArithmeticFunction ℝ)` from the definition `λ(n) = (-1)^Ω(n)`, using `cardFactors_mul` for the nonzero case and vanishing at `0`.
- No statement or blueprint metadata changes; no new helpers.

## Test plan
- [x] `lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1` succeeds
- [x] CI green
- [x] No new warnings beyond pre-existing `sorry`s / one pre-existing docstring lint
- [x] No new `sorry`s introduced

Made with Cursor.