### PR TITLE
fix: JY Theorem 1.4 blueprint should use Li

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/SecondarySummary.lean
@@ -330,7 +330,7 @@ theorem corollary_1_3 : Eπ.classicalBound 9.59 1.515 0.8274 1 2 := by
   (statement := /--
   One has
   \[
-  |\pi(x) - \mathrm{li}(x)| \leq 0.028 x (\log x)^{0.801}
+  |\pi(x) - \mathrm{Li}(x)| \leq 0.028 x (\log x)^{0.801}
     \exp(-0.1853 \log^{3/5} x / (\log \log x)^{1/5})
   \]
   for all $x \geq 23$.


### PR DESCRIPTION
## Summary
- `theorem_1_4` is `Eπ.vinogradovBound` (`|π − Li|`), but the blueprint still wrote `\mathrm{li}`.
- Related leftover from #1712 / #1713.

## Test plan
- [ ] Blueprint statement matches `Eπ` definition


Made with [Cursor](https://cursor.com)