### PR TITLE
fix: π* index, CMS closed interval, Goldbach/PT–JY blueprints

### DIFF
--- a/PrimeNumberTheoremAnd/Defs.lean
+++ b/PrimeNumberTheoremAnd/Defs.lean
@@ -67,7 +67,7 @@ noncomputable def pi (x : ℝ) : ℝ :=
   (statement := /--
   $\pi^*(x) = \sum_{k \geq 1} \pi(x^{1/k}) / k$. -/)]
 noncomputable def pi_star (x : ℝ) : ℝ :=
-  ∑' (k : ℕ), pi (x ^ (1 / (k : ℝ))) / (k : ℝ)
+  ∑' (k : ℕ), pi (x ^ (1 / (k + 1 : ℝ))) / (k + 1 : ℝ)
 
 @[blueprint
   "li-def"

--- a/PrimeNumberTheoremAnd/IEANTN/Buthe.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Buthe.lean
@@ -19,7 +19,8 @@ open MeasureTheory Real Chebyshev
   (title := "Buthe Equation (1.4)")
   (statement := /--
     $\pi^*(x) = \sum_{k \geq 1} \pi(x^{1/k}) / k$. -/)]
-noncomputable def pi_star (x : ℝ) : ℝ := ∑' (k : ℕ), pi (x ^ (1 / (k : ℝ))) / (k : ℝ)
+noncomputable def pi_star (x : ℝ) : ℝ :=
+  ∑' (k : ℕ), pi (x ^ (1 / (k + 1 : ℝ))) / (k + 1 : ℝ)
 
 @[blueprint
   "buthe-theorem-2a"

--- a/PrimeNumberTheoremAnd/IEANTN/Goldbach.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Goldbach.lean
@@ -58,7 +58,7 @@ theorem even_goldbach_test : even_conjecture 30 := by
   (title := "Odd Goldbach conjecture up to a given height")
   (statement := /--
   We say that the odd Goldbach conjecture is verified up to height $H$ if every odd
-  integer between $5$ and $H$ is the sum of three primes. -/)]
+  integer between $7$ and $H$ is the sum of three primes. -/)]
 def odd_conjecture (H : ℕ) : Prop :=
   ∀ n ∈ Finset.Icc 7 H, Odd n →
     ∃ p q r : ℕ, Nat.Prime p ∧ Nat.Prime q ∧ Nat.Prime r ∧ n = p + q + r

--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -130,9 +130,10 @@ theorem corollary_1 (X σ A B C ε₀ : ℝ) (h : (X, σ, A, B, C, ε₀) ∈ Ta
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
+  |\pi(x) - \mathrm{Li}(x)| \leq 235 x (\log x)^{0.52} \exp(-0.8 \sqrt{\log x})
   \]
-  for all $x \geq \exp(2000)$.
+  for all $x \geq \exp(2000)$
+  (equivalently $E_\pi$ classical bound with $A=235$, $B=1.52$, $C=0.8$, $R=1$).
   -/)
   (latexEnv := "theorem")]
 theorem corollary_2 : Eπ.classicalBound 235 1.52 0.8 1 (exp 2000) := by
@@ -271,9 +272,10 @@ blueprint_comment /-- results from \cite{johnston-yang}-/
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
+  |\pi(x) - \mathrm{Li}(x)| \leq 9.59 x (\log x)^{0.515} \exp(-0.8274 \sqrt{\log x})
   \]
-  for all $x \geq 2$.
+  for all $x \geq 2$
+  (equivalently $E_\pi$ classical bound with $A=9.59$, $B=1.515$, $C=0.8274$, $R=1$).
   -/)
   (latexEnv := "theorem")]
 theorem corollary_1_3 : Eπ.classicalBound 9.59 1.515 0.8274 1 2 := by

--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -332,7 +332,7 @@ theorem corollary_1_3 : Eπ.classicalBound 9.59 1.515 0.8274 1 2 := by
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{li}(x)| \leq 0.028 x (\log x)^{0.801}
+  |\pi(x) - \mathrm{Li}(x)| \leq 0.028 x (\log x)^{0.801}
     \exp(-0.1853 \log^{3/5} x / (\log \log x)^{1/5})
   \]
   for all $x \geq 23$.

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -264,8 +264,7 @@ Some results from \cite{Dusart1999}-/
   (latexEnv := "theorem")]
 theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
     pi x > x / (log x - 1) := by
-  -- Paper / Art01 use a strict inequality; `Dusart.corollary_5_3_a` is currently
-  -- stubbed as non-strict, so keep the paper-faithful statement here.
+  -- Art01 / Dusart1999 use a strict inequality. Dusart2018 Cor 5.3(a) is non-strict.
   sorry
 
 private lemma log_ge_22 {x : ℝ} (hx : x ≥ exp 22) : log x ≥ 22 := by

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -1427,12 +1427,15 @@ namespace CarneiroEtAl2019RH
 @[blueprint
   "thm:carneiroetal_2019_rh"
   (title := "Carneiro et al. 2019 under RH")
-  (statement := /-- Assuming the Riemann Hypothesis, for $x \geq 4$, there is a prime in the interval
-  \[ \left[ x, x + \frac{22}{25}\sqrt{x}\log x \right]. \]
-  -/)
+  (statement := /-- Assuming the Riemann Hypothesis, for $x \geq 4$, there is a prime in the
+  \emph{closed} interval
+  \[ \left[ x, x + \frac{22}{25}\sqrt{x}\log x \right]
+  \]
+  (\cite{CMS2019}, Theorem~5). Written with an explicit existential because
+  \texttt{HasPrimeInInterval} is open on the left. -/)
   (latexEnv := "theorem")]
 theorem has_prime_in_interval (x : ℝ) (hx : x ≥ 4) (RH : RiemannHypothesis) :
-    HasPrimeInInterval x ((22 / 25) * sqrt x * log x) := by sorry
+    ∃ p : ℕ, Nat.Prime p ∧ x ≤ p ∧ (p : ℝ) ≤ x + (22 / 25) * sqrt x * log x := by sorry
 
 end CarneiroEtAl2019RH
 

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -60,7 +60,7 @@ noncomputable def Buthe_chiStarIcc (x t : ℝ) : ℝ :=
     $\psi(x)=\sum_{n \geq 1}\chi^*_{[0,x]}(n)\Lambda(n)$.
   -/)]
 noncomputable def Buthe_psi (x : ℝ) : ℝ :=
-  ∑' n : ℕ, Buthe_chiStarIcc x n * (vonMangoldt n : ℝ)
+  ∑' n : ℕ, Buthe_chiStarIcc x (n + 1) * (vonMangoldt (n + 1) : ℝ)
 
 @[blueprint
   "buthe2-buthe-theta"
@@ -91,7 +91,7 @@ noncomputable def Buthe_pi (x : ℝ) : ℝ :=
     $\pi^*(x)=\sum_{k \geq 1}\pi(x^{1/k})/k$.
   -/)]
 noncomputable def Buthe_pi_star (x : ℝ) : ℝ :=
-  ∑' k : ℕ, Buthe_pi (x ^ (1 / (k : ℝ))) / (k : ℝ)
+  ∑' k : ℕ, Buthe_pi (x ^ (1 / (k + 1 : ℝ))) / (k + 1 : ℝ)
 
 lemma Buthe_chiStarIcc_nonneg (x t : ℝ) : 0 ≤ Buthe_chiStarIcc x t := by
   unfold Buthe_chiStarIcc


### PR DESCRIPTION
## Motivation
Several stub/blueprint statements still diverged from the papers or from the Lean definitions they wrap: Büthe π*/ψ indexing, CMS Thm 5 closed interval, odd Goldbach start, and PT/JY `li` vs `Eπ`/`Li`.

## Scope
- `Defs` / `Buthe` / `TMEEMT`: index `π*` and Büthe `ψ` from 1
- `CarneiroEtAl2019RH`: closed interval `[x, x+h]` (Stanford CMS)
- `odd_conjecture` blueprint: 5 → 7
- PT Cor 2 / JY Cor 1.3 / JY Thm 1.4 blueprints: `li` → `Li` (match `Eπ`)

Supersedes #1708, #1710, and #1717. Refs #1712.

## Test plan
- [x] Diff checked against Büthe (1.4), CMS Thm 5, Goldbach Lean start, and `Eπ` definitions
- [ ] CI Build project green after rebase

Made with Cursor.