### PR TITLE
feat(FKS2): certify row 1 small-window numerics

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24CheckedNumerics.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24CheckedNumerics.lean
@@ -5,21 +5,87 @@ import LeanCert.Tactic.IntervalAuto
 /-!
 # Checked small-window numerics for FKS2 Corollary 24
 
-This file replaces the trusted row-11 floor datum by a checked computation using
+This file replaces trusted small-window floor data by checked computations using
 the reusable PNT+ enclosures registered in `LeanCertEnclosures`.
 
-The calculation deliberately uses the larger rational box `[2, 34]`. LeanCert
-subdivides it into width-at-most-one leaves, verifies `Eπ x ≤ 19/20`, and separately
-checks that `19/20 ≤ x⁻¹˰⁰` there. Elementary exponential bounds place the FKS2
-window `[e, e³·⁵]` inside this box. As with PNT+'s existing finite table checks, the
-large decidable certificate uses `native_decide`; the enclosing theorems and analytic
-glue are checked by Lean's kernel.
+Each calculation enlarges its exponential window to a rational box. LeanCert subdivides
+that box into width-at-most-one leaves, verifies an `Eπ` bound, and separately checks the
+elementary comparison with the relevant Table-7 curve. As with PNT+'s existing finite
+table checks, the large decidable certificates use `native_decide`; the enclosing
+theorems and analytic glue are checked by Lean's kernel.
 -/
 
 namespace FKS2.Cor24Checked
 
 set_option maxHeartbeats 1000000 in
--- Reifying the 128-panel quadrature certificates needs more than the project default.
+-- Reifying the 192-panel quadrature certificates needs more than the project default.
+/-- The former trusted row-1 floor calculation, discharged by checked interval arithmetic. -/
+theorem floor_row1 : ∀ x ∈ Set.Icc (Real.exp (1 : ℝ)) (Real.exp (4 : ℝ)),
+    Eπ x ≤ 2 * Real.log x * x ^ (-(1 : ℝ) / 2) := by
+  have hexpLo : (2 : ℝ) ≤ Real.exp 1 := by
+    have h := Real.add_one_le_exp (1 : ℝ)
+    norm_num at h
+    exact h
+  have hexpHi : Real.exp (4 : ℝ) ≤ 58 := by
+    interval_decide (trust := kernel)
+  have hEpiLow : ∀ x ∈ Set.Icc (2 : ℝ) 34, Eπ x ≤ (19 / 20 : ℝ) := by
+    enclosure_bound (subdivisions := 8) (trust := native)
+  have hEpiMid : ∀ x ∈ Set.Icc (34 : ℝ) 50, Eπ x ≤ (19 / 20 : ℝ) := by
+    enclosure_bound (subdivisions := 8) (trust := native)
+  have hEpiHigh : ∀ x ∈ Set.Icc (50 : ℝ) 58, Eπ x ≤ (19 / 20 : ℝ) := by
+    enclosure_bound (subdivisions := 8) (trust := native)
+  intro x hx
+  have hx' : x ∈ Set.Icc (2 : ℝ) 58 :=
+    ⟨hexpLo.trans hx.1, hx.2.trans hexpHi⟩
+  have hxpos : 0 < x := lt_of_lt_of_le (by norm_num) hx'.1
+  have hlogLo : (1 : ℝ) ≤ Real.log x := by
+    rw [← Real.log_exp (1 : ℝ)]
+    exact Real.log_le_log (Real.exp_pos _) hx.1
+  have hlogHi : Real.log x ≤ (4 : ℝ) := by
+    rw [← Real.log_exp (4 : ℝ)]
+    exact Real.log_le_log hxpos hx.2
+  have lowerOn (a b : ℝ) (ha0 : 0 ≤ a) (ha : a ≤ Real.log x) (hb : Real.log x ≤ b)
+      (hconst : (19 / 20 : ℝ) ≤ 2 * a * Real.exp (-(b / 2))) :
+      (19 / 20 : ℝ) ≤
+      2 * Real.log x * Real.exp (Real.log x * (-(1 : ℝ) / 2)) := by
+    have hexp : Real.exp (-(b / 2)) ≤
+        Real.exp (Real.log x * (-(1 : ℝ) / 2)) :=
+      Real.exp_le_exp.mpr (by linarith)
+    have hfac : 2 * a ≤ 2 * Real.log x := by linarith
+    exact hconst.trans
+      (mul_le_mul hfac hexp (Real.exp_pos _).le (mul_nonneg (by norm_num) (ha0.trans ha)))
+  have hCurve : (19 / 20 : ℝ) ≤
+      2 * Real.log x * Real.exp (Real.log x * (-(1 : ℝ) / 2)) := by
+    rcases le_total (Real.log x) (7 / 5 : ℝ) with hlogSevenFifths | hlogSevenFifths
+    · apply lowerOn 1 (7 / 5) (by norm_num) hlogLo hlogSevenFifths
+      interval_decide (trust := kernel)
+    · rcases le_total (Real.log x) 2 with hlogTwo | hlogTwo
+      · apply lowerOn (7 / 5) 2 (by norm_num) hlogSevenFifths hlogTwo
+        interval_decide (trust := kernel)
+      · rcases le_total (Real.log x) (14 / 5 : ℝ) with hlogFourteenFifths | hlogFourteenFifths
+        · apply lowerOn 2 (14 / 5) (by norm_num) hlogTwo hlogFourteenFifths
+          interval_decide (trust := kernel)
+        · rcases le_total (Real.log x) (7 / 2 : ℝ) with hlogThreeHalf | hlogThreeHalf
+          · apply lowerOn (14 / 5) (7 / 2) (by norm_num) hlogFourteenFifths hlogThreeHalf
+            interval_decide (trust := kernel)
+          · rcases le_total (Real.log x) (18 / 5 : ℝ) with hlogEighteenFifths | hlogEighteenFifths
+            · apply lowerOn (7 / 2) (18 / 5) (by norm_num) hlogThreeHalf hlogEighteenFifths
+              interval_decide (trust := kernel)
+            · apply lowerOn (18 / 5) 4 (by norm_num) hlogEighteenFifths hlogHi
+              interval_decide (trust := kernel)
+  have hEpi : Eπ x ≤ (19 / 20 : ℝ) := by
+    rcases le_total x 34 with hx34 | hx34
+    · exact hEpiLow x ⟨hx'.1, hx34⟩
+    · rcases le_total x 50 with hx50 | hx50
+      · exact hEpiMid x ⟨hx34, hx50⟩
+      · exact hEpiHigh x ⟨hx50, hx'.2⟩
+  calc
+    Eπ x ≤ (19 / 20 : ℝ) := hEpi
+    _ ≤ 2 * Real.log x * Real.exp (Real.log x * (-(1 : ℝ) / 2)) := hCurve
+    _ = 2 * Real.log x * x ^ (-(1 : ℝ) / 2) := by rw [Real.rpow_def_of_pos hxpos]
+
+set_option maxHeartbeats 1000000 in
+-- Reifying the 192-panel quadrature certificates needs more than the project default.
 /-- The former trusted row-11 floor calculation, discharged by checked interval arithmetic. -/
 theorem floor_row11 : ∀ x ∈ Set.Icc (Real.exp (1 : ℝ)) (Real.exp (3.5 : ℝ)),
     Eπ x ≤ x ^ (-(1 : ℝ) / 100) := by

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row1.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24Row1.lean
@@ -1,3 +1,4 @@
+import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24CheckedNumerics
 import PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row4
 
 /-!
@@ -24,7 +25,7 @@ set_option linter.style.nativeDecide false
 
 The Table-7 row-1 curve, assembled from three segments split at `e^4`, `e^43`:
 
-* **floor-trusted** `[e^1, e^4]` — direct `π`/`Li` for small `x` (trusted, `sorry`);
+* **floor (checked)** `[e^1, e^4]` — direct `π`/`Li` interval enclosure for small `x`;
 * **Buthe floor** `[e^4, e^43]` — `floor_xhalf_of_check` + a dyadic slab cover of `[√4, √43]
   = [2, √43]` (`slabsFrom 2 93`);
 * **trusted band** `[e^43, e^57]` — Theorem-6 refined interpolation for `log x > log(10^19)`
@@ -65,14 +66,14 @@ theorem floor_row1 : ∀ x ∈ Set.Icc (Real.exp (4:ℝ)) (Real.exp (43:ℝ)),
         push_cast; linarith [h656])
     floor_slab_check_row1 hcurve
 
-/-- **Row-1 floor-trusted** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): the direct `π`/`Li`
+/-- **Row-1 floor (checked)** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): the direct `π`/`Li`
 interpolation for small `x` that the blueprint proof invokes
 (\cite[Lemmas 5.2, 5.3]{FKS}; "checks directly for particularly small `x`", FKS2.lean:4640).
-Same accepted numerical-data trust class as `Table4Ext.allCells_trusted` and
-`floor_trusted_row4`. -/
-theorem floor_trusted_row1 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
+The endpoint quadrature and enclosure checks are proof-producing; the resulting finite
+certificate uses the same `native_decide` boundary as the existing table checks. -/
+theorem floor_checked_row1 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
     Eπ x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
-  exact FKS2.Cor24Trusted.floor_trusted_row1
+  exact FKS2.Cor24Checked.floor_row1
 
 /-- **Row-1 trusted band** `[e^43, e^57]` (`log x ∈ (log 10^19, 57]`): the blueprint's
 Theorem-6 interpolation for `log x > log(10^19)` — "one simply proceeds as in
@@ -112,7 +113,7 @@ theorem corollary_24_row1 :
       exact ⟨by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr ha,
              by rw [← Real.exp_log hxpos]; exact Real.exp_le_exp.mpr hb⟩
     rcases le_total (Real.log x) 4 with h1 | h1
-    · exact floor_trusted_row1 x (cvt 1 4 hlo h1)
+    · exact floor_checked_row1 x (cvt 1 4 hlo h1)
     · rcases le_total (Real.log x) 43 with h2 | h2
       · exact floor_row1 x (cvt 4 43 h1 h2)
       · exact band_row1 x (cvt 43 57 h2 hhi)

--- a/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24TrustedNumerics.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/FKS2Cor24TrustedNumerics.lean
@@ -8,8 +8,8 @@ import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 
 This file collects, in one place, the trusted numerical
 `sorry`s that the formalisation of FKS2 Corollary 24 (`corollary_24_all`) **introduces**:
-twenty-one bounds on compact windows `x ∈ [eᵃ, eᵇ]`.  Row 11's small-`x` floor is
-now checked in `FKS2Cor24CheckedNumerics`; the remaining facts are small-`x`
+twenty bounds on compact windows `x ∈ [eᵃ, eᵇ]`.  The row 1 and row 11 small-`x`
+floors are now checked in `FKS2Cor24CheckedNumerics`; the remaining facts are small-`x`
 *floors* and large-`x` *slivers*/*bands* at the threshold.  Each is a finite-range
 numerical datum taken from the published computations of
 
@@ -18,7 +18,7 @@ numerical datum taken from the published computations of
 
 ## Scope
 
-These twenty-one are the remaining trust that Corollary 24 adds *on top of* the existing
+These twenty are the remaining trust that Corollary 24 adds *on top of* the existing
 development.  `corollary_24_all` additionally relies on trusted numerical `sorry`s that
 already live elsewhere in the repository and are **not** reproduced here:
 
@@ -67,13 +67,11 @@ the main development's root-namespace `Eπ` (`Defs.lean`). -/
 noncomputable def Epi (x : ℝ) : ℝ :=
   |(Nat.primeCounting ⌊x⌋₊ : ℝ) - ∫ t in (2 : ℝ)..x, 1 / Real.log t| / (x / Real.log x)
 
-/-! ### Row 1 — curve `2·log x·x^{-1/2}` -/
+/-! ### Row 1 — curve `2·log x·x^{-1/2}`
 
-/-- **Row 1 floor** `[e^1, e^4]` (`x ∈ [2.72, 54.6]`): direct `π`/`Li` check for small
-`x` (FKS2 §5.2–§5.3); `E_π(x) ≤ 2·log x·x^{-1/2}`.  Purely computational. -/
-theorem floor_trusted_row1 : ∀ x ∈ Set.Icc (Real.exp (1:ℝ)) (Real.exp (4:ℝ)),
-    Epi x ≤ 2 * Real.log x * x ^ (-(1:ℝ) / 2) := by
-  sorry
+The Row 1 floor is checked in `FKS2Cor24CheckedNumerics`; only the trusted
+large-`x` band remains here.
+-/
 
 /-- **Row 1 band** `[e^43, e^57]` (`x` from `≈5·10¹⁸`): trusted **tabular** boundary at
 the Table-7 threshold — FKS2's Theorem-6 interpolation, no direct prime count.

--- a/PrimeNumberTheoremAnd/IEANTN/LeanCertEnclosures.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/LeanCertEnclosures.lean
@@ -11,7 +11,7 @@ Importing it registers checked enclosures for the project definitions `pi`, `Li`
 `Eπ`.  The candidate generators are untrusted; the associated checker theorems establish
 the interval facts consumed by LeanCert.
 
-The default `Li` enclosure uses `liPanels = 128` checked quadrature panels at each
+The default `Li` enclosure uses `liPanels = 192` checked quadrature panels at each
 endpoint. Candidates wider than one are deliberately rejected so LeanCert's focused
 enclosure tactic subdivides before composing the endpoint bounds into an `Eπ` enclosure.
 -/
@@ -86,7 +86,7 @@ theorem pi_mem
 /-! ## Checked logarithmic-integral enclosure -/
 
 /-- Default panel count for checked `Li` endpoint quadrature. -/
-def liPanels : ℕ := 128
+def liPanels : ℕ := 192
 
 /-- LeanCert expression for the logarithmic-integral integrand `1 / log x`. -/
 def liIntegrandExpr : LeanCert.Core.Expr :=


### PR DESCRIPTION
## Motivation

FKS2 Corollary 24 Row 1 previously depended on a trusted numerical assertion over the small window [exp 1, exp 4]. This PR removes that assertion using the checked pi, Li, and Epi enclosure architecture introduced in #1729.

## Scope

- Prove the Row 1 small-window bound Epi(x) <= 2 log(x) x^(-1/2) with checked enclosures
- Cover Epi by three dyadically aligned rational boxes and compare the Table-7 curve on six elementary log slabs
- Increase the reusable checked Li endpoint quadrature from 128 to 192 panels for the wider window
- Replace the Row 1 trusted floor in the final assembly and reduce the Corollary 24 trusted-bound count from 21 to 20

Candidate generation remains untrusted. The enclosure soundness theorems, finite certificates, and analytic glue are checked by Lean; no new axioms or sorries are introduced. The heavy checked-numerics shard takes approximately 169 seconds to build locally and is cached for downstream modules.

## Test plan

- [x] lake build PrimeNumberTheoremAnd.IEANTN.FKS2Cor24CheckedNumerics
- [x] lake build PrimeNumberTheoremAnd.IEANTN.FKS2Cor24Row1
- [x] lake build PrimeNumberTheoremAnd.IEANTN.FKS2Cor24TrustedNumerics PrimeNumberTheoremAnd.IEANTN.FKS2
- [x] lake build :blueprint
- [x] git diff --check

Closes #1753
Refs #1429

Made with Codex.