### PR TITLE
chore(IK): give the comparison-test lemma its own blueprint label

### DIFF
--- a/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
+++ b/PrimeNumberTheoremAnd/IwaniecKowalskiCh1.lean
@@ -898,8 +898,8 @@ lemma two_pow_omega_le_sigma_zero {n : ℕ} (hn : n ≠ 0) :
     (dvd_of_mem_primeFactors hp)
 
 @[blueprint
-  "LSeriesSummable_two_pow_omega"
-  (title := "LSeriesSummable-two-pow-omega")
+  "LSeriesSummable_of_norm_le_norm"
+  (title := "LSeriesSummable-of-norm-le-norm")
   (statement := /--
     An L-series is convergent if the absolute value of each term is term wise less than a summable series.
   -/)


### PR DESCRIPTION
`LSeriesSummable.of_norm_le_norm` is annotated with the label `LSeriesSummable_two_pow_omega`:

```lean
@[blueprint
  "LSeriesSummable_two_pow_omega"
  (title := "LSeriesSummable-two-pow-omega")
  (statement := /-- An L-series is convergent if the absolute value of each term is term wise less than a summable series. -/)
  ...]
lemma LSeriesSummable.of_norm_le_norm …
```

but that label belongs to `LSeriesSummable_two_pow_omega`, twenty lines below, which carries its own full `@[blueprint]` block with the same label. So one blueprint node is claimed by two declarations, and the node for the 2^ω L-series gets the generic comparison test's statement and proof text.

Labelled after itself. It is the only case in the repo where two *full* statement blocks share a label and the label names a different declaration — I checked the rest by scanning every `@[blueprint]` attribute; the other repeated labels are the intended idiom of several lemmas realising one blueprint item, and every `proofUses` reference resolves (including the ones declared as `\label{...}` inside `blueprint_comment`).

`lake build PrimeNumberTheoremAnd.IwaniecKowalskiCh1` → `Build completed successfully (3567 jobs).`