### PR TITLE
fix(ci): narrow LeanCert imports and cache its build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,17 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
+      # LeanCert is a source dependency (no cloud olean cache, unlike Mathlib),
+      # so cache its package directory keyed on the resolved dependency
+      # revisions and toolchain. The git checkout must be cached together with
+      # .lake/build: if Lake has to re-clone the package it rebuilds from
+      # scratch even when build artifacts are present.
+      - name: Restore LeanCert package cache
+        uses: actions/cache@v4
+        with:
+          path: .lake/packages/leancert
+          key: leancert-${{ hashFiles('lake-manifest.json', 'lean-toolchain') }}
+
       - name: Build the project
         uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
         with:

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_a2_bounds.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_a2_bounds.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 LeanCert Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: LeanCert Contributors
 -/
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 import LeanCert.CertifiedBounds.BKLNW
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW
 

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_table10_rows_65_85.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_table10_rows_65_85.lean
@@ -1,4 +1,4 @@
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW_a2_bounds
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW_table10_rows_core

--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_table10_rows_core.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW_table10_rows_core.lean
@@ -1,7 +1,7 @@
 import Mathlib.Analysis.Convex.Deriv
 import Mathlib.Analysis.Convex.Jensen
 import Mathlib.Data.List.Sort
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW_a2_bounds
 

--- a/PrimeNumberTheoremAnd/IEANTN/Chebyshev.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Chebyshev.lean
@@ -7,7 +7,7 @@ import Mathlib.Tactic.NormNum.BigOperators
 import PrimeNumberTheoremAnd.IEANTN.LogTables
 import PrimeNumberTheoremAnd.IEANTN.SecondaryDefinitions
 import LeanCert.CertifiedBounds.Chebyshev
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 
 blueprint_comment /--
 \section{Chebyshev's estimates}\label{chebyshev-estimates-sec}

--- a/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Dusart.lean
@@ -3,7 +3,7 @@ import PrimeNumberTheoremAnd.IEANTN.RosserSchoenfeld.RosserSchoenfeldPrime
 import PrimeNumberTheoremAnd.IEANTN.PrimeInInterval
 import PrimeNumberTheoremAnd.IEANTN.eSHP.eSHP
 import PrimeNumberTheoremAnd.IEANTN.BKLNW.BKLNW
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 import PrimeNumberTheoremAnd.IEANTN.LogTables
 
 blueprint_comment /--

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Floor/Cor22Floor.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Floor/Cor22Floor.lean
@@ -2,7 +2,7 @@ import PrimeNumberTheoremAnd.IEANTN.FKS2
 import PrimeNumberTheoremAnd.IEANTN.FKS2Tables.Table4Ext
 import LeanCert.CertifiedBounds.Chebyshev
 import LeanCert.Validity.AffineCover
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 
 open LeanCert.CertifiedBounds.Chebyshev
 open Real MeasureTheory Chebyshev LeanCert.Core LeanCert.Validity

--- a/PrimeNumberTheoremAnd/IEANTN/LogTables.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/LogTables.lean
@@ -6,7 +6,7 @@ Each bound is proved by LeanCert's `interval_decide` tactic (verified Taylor ser
 
 Reviving a centuries-old practice: Napier (1614), Briggs (1624), now Lean (2026).
 -/
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 
 namespace LogTables
 

--- a/PrimeNumberTheoremAnd/IEANTN/Ramanujan/RamanujanCalculations.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/Ramanujan/RamanujanCalculations.lean
@@ -1,5 +1,5 @@
 import PrimeNumberTheoremAnd.Defs
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 
 namespace Ramanujan
 

--- a/PrimeNumberTheoremAnd/IEANTN/SecondaryDefinitions.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondaryDefinitions.lean
@@ -5,7 +5,7 @@ import PrimeNumberTheoremAnd.Consequences
 import PrimeNumberTheoremAnd.IEANTN.PrimaryDefinitions
 import PrimeNumberTheoremAnd.IEANTN.Li2Bounds
 import PrimeNumberTheoremAnd.IEANTN.LiSeries
-import LeanCert.Tactic
+import LeanCert.Tactic.IntervalAuto
 import PrimeNumberTheoremAnd.EulerMascheroniBounds
 import PrimeNumberTheoremAnd.IEANTN.LnFactorialSeries
 import PrimeNumberTheoremAnd.IEANTN.LogTables


### PR DESCRIPTION
My v4.32.2 LeanCert bump regressed main CI, and the manifest change also triggered a one-time dependency-doc cache rebuild (taking it to 2hs, was 99% done)

Imported LeanCert.Tactic.IntervalAuto (the two tactics actually used) instead of the umbrella to address this