### PR TITLE
feat(IK): prove zeta_pow_three_eq via Euler products

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -1096,6 +1096,86 @@ private lemma LSeriesSummable_tau_sq {s : ℂ} (hs : 1 < s.re) :
   rw [summable_norm_iff, ← LSeriesSummable]
   exact LSeries_d_summable 3 hs
 
+private lemma tau_sq_LSeries.term_isMultiplicative (s : ℂ) {m n : ℕ} (hmn : m.Coprime n) :
+    LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s (m * n) =
+      LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s m *
+        LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s n :=
+  LSeries.term_isMultiplicative_if_fun_isMultiplicative tau_sq_isMultiplicative s hmn
+
+/-- Local Euler factor: $\sum_e \tau((p^e)^2)\,p^{-es}=(1+p^{-s})/(1-p^{-s})^2$. -/
+private lemma tau_sq_tsum_prime_pow {s : ℂ} (hs : 1 < s.re) (p : Primes) :
+    sumOnPrimePows (LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s) p =
+      (1 + (p : ℂ) ^ (-s)) / (1 - (p : ℂ) ^ (-s)) ^ 2 := by
+  have hsub : 1 - (p : ℂ) ^ (-s) ≠ 0 := Complex.one_sub_prime_cpow_ne_zero p.2 hs
+  set x : ℂ := (p : ℂ) ^ (-s)
+  have hx : ‖x‖ < 1 := by
+    dsimp only [x]
+    rw [Complex.norm_cpow_of_ne_zero (Nat.cast_ne_zero.mpr p.2.ne_zero)]
+    · norm_num
+      exact lt_of_lt_of_le
+        (Real.rpow_lt_rpow_of_exponent_lt (mod_cast p.2.one_lt) (neg_lt_zero.mpr (by linarith)))
+        (by norm_num)
+  have hx0 : 1 - x ≠ 0 := by simpa [x] using hsub
+  have hxpow : ∀ e : ℕ, (p.val : ℂ) ^ (-(e : ℂ) * s) = x ^ e := by
+    intro e
+    simp only [x]
+    rw [← Complex.cpow_nat_mul]
+    ring_nf
+  have h_term : ∀ e : ℕ,
+      LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s (p.val ^ e) =
+        (2 * (e : ℂ) + 1) * x ^ e := by
+    intro e
+    calc
+      LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s (p.val ^ e)
+          = (↑(2 * e + 1) : ℂ) * (p.val : ℂ) ^ (-(e : ℂ) * s) := by
+            simp only [neg_mul, LSeries.term, Nat.pow_eq_zero, ne_eq, cast_pow,
+              Nat.Prime.ne_zero p.prop, false_and, ↓reduceIte]
+            rw [tau_sq_apply_prime_pow p.prop]
+            simp only [Complex.cpow_neg, div_eq_mul_inv, ← Complex.natCast_cpow_natCast_mul,
+              cast_add, cast_mul, cast_one]
+      _ = (2 * (e : ℂ) + 1) * x ^ e := by
+            rw [hxpow]
+            push_cast
+            ring
+  have hid : 2 * (x / (1 - x) ^ 2) + (1 - x)⁻¹ = (1 + x) / (1 - x) ^ 2 := by
+    field_simp [hx0]
+    ring
+  have hsum' :
+      HasSum (fun e : ℕ ↦ 2 * ((e : ℂ) * x ^ e) + x ^ e)
+        (2 * (x / (1 - x) ^ 2) + (1 - x)⁻¹) :=
+    ((hasSum_coe_mul_geometric_of_norm_lt_one hx).mul_left (2 : ℂ)).add
+      (hasSum_geometric_of_norm_lt_one hx)
+  have hfun : (fun e : ℕ ↦ (2 * (e : ℂ) + 1) * x ^ e) =
+      (fun e : ℕ ↦ 2 * ((e : ℂ) * x ^ e) + x ^ e) := by
+    ext e; ring
+  have hsum : HasSum (fun e : ℕ ↦ (2 * (e : ℂ) + 1) * x ^ e)
+      ((1 + x) / (1 - x) ^ 2) := by
+    rw [hfun, ← hid]
+    exact hsum'
+  simpa [sumOnPrimePows_apply, h_term] using hsum.tsum_eq
+
+private lemma tau_sq_LSeries_eulerProduct_tprod (s : ℂ) (hs : 1 < s.re) :
+    LSeries (fun n ↦ (τ (n ^ 2) : ℂ)) s =
+      ∏' p : Primes, (1 + (p : ℂ) ^ (-s)) / (1 - (p : ℂ) ^ (-s)) ^ 2 := by
+  convert! HasProd.tprod_eq
+      (EulerProduct.eulerProduct_hasProd (R := ℂ) ?_ ?_ _ _) |>.symm using 1
+  · apply tprod_congr
+    simp only [← tau_sq_tsum_prime_pow hs, sumOnPrimePows_apply, implies_true]
+  · simp [LSeries.term, tau]
+  · intro m n hmn; exact tau_sq_LSeries.term_isMultiplicative s hmn
+  · convert! (LSeriesSummable_tau_sq hs).norm using 1
+  · unfold LSeries.term; simp only [↓reduceIte]
+
+private lemma tau_sq_LSeries_eulerProduct_hasProd (s : ℂ) (hs : 1 < s.re) :
+    HasProd (fun p : Primes ↦ (1 + (p : ℂ) ^ (-s)) / (1 - (p : ℂ) ^ (-s)) ^ 2)
+      (LSeries (fun n ↦ (τ (n ^ 2) : ℂ)) s) := by
+  convert! EulerProduct.eulerProduct_hasProd _ _ _
+      (LSeries.term_zero (fun n ↦ (τ (n ^ 2) : ℂ)) s) using 1
+  · funext p; exact Eq.symm (tau_sq_tsum_prime_pow hs p)
+  · simp [LSeries.term, tau]
+  · intro _ _ hmn; exact tau_sq_LSeries.term_isMultiplicative s hmn
+  · convert! (LSeriesSummable_tau_sq hs).norm using 1
+
 @[blueprint
   "LSeriesSummable_moebius_sq"
   (title := "LSeriesSummable-moebius-sq")

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -681,7 +681,8 @@ lemma zeta_mul_tau_square_eq (s : ℂ) (hs : 1 < s.re) :
     riemannZeta s * LSeries (fun n ↦ τ (n ^ 2)) s = LSeries (fun n ↦ (τ n) ^ 2) s := by
   sorry
 
--- `zeta_pow_three_eq` (IK 1.30) proved below via Euler products.
+-- `zeta_pow_three_eq` (IK 1.30) is proved below via Euler products, after the
+-- `two_pow_omega` / `sumOnPrimePows` infrastructure (independent of Ramanujan).
 
 /--
 Zeta cubed alt:
@@ -1175,6 +1176,50 @@ private lemma tau_sq_LSeries_eulerProduct_hasProd (s : ℂ) (hs : 1 < s.re) :
   · simp [LSeries.term, tau]
   · intro _ _ hmn; exact tau_sq_LSeries.term_isMultiplicative s hmn
   · convert! (LSeriesSummable_tau_sq hs).norm using 1
+
+/--
+Zeta cubed:
+`ζ(s)^3 = ζ(2s) ∑ τ(n^2) n^(-s)`. -/
+@[blueprint
+  "zeta_pow_three_eq"
+  (title := "zeta pow three eq")
+  (statement := /-- Zeta cubed: $\zeta(s)^3 = \zeta(2s) \sum_{n=1}^{\infty}\tau(n^2) n^{-s}$ for $\Re(s) > 1$.
+  \begin{verbatim}
+  This is IK (1.30).
+  \end{verbatim}
+  -/)
+  (proof := /--
+  Direct Euler-product proof (independent of Ramanujan / Baby Rankin--Selberg).
+  Locally $\tau((p^k)^2)=\tau(p^{2k})=2k+1$, and $\sum_k(2k+1)x^k=(1+x)/(1-x)^2$ for $|x|<1$.
+  Multiplying by the local factor $1/(1-x^2)$ of $\zeta(2s)$ recovers $1/(1-x)^3$, the local
+  factor of $\zeta(s)^3$. Absolute convergence follows by comparing $\tau(n^2)\le d_3(n)$.
+  -/)]
+lemma zeta_pow_three_eq (s : ℂ) (hs : 1 < s.re) :
+    riemannZeta s ^ 3 = riemannZeta (2 * s) * LSeries (fun n ↦ τ (n ^ 2)) s := by
+  have hs' : 1 < (2 * s).re := by rw [Complex.mul_re]; norm_num; linarith
+  have mulζ := (riemannZeta_eulerProduct_hasProd hs).multipliable
+  change riemannZeta s ^ 3 = riemannZeta (2 * s) * LSeries (fun n ↦ (τ (n ^ 2) : ℂ)) s
+  have hRHS :
+      riemannZeta (2 * s) * LSeries (fun n ↦ (τ (n ^ 2) : ℂ)) s =
+        ∏' p : Primes,
+          (1 - (p : ℂ) ^ (-(2 * s)))⁻¹ *
+            ((1 + (p : ℂ) ^ (-s)) / (1 - (p : ℂ) ^ (-s)) ^ 2) := by
+    rw [← riemannZeta_eulerProduct_tprod hs', tau_sq_LSeries_eulerProduct_tprod s hs,
+      ← Multipliable.tprod_mul]
+    · exact ⟨riemannZeta (2 * s), riemannZeta_eulerProduct_hasProd hs'⟩
+    · exact ⟨LSeries (fun n ↦ (τ (n ^ 2) : ℂ)) s, tau_sq_LSeries_eulerProduct_hasProd s hs⟩
+  rw [hRHS, ← riemannZeta_eulerProduct_tprod hs, ← mulζ.tprod_pow 3]
+  refine tprod_congr fun p ↦ ?_
+  have hsub := Complex.one_sub_prime_cpow_ne_zero p.2 hs
+  have hadd := Complex.one_add_prime_cpow_ne_zero p.2 hs
+  have hsq : 1 - ((p : ℂ) ^ (-s)) ^ 2 ≠ 0 := by
+    rw [show 1 - ((p : ℂ) ^ (-s)) ^ 2 =
+        (1 - (p : ℂ) ^ (-s)) * (1 + (p : ℂ) ^ (-s)) from by ring]
+    exact mul_ne_zero hsub hadd
+  rw [show (-(2 * s) : ℂ) = -s + -s from by ring,
+    Complex.cpow_add _ _ (Nat.cast_ne_zero.mpr p.2.ne_zero)]
+  field_simp
+  ring
 
 @[blueprint
   "LSeriesSummable_moebius_sq"

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -681,24 +681,7 @@ lemma zeta_mul_tau_square_eq (s : ℂ) (hs : 1 < s.re) :
     riemannZeta s * LSeries (fun n ↦ τ (n ^ 2)) s = LSeries (fun n ↦ (τ n) ^ 2) s := by
   sorry
 
-/--
-Zeta cubed:
-`ζ(s)^3 = ζ(2s) ∑ τ(n^2) n^(-s)`. -/
-@[blueprint
-  "zeta_pow_three_eq"
-  (title := "zeta pow three eq")
-  (statement := /-- Zeta cubed: $\zeta(s)^3 = \zeta(2s) \sum_{n=1}^{\infty}\tau(n^2) n^{-s}$ for $\Re(s) > 1$.
-  \begin{verbatim}
-  This is IK (1.30).
-  \end{verbatim}
-  -/)
-  (proof := /--
-  This follows from the previous two theorems. From the corollary of Ramanujan's formula, we have $\zeta(s)^4 = \zeta(2s) \sum_{n=1}^{\infty} \tau(n)^2 n^{-s}$. From the Baby Rankin-Selberg result, we have $\zeta(s) \sum_{n=1}^{\infty} \tau(n^2) n^{-s} = \sum_{n=1}^{\infty} \tau(n)^2 n^{-s}$. Combining these two results, we can express $\zeta(s)^4$ in terms of $\zeta(s)$ and $\sum_{n=1}^{\infty} \tau(n^    2) n^{-s}$, which leads to the conclusion that $\zeta(s)^3 = \zeta(2s) \sum_{n=1}^{\infty} \tau(n^2) n^{-s}$.
-  -/)]
-lemma zeta_pow_three_eq (s : ℂ) (hs : 1 < s.re) :
-    riemannZeta s ^ 3 = riemannZeta (2 * s) * LSeries (fun n ↦ τ (n ^ 2)) s := by
-  apply mul_left_cancel₀ (riemannZeta_ne_zero_of_one_lt_re hs)
-  linear_combination (zeta_pow_four_eq s hs) - riemannZeta (2 * s) * (zeta_mul_tau_square_eq s hs)
+-- `zeta_pow_three_eq` (IK 1.30) proved below via Euler products.
 
 /--
 Zeta cubed alt:
@@ -1026,6 +1009,92 @@ lemma zeta_pow_two (s : ℂ) (hs : 1 < s.re) :
     ring
   · exact ⟨LSeries (fun n ↦ 2 ^ (ω n)) s, two_pow_omega_LSeries_eulerProduct_hasProd s hs⟩
   · exact ⟨riemannZeta (2 * s), riemannZeta_eulerProduct_hasProd hs'⟩
+
+/-- Local evaluation: $\tau((p^e)^2)=\tau(p^{2e})=2e+1$. -/
+private lemma tau_sq_apply_prime_pow {p e : ℕ} (hp : p.Prime) :
+    τ ((p ^ e) ^ 2) = 2 * e + 1 := by
+  rw [← pow_mul, mul_comm e, sigma_zero_apply_prime_pow hp]
+
+/-- $n\mapsto\tau(n^2)$ is multiplicative (as a complex-valued arithmetic function). -/
+private lemma tau_sq_isMultiplicative :
+    (toArithmeticFunction (fun n ↦ (τ (n ^ 2) : ℂ))).IsMultiplicative := by
+  simp only [IsMultiplicative, toArithmeticFunction, coe_mk, one_ne_zero, ↓reduceIte,
+    _root_.mul_eq_zero, mul_ite, mul_zero, ite_mul, zero_mul, one_pow]
+  refine ⟨by simp [tau], ?_⟩
+  intro m n hmn
+  by_cases m_eq_zero : m = 0 <;> simp only [m_eq_zero, true_or, ↓reduceIte, ite_self]
+  by_cases n_eq_zero : n = 0 <;> simp only [n_eq_zero, or_true, ↓reduceIte]
+  simp only [or_self, ↓reduceIte, Nat.cast_inj]
+  have hcop : (m ^ 2).Coprime (n ^ 2) := by
+    rw [Nat.coprime_pow_left_iff (by decide : 0 < 2),
+      Nat.coprime_pow_right_iff (by decide : 0 < 2)]
+    exact hmn
+  rw [mul_pow]
+  exact_mod_cast (isMultiplicative_sigma (k := 0)).map_mul_of_coprime hcop
+
+/-- Same multiplicativity without the complex cast, for comparison at prime powers. -/
+private lemma tau_sq_nat_isMultiplicative :
+    (toArithmeticFunction (fun n ↦ τ (n ^ 2))).IsMultiplicative := by
+  simp only [IsMultiplicative, toArithmeticFunction, coe_mk, one_ne_zero, ↓reduceIte,
+    _root_.mul_eq_zero]
+  refine ⟨by simp [tau], ?_⟩
+  intro m n hmn
+  by_cases m_eq_zero : m = 0
+  · simp [m_eq_zero]
+  by_cases n_eq_zero : n = 0
+  · simp [n_eq_zero]
+  simp only [m_eq_zero, n_eq_zero, ↓reduceIte, mul_ite, mul_zero, ite_mul, zero_mul, or_self]
+  have hcop : (m ^ 2).Coprime (n ^ 2) := by
+    rw [Nat.coprime_pow_left_iff (by decide : 0 < 2),
+      Nat.coprime_pow_right_iff (by decide : 0 < 2)]
+    exact hmn
+  rw [mul_pow]
+  exact (isMultiplicative_sigma (k := 0)).map_mul_of_coprime hcop
+
+/-- Local inequality $2a+1\le\binom{a+2}{2}$. -/
+private lemma two_mul_add_one_le_choose_two (a : ℕ) :
+    2 * a + 1 ≤ (a + 2).choose 2 := by
+  rw [Nat.choose_two_right]
+  refine (Nat.le_div_iff_mul_le (by decide : 0 < 2)).2 ?_
+  -- Goal: $(2a+1)*2 \le (a+2)(a+2-1)$. Note $a+2-1=a+1`.
+  have hsub : a + 2 - 1 = a + 1 := by cases a <;> rfl
+  rw [hsub, show (2 * a + 1) * 2 = 4 * a + 2 from by ring,
+    show (a + 2) * (a + 1) = a * a + 3 * a + 2 from by ring]
+  have : 4 * a ≤ a * a + 3 * a := by
+    cases a with
+    | zero => decide
+    | succ a => nlinarith
+  exact Nat.add_le_add_right this 2
+
+/-- Pointwise bound $\tau(n^2)\le d_3(n)$ (used for absolute convergence). -/
+private lemma tau_sq_le_d_three {n : ℕ} (hn : n ≠ 0) : τ (n ^ 2) ≤ d 3 n := by
+  let f : ArithmeticFunction ℕ := toArithmeticFunction (fun k ↦ τ (k ^ 2))
+  have hf : f.IsMultiplicative := tau_sq_nat_isMultiplicative
+  have hfeq : f n = τ (n ^ 2) := by simp [f, toArithmeticFunction, hn]
+  rw [← hfeq, hf.multiplicative_factorization f hn,
+    (d_isMultiplicative 3).multiplicative_factorization (d 3) hn]
+  refine Finset.prod_le_prod' fun p hp ↦ ?_
+  have hp' : p.Prime := prime_of_mem_primeFactors hp
+  let a := n.factorization p
+  change f (p ^ a) ≤ d 3 (p ^ a)
+  have hfa : f (p ^ a) = τ ((p ^ a) ^ 2) := by
+    dsimp [f, toArithmeticFunction]
+    rw [if_neg (pow_ne_zero _ hp'.ne_zero)]
+  rw [hfa, tau_sq_apply_prime_pow hp', d_apply_prime_pow (by decide : 0 < 3) hp']
+  exact two_mul_add_one_le_choose_two a
+
+private lemma LSeriesSummable_tau_sq {s : ℂ} (hs : 1 < s.re) :
+    LSeriesSummable (fun n ↦ (τ (n ^ 2) : ℂ)) s := by
+  have hgf : ∀ n, ‖LSeries.term (fun n ↦ (τ (n ^ 2) : ℂ)) s n‖ ≤
+      ‖LSeries.term (fun n ↦ (d 3 n : ℂ)) s n‖ := by
+    intro n
+    by_cases hn : n = 0
+    · simp [LSeries.term, hn]
+    · simp only [LSeries.term, hn, ↓reduceIte, Complex.norm_div, RCLike.norm_natCast]
+      exact div_le_div_of_nonneg_right (by exact_mod_cast tau_sq_le_d_three hn) (norm_nonneg _)
+  apply LSeriesSummable.of_norm_le_norm hgf
+  rw [summable_norm_iff, ← LSeriesSummable]
+  exact LSeries_d_summable 3 hs
 
 @[blueprint
   "LSeriesSummable_moebius_sq"


### PR DESCRIPTION
## Summary
- Prove `zeta_pow_three_eq` (IK 1.30) by a direct Euler-product argument, independent of Ramanujan / Baby Rankin–Selberg.
- Locally $\tau((p^k)^2)=2k+1$ and $\sum_k(2k+1)x^k=(1+x)/(1-x)^2$; multiplying by the $\zeta(2s)$ factor recovers $1/(1-x)^3$.
- Absolute convergence via $\tau(n^2)\le d_3(n)$.

Closes #1696.

Made with Cursor.

## Test plan
- [x] `lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)