### PR TITLE
fix: BKLNW proof-comment typo, Perron Verso closer, Wiener nnabla note

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/BKLNW/BKLNW.lean
@@ -136,7 +136,7 @@ theorem lemma_11b (I : Pre_inputs) {b x : ℝ} (hb : 0 < b) (hx : x ≥ exp b) :
   and
   $$ M_0 = \varepsilon(\log X_1). $$
   -/)
-  (proof := /-- Combine Lemmas \ref{bklnw-lemma-11a} with $b = \log X_1$ for the upper bound, and and \ref{bklnw-lemma-11b} with $b = \log X_0$ for the lower bound. -/)
+  (proof := /-- Combine Lemmas \ref{bklnw-lemma-11a} with $b = \log X_1$ for the upper bound, and \ref{bklnw-lemma-11b} with $b = \log X_0$ for the lower bound. -/)
   (latexEnv := "theorem")
   (discussion := 790)]
 theorem thm_1a {X₀ X₁ x : ℝ} (hX₀ : X₀ ≥ exp 20) (hX₁ : X₁ ≥ exp 20) (hx₀ : x ≥ X₀) (hx₁ : x ≥ X₁) :

--- a/PrimeNumberTheoremAnd/PerronFormula.lean
+++ b/PrimeNumberTheoremAnd/PerronFormula.lean
@@ -641,7 +641,7 @@ lemma isTheta (xpos : 0 < x) :
   (latexEnv := "lemma")]
 lemma isIntegrable (xpos : 0 < x) (σ_ne_zero : σ ≠ 0) (σ_ne_neg_one : σ ≠ -1) :
     Integrable fun (t : ℝ) ↦ f x (σ + t * I) := by
-  /-- By \ref{isHolomorphicOn}, $f$ is continuous, so it is integrable on any interval.-/
+  /-- By \ref{isHolomorphicOn}, $f$ is continuous, so it is integrable on any interval. -/
   have : Continuous (fun (y : ℝ) ↦ f x (σ + y * I)) := by
     refine (isHolomorphicOn xpos).continuousOn.comp_continuous (by continuity) fun x ↦
       not_or.mpr ?_

--- a/PrimeNumberTheoremAnd/Wiener.lean
+++ b/PrimeNumberTheoremAnd/Wiener.lean
@@ -539,7 +539,8 @@ def cumsum [AddCommMonoid E] (u : ℕ → E) (n : ℕ) : E := ∑ i ∈ Finset.r
 
 def nabla [Sub E] (u : α → E) (n : α) : E := u (n + 1) - u n
 
-/- TODO nnabla is redundant -/
+/- `nnabla` is the backward difference `u n - u (n+1)`; kept alongside `nabla`
+   for summation-by-parts identities that prefer that orientation. -/
 def nnabla [Sub E] (u : α → E) (n : α) : E := u n - u (n + 1)
 
 def shift (u : α → E) (n : α) : E := u (n + 1)


### PR DESCRIPTION
## Motivation
Small docstring/blueprint hygiene: a duplicated word in a BKLNW proof sketch, a missing Verso closer space, and a TODO that incorrectly called `nnabla` redundant while it is used throughout Wiener.

## Scope
- `BKLNW.thm_1a` proof comment: “and and” → “and”
- `PerronFormula.isIntegrable`: space before `-/`
- `Wiener`: replace “TODO nnabla is redundant” with a short note that it is the backward difference used in SBP identities

## Test plan
- [ ] CI / build unaffected (comments only)
- [ ] Blueprint text for thm_1a reads correctly

awaiting-review

Made with [Cursor](https://cursor.com)