### PR TITLE
feat(TMEEMT): fill Dusart1999.theorem_c from Dusart theorem 4.2

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -404,9 +404,20 @@ theorem theorem_b (x : ℝ) (hx : x ≥ 10544111) :
   "thm:dusart1999-c"
   (title := "Dusart 1999, part c")
   (statement := /-- For $x \geq 3{,}594{,}641$, we have $|\vartheta(x) - x| \leq \frac{0.2\, x}{\log^2 x}$. -/)
+  (proof := /-- Restatement of \ref{Dusart_thm_4_2} at the table row $(k,\eta_k,x_k)=(2,0.2,3594641)$. -/)
+  (proofUses := ["Dusart_thm_4_2"])
   (latexEnv := "theorem")]
 theorem theorem_c (x : ℝ) (hx : x ≥ 3594641) :
-    |θ x - x| ≤ 0.2 * x / (log x) ^ 2 := by sorry
+    |θ x - x| ≤ 0.2 * x / (log x) ^ 2 := by
+  have hx_pos : (0 : ℝ) < x := by linarith
+  have hlog_pos : (0 : ℝ) < log x := log_pos (by linarith)
+  have hlog2_pos : (0 : ℝ) < (log x) ^ 2 := pow_pos hlog_pos 2
+  have hmem : (2, (0.2 : ℝ), (3594641 : ℝ)) ∈ Dusart.Table_4_2 := by
+    simp [Dusart.Table_4_2]
+  have hEθ := Dusart.theorem_4_2 hmem hx
+  unfold Eθ at hEθ
+  rw [div_le_div_iff₀ hx_pos hlog2_pos] at hEθ
+  rwa [le_div_iff₀ hlog2_pos]
 
 @[blueprint
   "thm:dusart1999-d"


### PR DESCRIPTION
Fixes #1763.

## Motivation

TMEEMT asks to fill sorrys that are already stated elsewhere. `Dusart1999.theorem_c` is the absolute-error form of `Dusart.theorem_4_2` at the Table 4.2 row `(2, 0.2, 3594641)`. Same glue as the existing `theorem_d` / `theta_improv_2` proofs.

## Scope

- `theorem_c`: rewrite `Eθ x ≤ 0.2 / (log x)^2` as `|θ x - x| ≤ 0.2 x / (log x)^2` for `x ≥ 3594641`.
- No other declaration touched.

## Test plan

- [ ] `lake build PrimeNumberTheoremAnd.IEANTN.TMEEMT` — not run locally yet. CI covers it.
- [ ] No new warnings other than `declaration uses 'sorry'`. The TMEEMT `theorem_c` sorry goes away; it still depends on the existing `sorry` in `Dusart.theorem_4_2`.
