### PR TITLE
feat(TMEEMT): fill Dusart1999.pi_inequality from Dusart corollary 5.3(a)

### DIFF
--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -272,11 +272,53 @@ Some results from \cite{Dusart1999}-/
   "thm:dusart1999-pi"
   (title := "Dusart 1999, $\\pi$ inequality")
   (statement := /-- For $x \geq 5393$, we have $\pi(x) > \frac{x}{\log x - 1}$. -/)
+  (proof := /-- Non-strict form is \ref{Dusart_cor_5_3_a}. Upgrade to a strict
+    inequality because $\pi$ is constant on each $[n,n+1)$ while
+    $x/(\log x-1)$ is strictly increasing for $x>e^2$. -/)
+  (proofUses := ["Dusart_cor_5_3_a"])
   (latexEnv := "theorem")]
 theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
     pi x > x / (log x - 1) := by
-  -- Art01 / Dusart1999 use a strict inequality. Dusart2018 Cor 5.3(a) is non-strict.
-  sorry
+  have hx0 : (0 : ℝ) ≤ x := by linarith
+  have hxpos : (0 : ℝ) < x := by linarith
+  have hx1 : (1 : ℝ) < x := by linarith
+  have hexp2 : exp 2 < x := by
+    have h : exp 2 < 9 := by
+      have : exp 2 = exp 1 * exp 1 := by rw [← exp_add]; norm_num
+      nlinarith [exp_one_lt_d9]
+    linarith
+  have hlogx2 : (2 : ℝ) < log x := by
+    rwa [← log_exp 2, log_lt_log_iff (exp_pos _) hxpos]
+  have hdenx : (0 : ℝ) < log x - 1 := by linarith
+  set y := (x + (⌊x⌋₊ + 1 : ℝ)) / 2
+  have hxy : x < y := by
+    have := Nat.lt_floor_add_one x
+    dsimp [y]; linarith
+  have hyu : y < (⌊x⌋₊ : ℝ) + 1 := by
+    have : (⌊x⌋₊ : ℝ) ≤ x := Nat.floor_le hx0
+    dsimp [y]; linarith
+  have hyl : (⌊x⌋₊ : ℝ) ≤ y := by
+    have : (⌊x⌋₊ : ℝ) ≤ x := Nat.floor_le hx0
+    dsimp [y]; linarith
+  have hfloor : ⌊y⌋₊ = ⌊x⌋₊ := Nat.floor_eq_on_Ico _ _ ⟨hyl, hyu⟩
+  have hpi : pi x = pi y := by simp [pi, hfloor]
+  have hypos : (0 : ℝ) < y := by linarith
+  have hge := Dusart.corollary_5_3_a (by linarith : y ≥ 5393)
+  have hz : (1 : ℝ) < y / x := (one_lt_div hxpos).mpr hxy
+  have hlogz : log (y / x) < y / x - 1 :=
+    log_lt_sub_one_of_pos (div_pos hypos hxpos) (ne_of_gt hz)
+  have hlog_div : log (y / x) = log y - log x := log_div hypos.ne' hxpos.ne'
+  have hdeny : (0 : ℝ) < log y - 1 := by
+    have : (2 : ℝ) < log y := lt_trans hlogx2 (log_lt_log hxpos hxy)
+    linarith
+  have hstrict : x / (log x - 1) < y / (log y - 1) := by
+    rw [div_lt_div_iff₀ hdenx hdeny]
+    have : log y < log x + y / x - 1 := by linarith
+    have hmul := mul_lt_mul_of_pos_left this hxpos
+    have hrw : x * (log x + y / x - 1) = x * log x + y - x := by field_simp; ring
+    nlinarith
+  rw [hpi]
+  exact lt_of_lt_of_le hstrict hge
 
 private lemma log_ge_22 {x : ℝ} (hx : x ≥ exp 22) : log x ≥ 22 := by
   calc (22 : ℝ) = log (exp 22) := (log_exp 22).symm

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -282,12 +282,15 @@ theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
   have hx0 : (0 : ℝ) ≤ x := by linarith
   have hxpos : (0 : ℝ) < x := by linarith
   have hx1 : (1 : ℝ) < x := by linarith
-  -- e² ≈ 7.39 < 8 ≤ 5393 ≤ x, so log x > 2 and the denominator is positive.
+  -- e² < 9 ≤ 5393 ≤ x, so log x > 2 and the denominator is positive.
   have hexp2 : exp 2 < x := by
-    have h8 : exp 2 < (8 : ℝ) := by
-      have heq : exp 2 = exp 1 * exp 1 := by rw [← exp_add]; norm_num
-      nlinarith [exp_one_lt_d9, heq]
-    exact lt_of_lt_of_le h8 (le_trans (by norm_num : (8 : ℝ) ≤ 5393) hx)
+    have he1 : exp 1 < (3 : ℝ) := lt_trans exp_one_lt_d9 (by norm_num)
+    have h9 : exp 2 < (9 : ℝ) := by
+      calc
+        exp 2 = exp 1 * exp 1 := (exp_add 1 1).symm
+        _ < 3 * 3 := mul_lt_mul'' he1 he1 (exp_pos _).le (exp_pos _).le
+        _ = 9 := by norm_num
+    exact lt_of_lt_of_le h9 (le_trans (by norm_num : (9 : ℝ) ≤ 5393) hx)
   have hlogx2 : (2 : ℝ) < log x := by
     rwa [← log_exp 2, log_lt_log_iff (exp_pos _) hxpos]
   have hdenx : (0 : ℝ) < log x - 1 := by linarith
@@ -312,11 +315,25 @@ theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
     linarith
   have hstrict : x / (log x - 1) < y / (log y - 1) := by
     rw [div_lt_div_iff₀ hdenx hdeny]
-    have : log y < log x + y / x - 1 := by linarith [hlog_div, hlogz]
-    have hmul := mul_lt_mul_of_pos_left this hxpos
-    have hrw : x * (log x + y / x - 1) = x * log x + y - x := by field_simp; ring
-    have h1 : x * log y < x * log x + y - x := by linarith [hmul, hrw]
-    nlinarith [h1, hdenx, sub_pos.mpr hxy]
+    -- goal: x * (log y - 1) < y * (log x - 1)
+    have hstep : log y < log x + y / x - 1 := by linarith [hlog_div, hlogz]
+    have hmul : x * log y < x * (log x + y / x - 1) :=
+      mul_lt_mul_of_pos_left hstep hxpos
+    have hrw : x * (log x + y / x - 1) = x * log x + y - x := by
+      simp [mul_add, mul_sub, mul_div_cancel₀ _ hxpos.ne']
+    have h1 : x * log y < x * log x + y - x := by rwa [hrw] at hmul
+    -- x*(log y - 1) < y*(log x - 1) ⇔ x*log y - x < y*log x - y.
+    -- From h1 the LHS is < x*log x + y - 2x, and that ≤ RHS since
+    -- log x > 2 and x < y ⇒ x*(log x - 2) ≤ y*(log x - 2).
+    have hxlog : x * (log y - 1) < y * (log x - 1) := by
+      have hmid : x * log y - x < x * log x + y - 2 * x := by linarith [h1]
+      have hcmp : x * log x + y - 2 * x ≤ y * log x - y := by
+        have hfac : (0 : ℝ) < log x - 2 := by linarith [hlogx2]
+        have : x * (log x - 2) ≤ y * (log x - 2) :=
+          mul_le_mul_of_nonneg_right (le_of_lt hxy) hfac.le
+        linarith
+      linarith
+    exact hxlog
   rw [hpi]
   exact lt_of_lt_of_le hstrict hge
 

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -278,30 +278,29 @@ Some results from \cite{Dusart1999}-/
   (proofUses := ["Dusart_cor_5_3_a"])
   (latexEnv := "theorem")]
 theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
-    pi x > x / (log x - 1) := by
+    _root_.pi x > x / (log x - 1) := by
   have hx0 : (0 : ℝ) ≤ x := by linarith
   have hxpos : (0 : ℝ) < x := by linarith
   have hx1 : (1 : ℝ) < x := by linarith
+  -- e² ≈ 7.39 < 8 ≤ 5393 ≤ x, so log x > 2 and the denominator is positive.
   have hexp2 : exp 2 < x := by
-    have h : exp 2 < 9 := by
-      have : exp 2 = exp 1 * exp 1 := by rw [← exp_add]; norm_num
-      nlinarith [exp_one_lt_d9]
-    linarith
+    have h8 : exp 2 < (8 : ℝ) := by
+      have heq : exp 2 = exp 1 * exp 1 := by rw [← exp_add]; norm_num
+      nlinarith [exp_one_lt_d9, heq]
+    exact lt_of_lt_of_le h8 (le_trans (by norm_num : (8 : ℝ) ≤ 5393) hx)
   have hlogx2 : (2 : ℝ) < log x := by
     rwa [← log_exp 2, log_lt_log_iff (exp_pos _) hxpos]
   have hdenx : (0 : ℝ) < log x - 1 := by linarith
   set y := (x + (⌊x⌋₊ + 1 : ℝ)) / 2
-  have hxy : x < y := by
-    have := Nat.lt_floor_add_one x
-    dsimp [y]; linarith
-  have hyu : y < (⌊x⌋₊ : ℝ) + 1 := by
-    have : (⌊x⌋₊ : ℝ) ≤ x := Nat.floor_le hx0
-    dsimp [y]; linarith
-  have hyl : (⌊x⌋₊ : ℝ) ≤ y := by
-    have : (⌊x⌋₊ : ℝ) ≤ x := Nat.floor_le hx0
-    dsimp [y]; linarith
+  have hx_lt_succ : x < (⌊x⌋₊ : ℝ) + 1 := Nat.lt_floor_add_one x
+  have hfle : (⌊x⌋₊ : ℝ) ≤ x := Nat.floor_le hx0
+  have hxy : x < y := by dsimp [y]; linarith
+  have hyu : y < (⌊x⌋₊ : ℝ) + 1 := by dsimp [y]; linarith
+  have hyl : (⌊x⌋₊ : ℝ) ≤ y := by dsimp [y]; linarith
   have hfloor : ⌊y⌋₊ = ⌊x⌋₊ := Nat.floor_eq_on_Ico _ _ ⟨hyl, hyu⟩
-  have hpi : pi x = pi y := by simp [pi, hfloor]
+  have hpi : _root_.pi x = _root_.pi y := by
+    unfold _root_.pi
+    rw [hfloor]
   have hypos : (0 : ℝ) < y := by linarith
   have hge := Dusart.corollary_5_3_a (by linarith : y ≥ 5393)
   have hz : (1 : ℝ) < y / x := (one_lt_div hxpos).mpr hxy
@@ -313,15 +312,11 @@ theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
     linarith
   have hstrict : x / (log x - 1) < y / (log y - 1) := by
     rw [div_lt_div_iff₀ hdenx hdeny]
-    have : log y < log x + y / x - 1 := by linarith
+    have : log y < log x + y / x - 1 := by linarith [hlog_div, hlogz]
     have hmul := mul_lt_mul_of_pos_left this hxpos
     have hrw : x * (log x + y / x - 1) = x * log x + y - x := by field_simp; ring
-    have h1 : x * log y < x * log x + y - x := by linarith
-    have h2 : y * log x - x * log y > (y - x) * (log x - 1) := by nlinarith
-    have h3 : (y - x) * (log x - 1) > y - x := by
-      have : (0 : ℝ) < y - x := sub_pos.mpr hxy
-      nlinarith
-    nlinarith
+    have h1 : x * log y < x * log x + y - x := by linarith [hmul, hrw]
+    nlinarith [h1, hdenx, sub_pos.mpr hxy]
   rw [hpi]
   exact lt_of_lt_of_le hstrict hge
 

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -286,8 +286,12 @@ theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
   have hexp2 : exp 2 < x := by
     have he1 : exp 1 < (3 : ℝ) := lt_trans exp_one_lt_d9 (by norm_num)
     have h9 : exp 2 < (9 : ℝ) := by
+      have heq : exp 2 = exp 1 * exp 1 := by
+        calc
+          exp 2 = exp (1 + 1) := by congr 1; norm_num
+          _ = exp 1 * exp 1 := (exp_add 1 1).symm
       calc
-        exp 2 = exp 1 * exp 1 := (exp_add 1 1).symm
+        exp 2 = exp 1 * exp 1 := heq
         _ < 3 * 3 := mul_lt_mul'' he1 he1 (exp_pos _).le (exp_pos _).le
         _ = 9 := by norm_num
     exact lt_of_lt_of_le h9 (le_trans (by norm_num : (9 : ℝ) ≤ 5393) hx)

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -316,6 +316,11 @@ theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
     have : log y < log x + y / x - 1 := by linarith
     have hmul := mul_lt_mul_of_pos_left this hxpos
     have hrw : x * (log x + y / x - 1) = x * log x + y - x := by field_simp; ring
+    have h1 : x * log y < x * log x + y - x := by linarith
+    have h2 : y * log x - x * log y > (y - x) * (log x - 1) := by nlinarith
+    have h3 : (y - x) * (log x - 1) > y - x := by
+      have : (0 : ℝ) < y - x := sub_pos.mpr hxy
+      nlinarith
     nlinarith
   rw [hpi]
   exact lt_of_lt_of_le hstrict hge

--- a/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
+++ b/PrimeNumberTheoremAnd/IEANTN/TMEEMT.lean
@@ -282,19 +282,9 @@ theorem pi_inequality (x : ℝ) (hx : x ≥ 5393) :
   have hx0 : (0 : ℝ) ≤ x := by linarith
   have hxpos : (0 : ℝ) < x := by linarith
   have hx1 : (1 : ℝ) < x := by linarith
-  -- e² < 9 ≤ 5393 ≤ x, so log x > 2 and the denominator is positive.
-  have hexp2 : exp 2 < x := by
-    have he1 : exp 1 < (3 : ℝ) := lt_trans exp_one_lt_d9 (by norm_num)
-    have h9 : exp 2 < (9 : ℝ) := by
-      have heq : exp 2 = exp 1 * exp 1 := by
-        calc
-          exp 2 = exp (1 + 1) := by congr 1; norm_num
-          _ = exp 1 * exp 1 := (exp_add 1 1).symm
-      calc
-        exp 2 = exp 1 * exp 1 := heq
-        _ < 3 * 3 := mul_lt_mul'' he1 he1 (exp_pos _).le (exp_pos _).le
-        _ = 9 := by norm_num
-    exact lt_of_lt_of_le h9 (le_trans (by norm_num : (9 : ℝ) ≤ 5393) hx)
+  -- e² < 8 ≤ 5393 ≤ x, so log x > 2 and the denominator is positive.
+  have hexp2 : exp 2 < x :=
+    lt_of_lt_of_le LogTables.exp_two_lt_eight (le_trans (by norm_num : (8 : ℝ) ≤ 5393) hx)
   have hlogx2 : (2 : ℝ) < log x := by
     rwa [← log_exp 2, log_lt_log_iff (exp_pos _) hxpos]
   have hdenx : (0 : ℝ) < log x - 1 := by linarith


### PR DESCRIPTION
Fixes #1762.

## Motivation

TMEEMT asks to fill sorrys that are already stated elsewhere. `Dusart1999.pi_inequality` is the wiki's strict form of Dusart 2018 corollary 5.3(a).

## Scope

- Uses `Dusart.corollary_5_3_a` (`π(x) ≥ x / (log x - 1)` for `x ≥ 5393`).
- Upgrades `≥` to `>` because `π` is constant on each `[n, n+1)` while `x / (log x - 1)` is strictly increasing for `x > e²`.
- No other declaration touched.

## Test plan

- [ ] `lake build PrimeNumberTheoremAnd.IEANTN.TMEEMT` — not run locally yet. CI covers it.
- [ ] No new warnings other than `declaration uses 'sorry'`. The TMEEMT `pi_inequality` sorry goes away; it still depends on the existing `sorry` in `Dusart.corollary_5_3_a`.
