### PR TITLE
fix: CMS closed interval; Goldbach 7; PT/JY Li

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/Goldbach.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Goldbach.lean
@@ -58,7 +58,7 @@ theorem even_goldbach_test : even_conjecture 30 := by
   (title := "Odd Goldbach conjecture up to a given height")
   (statement := /--
   We say that the odd Goldbach conjecture is verified up to height $H$ if every odd
-  integer between $5$ and $H$ is the sum of three primes. -/)]
+  integer between $7$ and $H$ is the sum of three primes. -/)]
 def odd_conjecture (H : ℕ) : Prop :=
   ∀ n ∈ Finset.Icc 7 H, Odd n →
     ∃ p q r : ℕ, Nat.Prime p ∧ Nat.Prime q ∧ Nat.Prime r ∧ n = p + q + r

--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -130,9 +130,10 @@ theorem corollary_1 (X σ A B C ε₀ : ℝ) (h : (X, σ, A, B, C, ε₀) ∈ Ta
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
+  |\pi(x) - \mathrm{Li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
   \]
-  for all $x \geq \exp(2000)$.
+  for all $x \geq \exp(2000)$
+  (equivalently $E_\pi$ classical bound with $A=235$, $B=1.52$, $C=0.8$, $R=1$).
   -/)
   (latexEnv := "theorem")]
 theorem corollary_2 : Eπ.classicalBound 235 1.52 0.8 1 (exp 2000) := by
@@ -271,9 +272,10 @@ blueprint_comment /-- results from \cite{johnston-yang}-/
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
+  |\pi(x) - \mathrm{Li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
   \]
-  for all $x \geq 2$.
+  for all $x \geq 2$
+  (equivalently $E_\pi$ classical bound with $A=9.59$, $B=1.515$, $C=0.8274$, $R=1$).
   -/)
   (latexEnv := "theorem")]
 theorem corollary_1_3 : Eπ.classicalBound 9.59 1.515 0.8274 1 2 := by

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -1427,12 +1427,15 @@ namespace CarneiroEtAl2019RH
 @[blueprint
   "thm:carneiroetal_2019_rh"
   (title := "Carneiro et al. 2019 under RH")
-  (statement := /-- Assuming the Riemann Hypothesis, for $x \geq 4$, there is a prime in the interval
-  \[ \left[ x, x + \frac{22}{25}\sqrt{x}\log x \right]. \]
-  -/)
+  (statement := /-- Assuming the Riemann Hypothesis, for $x \geq 4$, there is a prime in the
+  \emph{closed} interval
+  \[ \left[ x, x + \frac{22}{25}\sqrt{x}\log x \right]
+  \]
+  (\cite{CMS2019}, Theorem~5). The shared predicate `HasPrimeInInterval` is open on the
+  left, so this statement is written directly. -/)
   (latexEnv := "theorem")]
 theorem has_prime_in_interval (x : ℝ) (hx : x ≥ 4) (RH : RiemannHypothesis) :
-    HasPrimeInInterval x ((22 / 25) * sqrt x * log x) := by sorry
+    ∃ p : ℕ, Nat.Prime p ∧ x ≤ p ∧ (p : ℝ) ≤ x + (22 / 25) * sqrt x * log x := by sorry
 
 end CarneiroEtAl2019RH
 


### PR DESCRIPTION
## Motivation
CMS Thm 5 needs a closed left endpoint, but `HasPrimeInInterval` is open on the left. Odd Goldbach blueprint said 5 while Lean starts at 7. PT/JY blueprints said `li` while Lean uses `Eπ`/`Li`.

## Scope
- `CarneiroEtAl2019RH.has_prime_in_interval`: write `∃` with `x ≤ p ≤ x+h` (as Schoenfeld)
- `odd_conjecture` blueprint: 5 → 7
- PT Cor 2 / JY Cor 1.3 blueprints: `li` → `Li`

Closes #1709.

## Test plan
- [x] Diff checked vs CMS Thm 5 / Goldbach / Eπ defs
- [x] CI Build project

Made with Cursor.