### PR TITLE
docs(PULL_REQUEST_STYLE): general-purpose tables (§5) + AI disclosure labels (§13)

### DIFF
--- a/PULL_REQUEST_STYLE.md
+++ b/PULL_REQUEST_STYLE.md
@@ -207,6 +207,16 @@ Concretely:
   `BKLNW_app_tables.lean`). These files build once and cache; downstream
   paper files consume them as opaque theorems. Follow that pattern for any
   new bulk numeric evidence.
+- **`LogTables.lean` and `PrimeTables.lean` are the project-wide, general-
+  purpose homes** (the other `*_tables.lean` files are scoped to specific
+  papers). Any purely numerical bound *on logarithms, exponentials,
+  elementary constants of the form $\log n$, $\exp(-x)$, $\pi$, $\gamma$,
+  etc.* belongs in `LogTables.lean`; any purely numerical bound about
+  primes or prime-counting quantities belongs in `PrimeTables.lean`.
+  Don't inline such facts into a proof file even if you only need them
+  once — the next contributor with a similar need should find them there.
+  Blueprint them with `@[blueprint]` so they surface in the blueprint
+  index (§4).
 - **Very large certificate corpora get sharded across many small files**
   — the BKLNW Table 10 architecture (~22 files
   `BKLNW_table10_rows_*` + `_dispatch` + `_next` + `_values`) is the
@@ -404,7 +414,27 @@ rules as any other contribution — but they should also:
 
 1. **Disclose the tool** in the PR body (e.g. "Made with Cursor", or
    the auto-generated footer produced by these tools). Doesn't need to
-   be a manifesto — one line is fine.
+   be a manifesto — one line is fine. **Also apply the `ai` label**
+   (umbrella "Formalised using AI") to the PR, plus the tool-specific
+   label if one exists in the repo's label set. The current tool
+   labels are:
+
+   | Label         | Tool                                    |
+   |---------------|-----------------------------------------|
+   | `aristotle`   | Aristotle by Harmonic                   |
+   | `alpha-proof` | AlphaProof by Google DeepMind           |
+   | `claude`      | Claude models by Anthropic              |
+   | `cursor`      | Cursor                                  |
+   | `gemini`      | Gemini models                           |
+   | `gpt`         | GPT models by OpenAI                    |
+   | `seed`        | Seed by Bytedance                       |
+
+   Apply all that apply (e.g. Claude used inside Cursor gets both
+   `claude` and `cursor` in addition to `ai`). If the tool you used
+   isn't listed, mention it in the PR body and either request a new
+   label or use the umbrella `ai` alone. Labels let maintainers filter
+   the PR queue by tool and calibrate review effort — the disclosure
+   in prose is easy to miss when scanning `github.com/…/pulls`.
 2. **Consolidate before submitting**, per §1. If your assistant proposes
    twelve one-line changes to a single file, open one PR, not twelve.
    Reviewer bandwidth doesn't scale with your ease of generating diffs.


### PR DESCRIPTION
## Summary

Two additions to `PULL_REQUEST_STYLE.md` (introduced in #1674, extended in #1679):

- **§5 (Compile-time hygiene)** — new bullet promoting `LogTables.lean` and `PrimeTables.lean` as the project-wide, general-purpose homes for purely numerical bounds. The distinction is against the paper-specific `*_tables.lean` files (`BKLNW_tables.lean`, `FioriKadiriSwidinsky_tables.lean`, etc.): anything scoped to a single paper stays with that paper's tables; anything general (bounds on `log n`, `exp(-x)`, `π`, `γ`, prime-counting quantities) goes into the general-purpose homes. Recommends blueprinting with `@[blueprint]` so future contributors can find them via the blueprint index.

- **§13 (AI-assisted contributions) item 1** — expanded the "Disclose the tool" bullet to also require applying the `ai` GitHub label plus the appropriate tool-specific label. Added a table mapping the eight tool labels currently in the repo (`aristotle`, `alpha-proof`, `claude`, `cursor`, `gemini`, `gpt`, `seed`, and the umbrella `ai`) to their tools. Rationale: prose disclosure in the PR body is easy to miss when scanning the PRs page, but a label lets maintainers filter and calibrate review effort at a glance.

## Test plan

- [x] Markdown renders cleanly (table + prose).
- [x] Section numbering unchanged (1-15), no cross-reference shifts.
- [x] Label list cross-checked against `gh label list` at time of authoring.
- [ ] Maintainer sign-off — the guide remains explicitly work-in-progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)