### PR TITLE
docs(IK): blueprint notes for zeta power Euler-product routes

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -677,7 +677,11 @@ Baby Rankin-Selberg:
   \end{verbatim}
   -/)
   (proof := /--
-  This follows from the multiplicative properties of the divisor function $\tau$ and the definition of the L-series. The left-hand side can be expressed as a product of L-series corresponding to $\zeta$ and the function $n \mapsto \tau(n^2)$. The right-hand side is the L-series of the function $n \mapsto \tau(n)^2$. By analyzing the Euler products and using the fact that $\tau(n)$ counts divisors, we can derive the stated equality.
+  Baby Rankin–Selberg: compare Euler products. Locally $\tau(p^k)=k+1$, so
+  $\sum_k \tau(p^k)^2 p^{-ks}=(1+p^{-s})/(1-p^{-s})^3$ while
+  $\sum_k \tau(p^{2k}) p^{-ks}=\sum_j j\, p^{-js}=(1-p^{-s})^{-2}$.
+  Alternatively, this follows from Ramanujan (1.28) at $\alpha=\beta=0$ once
+  `zeta_mul_zeta_mul_zeta_mul_zeta_eq` is available (#1688).
   -/)]
 lemma zeta_mul_tau_square_eq (s : ℂ) (hs : 1 < s.re) :
     riemannZeta s * LSeries (fun n ↦ τ (n ^ 2)) s = LSeries (fun n ↦ (τ n) ^ 2) s := by

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -652,7 +652,9 @@ theorem zeta_mul_zeta_mul_zeta_mul_zeta_eq (α β s : ℂ) (h1 : 1 < s.re) (h2 :
   \end{verbatim}
   -/)
   (proof := /--
-  This is a special case of the previous theorem where we set $\alpha = \beta = 0$.
+  Special case $\alpha=\beta=0$ of Ramanujan (1.28), or — independently —
+  an Euler-product proof using $\tau(p^k)^2=(k+1)^2$ and
+  $\sum_k(k+1)^2 x^k=(1+x)/(1-x)^3$ (#1690).
   -/)]
 theorem zeta_pow_four_eq (s : ℂ) (hs : 1 < s.re) :
     riemannZeta s ^ 4 = riemannZeta (2 * s) * LSeries (fun n ↦ (τ n) ^ 2) s := by

--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -699,7 +699,9 @@ Zeta cubed:
   \end{verbatim}
   -/)
   (proof := /--
-  This follows from the previous two theorems. From the corollary of Ramanujan's formula, we have $\zeta(s)^4 = \zeta(2s) \sum_{n=1}^{\infty} \tau(n)^2 n^{-s}$. From the Baby Rankin-Selberg result, we have $\zeta(s) \sum_{n=1}^{\infty} \tau(n^2) n^{-s} = \sum_{n=1}^{\infty} \tau(n)^2 n^{-s}$. Combining these two results, we can express $\zeta(s)^4$ in terms of $\zeta(s)$ and $\sum_{n=1}^{\infty} \tau(n^    2) n^{-s}$, which leads to the conclusion that $\zeta(s)^3 = \zeta(2s) \sum_{n=1}^{\infty} \tau(n^2) n^{-s}$.
+  Two routes: (i) Ramanujan chain — divide `zeta_pow_four_eq` by this lemma after
+  cancelling a factor of $\zeta(s)$; (ii) direct Euler product for $\tau(n^2)$
+  (independent proof, #1696). The formal proof below uses route (i).
   -/)]
 lemma zeta_pow_three_eq (s : ℂ) (hs : 1 < s.re) :
     riemannZeta s ^ 3 = riemannZeta (2 * s) * LSeries (fun n ↦ τ (n ^ 2)) s := by


### PR DESCRIPTION
## Summary
- Blueprint proof notes for `zeta_pow_three_eq` / `zeta_pow_four_eq` / `zeta_mul_tau_square_eq` documenting the Euler-product route vs Ramanujan chain (aligns with Tao/maintainer proof style).
- Docs-only; no sorry changes.
- Reopens closed #1736 after AI open-PR cap adjustment.
- Does **not** compete with pink-iguana or @Robby955's Ramanujan draft #1730.

## Test plan
- [x] Docs-only diff; no `sorry` changes
- [ ] CI Build project green

Made with Cursor.

Made with [Cursor](https://cursor.com)